### PR TITLE
refactor(bridge): favor composition over inheritance

### DIFF
--- a/contracts/src/bridge/IL1Bridge.sol
+++ b/contracts/src/bridge/IL1Bridge.sol
@@ -28,9 +28,9 @@ abstract contract IL1Bridge {
         bytes memory _calldata,
         uint256 _maxGas,
         uint256 _gasPriceBid
-    ) internal virtual returns (uint256);
+    ) public payable virtual returns (uint256);
 
-    function getSubmissionPrice(uint256 _calldatasize) internal view virtual returns (uint256);
+    function getSubmissionPrice(uint256 _calldatasize) public view virtual returns (uint256);
 
-    function onlyAuthorized() internal virtual;
+    function onlyAuthorized() public view virtual;
 }

--- a/contracts/src/bridge/IL2Bridge.sol
+++ b/contracts/src/bridge/IL2Bridge.sol
@@ -13,7 +13,7 @@ abstract contract IL2Bridge {
      * @param _calldata The L1 encoded message data.
      * @return Unique id to track the message request/transaction.
      */
-    function sendCrossDomainMessage(bytes memory _calldata) internal virtual returns (uint256);
+    function sendCrossDomainMessage(bytes memory _calldata) public payable virtual returns (uint256);
 
-    function onlyAuthorized() internal virtual;
+    function onlyAuthorized() public view virtual;
 }

--- a/contracts/src/bridge/arbitrum/ArbL2Bridge.sol
+++ b/contracts/src/bridge/arbitrum/ArbL2Bridge.sol
@@ -16,12 +16,14 @@ import "./AddressAliasHelper.sol";
 import "../IL2Bridge.sol";
 
 contract ArbL2Bridge is IL2Bridge {
+    address public l2Gateway;
     address public l1Target;
     IArbSys constant arbsys = IArbSys(address(100));
 
     event L2ToL1TxCreated(uint256 indexed withdrawalId);
 
-    constructor(address _l1Target) {
+    constructor(address _l2Gateway, address _l1Target) {
+        l2Gateway = _l2Gateway;
         l1Target = _l1Target;
     }
 
@@ -31,14 +33,15 @@ contract ArbL2Bridge is IL2Bridge {
      * @param _calldata The L1 encoded message data.
      * @return Unique id to track the message request/transaction.
      */
-    function sendCrossDomainMessage(bytes memory _calldata) internal override returns (uint256) {
+    function sendCrossDomainMessage(bytes memory _calldata) public payable override returns (uint256) {
+        require(msg.sender == l2Gateway, "Only L2 gateway");
         uint256 withdrawalId = arbsys.sendTxToL1(l1Target, _calldata);
 
         emit L2ToL1TxCreated(withdrawalId);
         return withdrawalId;
     }
 
-    function onlyAuthorized() internal override {
+    function onlyAuthorized() public view override {
         require(msg.sender == AddressAliasHelper.applyL1ToL2Alias(l1Target), "Only L1 target");
     }
 }

--- a/contracts/src/bridge/xdai/xDaiL1Bridge.sol
+++ b/contracts/src/bridge/xdai/xDaiL1Bridge.sol
@@ -15,10 +15,16 @@ import "./interfaces/IAMB.sol";
 import "../IL1Bridge.sol";
 
 contract xDaiL1Bridge is IL1Bridge {
+    address public l1Gateway;
     address public l2Target;
     IAMB amb;
 
-    constructor(address _l2Target, IAMB _amb) {
+    constructor(
+        address _l1Gateway,
+        address _l2Target,
+        IAMB _amb
+    ) {
+        l1Gateway = _l1Gateway;
         l2Target = _l2Target;
         amb = _amb;
     }
@@ -27,7 +33,7 @@ contract xDaiL1Bridge is IL1Bridge {
         bytes memory _calldata,
         uint256 _maxGas,
         uint256 _gasPriceBid
-    ) internal override returns (uint256) {
+    ) public payable override returns (uint256) {
         bytes32 id = amb.requireToPassMessage(l2Target, _calldata, amb.maxGasPerTx());
         return uint256(id);
     }
@@ -38,11 +44,11 @@ contract xDaiL1Bridge is IL1Bridge {
      */
     function getSubmissionPrice(
         uint256 /* _calldatasize */
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return 0;
     }
 
-    function onlyAuthorized() internal override {
+    function onlyAuthorized() public view override {
         require(msg.sender == address(amb), "Only AMB allowed");
         // require(amb.messageSourceChainId() == foreignChainId, "Only foreign chain allowed");
         require(amb.messageSender() == l2Target, "Only foreign gateway allowed");

--- a/contracts/src/bridge/xdai/xDaiL2Bridge.sol
+++ b/contracts/src/bridge/xdai/xDaiL2Bridge.sol
@@ -15,20 +15,27 @@ import "./interfaces/IAMB.sol";
 import "../IL2Bridge.sol";
 
 contract xDaiL2Bridge is IL2Bridge {
+    address public l2Gateway;
     address public l1Target;
     IAMB amb;
 
-    constructor(address _l1Target, IAMB _amb) {
+    constructor(
+        address _l2Gateway,
+        address _l1Target,
+        IAMB _amb
+    ) {
+        l2Gateway = _l2Gateway;
         l1Target = _l1Target;
         amb = _amb;
     }
 
-    function sendCrossDomainMessage(bytes memory _calldata) internal override returns (uint256) {
+    function sendCrossDomainMessage(bytes memory _calldata) public payable override returns (uint256) {
+        require(msg.sender == l2Gateway, "Only L2 gateway");
         bytes32 id = amb.requireToPassMessage(l1Target, _calldata, amb.maxGasPerTx());
         return uint256(id);
     }
 
-    function onlyAuthorized() internal override {
+    function onlyAuthorized() public view override {
         require(msg.sender == address(amb), "Only AMB allowed");
         // require(amb.messageSourceChainId() == homeChainId, "Only home chain allowed");
         require(amb.messageSender() == l1Target, "Only home gateway allowed");

--- a/contracts/src/gateway/BaseHomeGateway.sol
+++ b/contracts/src/gateway/BaseHomeGateway.sol
@@ -16,10 +16,11 @@ import "../bridge/IL2Bridge.sol";
 import "./interfaces/IHomeGateway.sol";
 import "./interfaces/IForeignGateway.sol";
 
-abstract contract BaseHomeGateway is IL2Bridge, IHomeGateway {
+abstract contract BaseHomeGateway is IHomeGateway {
     mapping(uint256 => bytes32) public disputeIDtoHash;
     mapping(bytes32 => uint256) public disputeHashtoID;
 
+    IL2Bridge public l2Bridge;
     IForeignGateway public foreignGateway;
     IArbitrator public arbitrator;
     uint256 public chainID;
@@ -33,11 +34,16 @@ abstract contract BaseHomeGateway is IL2Bridge, IHomeGateway {
     mapping(bytes32 => RelayedData) public disputeHashtoRelayedData;
 
     modifier onlyFromL1() {
-        onlyAuthorized();
+        l2Bridge.onlyAuthorized();
         _;
     }
 
-    constructor(IArbitrator _arbitrator, IForeignGateway _foreignGateway) {
+    constructor(
+        IL2Bridge _l2Bridge,
+        IArbitrator _arbitrator,
+        IForeignGateway _foreignGateway
+    ) {
+        l2Bridge = _l2Bridge;
         arbitrator = _arbitrator;
         foreignGateway = _foreignGateway;
 
@@ -59,7 +65,7 @@ abstract contract BaseHomeGateway is IL2Bridge, IHomeGateway {
         bytes4 methodSelector = IForeignGateway.relayRule.selector;
         bytes memory data = abi.encodeWithSelector(methodSelector, disputeHash, _ruling, relayedData.forwarder);
 
-        sendCrossDomainMessage(data);
+        l2Bridge.sendCrossDomainMessage(data);
     }
 
     /**

--- a/contracts/src/gateway/arbitrum/ArbitrumGateway.sol
+++ b/contracts/src/gateway/arbitrum/ArbitrumGateway.sol
@@ -2,16 +2,14 @@
 
 pragma solidity ^0.8.0;
 
-import "../../arbitration/IArbitrator.sol";
 import "../../bridge/arbitrum/ArbL2Bridge.sol";
-
-import "../interfaces/IHomeGateway.sol";
 import "../BaseHomeGateway.sol";
 
-contract ArbitrumGateway is BaseHomeGateway, ArbL2Bridge {
+contract ArbitrumGateway is BaseHomeGateway {
     constructor(
+        ArbL2Bridge _l2Bridge,
         IArbitrator _arbitrator,
         IForeignGateway _foreignGateway,
         address _l1Target
-    ) BaseHomeGateway(_arbitrator, _foreignGateway) ArbL2Bridge(_l1Target) {}
+    ) BaseHomeGateway(_l2Bridge, _arbitrator, _foreignGateway) {}
 }

--- a/contracts/src/gateway/arbitrum/EthereumGateway.sol
+++ b/contracts/src/gateway/arbitrum/EthereumGateway.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.0;
 
 import "../../bridge/arbitrum/ArbL1Bridge.sol";
 
-import "../interfaces/IForeignGateway.sol";
 import "../BaseForeignGateway.sol";
 
-contract EthereumGateway is BaseForeignGateway, ArbL1Bridge {
+contract EthereumGateway is BaseForeignGateway {
     constructor(
         address _governor,
+        ArbL1Bridge _l1Bridge,
         IHomeGateway _homeGateway,
         uint256[] memory _feeForJuror,
         address _l2Target,
         address _inbox
-    ) BaseForeignGateway(_governor, _homeGateway, _feeForJuror) ArbL1Bridge(_l2Target, _inbox) {}
+    ) BaseForeignGateway(_governor, _l1Bridge, _homeGateway, _feeForJuror) {}
 }

--- a/contracts/src/gateway/xdai/EthereumGateway.sol
+++ b/contracts/src/gateway/xdai/EthereumGateway.sol
@@ -3,17 +3,15 @@
 pragma solidity ^0.8.0;
 
 import "../../bridge/xdai/xDaiL1Bridge.sol";
-import "../../bridge/xdai/interfaces/IAMB.sol";
-
-import "../interfaces/IForeignGateway.sol";
 import "../BaseForeignGateway.sol";
 
-contract EthereumGateway is BaseForeignGateway, xDaiL1Bridge {
+contract EthereumGateway is BaseForeignGateway {
     constructor(
         address _governor,
+        xDaiL1Bridge _l1Bridge,
         IHomeGateway _homeGateway,
         uint256[] memory _feeForJuror,
         address _l2Target,
         IAMB _amb
-    ) BaseForeignGateway(_governor, _homeGateway, _feeForJuror) xDaiL1Bridge(_l2Target, _amb) {}
+    ) BaseForeignGateway(_governor, _l1Bridge, _homeGateway, _feeForJuror) {}
 }

--- a/contracts/src/gateway/xdai/xDaiGateway.sol
+++ b/contracts/src/gateway/xdai/xDaiGateway.sol
@@ -2,18 +2,15 @@
 
 pragma solidity ^0.8.0;
 
-import "../../arbitration/IArbitrator.sol";
 import "../../bridge/xdai/xDaiL2Bridge.sol";
-import "../../bridge/xdai/interfaces/IAMB.sol";
-
-import "../interfaces/IHomeGateway.sol";
 import "../BaseHomeGateway.sol";
 
-contract xDaiGateway is BaseHomeGateway, xDaiL2Bridge {
+contract xDaiGateway is BaseHomeGateway {
     constructor(
+        xDaiL2Bridge _l2Bridge,
         IArbitrator _arbitrator,
         IForeignGateway _foreignGateway,
         address _l1Target,
         IAMB _amb
-    ) BaseHomeGateway(_arbitrator, _foreignGateway) xDaiL2Bridge(_l1Target, _amb) {}
+    ) BaseHomeGateway(_l2Bridge, _arbitrator, _foreignGateway) {}
 }


### PR DESCRIPTION
"BaseForeignGateway is an IL1Bridge" replaced by "BaseForeignGateway has an IL1Bridge".

In particular: 
- "arbitrum.EthereumGateway has an ArbL1Bridge" 
- "xdai.EthereumGateway has a xDaiL1Bridge"

Similarly for BaseHomeGateway.

The main differences:
- Access control is required in the implementation of `ILxBridge.sendCrossDomainMessage()`
- Slightly more gas, mostly relevant for Mainnet. In practice this bridge is not used during normal operations later (challenges only), and the fast bridge version will be called for a batch of messages, so the gas cost is incurred for a batch, not per message.