### PR TITLE
Feat: Add getTimesPerPeriod to KlerosCore

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -715,6 +715,15 @@ contract KlerosCore is IArbitrator {
         locked = juror.lockedTokens[_subcourtID];
     }
 
+    /** @dev Gets the timesPerPeriod array for a given court.
+     *  @param _subcourtID The ID of the court to get the times from.
+     *  @return timesPerPeriod The timesPerPeriod array for the given court.
+     */
+    function getTimesPerPeriod(uint96 _subcourtID) external view returns (uint256[4] memory timesPerPeriod) {
+        Court storage court = courts[_subcourtID];
+        timesPerPeriod = court.timesPerPeriod;
+    }
+
     // ************************************* //
     // *   Public Views for Dispute Kits   * //
     // ************************************* //


### PR DESCRIPTION
This getter was needed to access timesPerPeriod array for a given court since the default getter generated for public variables by the solidity compiler does not include arrays.