### PR TITLE
feat(Evidence): evidence submission from the arbitration side

### DIFF
--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -12,6 +12,7 @@ pragma solidity ^0.8;
 
 import "./BaseDisputeKit.sol";
 import "../../rng/RNG.sol";
+import "../../evidence/IEvidence.sol";
 
 /**
  *  @title DisputeKitClassic
@@ -23,7 +24,7 @@ import "../../rng/RNG.sol";
  *  TODO:
  *  - phase management: Generating->Drawing->Resolving->Generating in coordination with KlerosCore to freeze staking.
  */
-contract DisputeKitClassic is BaseDisputeKit {
+contract DisputeKitClassic is BaseDisputeKit, IEvidence {
     // ************************************* //
     // *             Structs               * //
     // ************************************* //
@@ -382,6 +383,14 @@ contract DisputeKitClassic is BaseDisputeKit {
             _beneficiary.send(amount); // Deliberate use of send to prevent reverting fallback. It's the user's responsibility to accept ETH.
             emit Withdrawal(_disputeID, _round, _choice, _beneficiary, amount);
         }
+    }
+
+    /** @dev Submits evidence.
+     *  @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to. It's the submitter responsability to submit the right evidence group ID.
+     *  @param _evidence IPFS path to evidence, example: '/ipfs/Qmarwkf7C9RuzDEJNnarT3WZ7kem5bk8DZAzx78acJjMFH/evidence.json'.
+     */
+    function submitEvidence(uint256 _evidenceGroupID, string calldata _evidence) external {
+        emit Evidence(core, _evidenceGroupID, msg.sender, _evidence);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -11,8 +11,8 @@
 pragma solidity ^0.8;
 
 import "./BaseDisputeKit.sol";
-
 import "../../rng/RNG.sol";
+import "../../evidence/IEvidence.sol";
 
 interface IProofOfHumanity {
     /** @dev Return true if the submission is registered and not expired.
@@ -30,7 +30,7 @@ interface IProofOfHumanity {
  *  - an incentive system: equal split between coherent votes,
  *  - an appeal system: fund 2 choices only, vote on any choice.
  */
-contract DisputeKitSybilResistant is BaseDisputeKit {
+contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
     // ************************************* //
     // *             Structs               * //
     // ************************************* //
@@ -394,6 +394,14 @@ contract DisputeKitSybilResistant is BaseDisputeKit {
             _beneficiary.send(amount); // Deliberate use of send to prevent reverting fallback. It's the user's responsibility to accept ETH.
             emit Withdrawal(_disputeID, _round, _choice, _beneficiary, amount);
         }
+    }
+
+    /** @dev Submits evidence.
+     *  @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to. It's the submitter responsability to submit the right evidence group ID.
+     *  @param _evidence IPFS path to evidence, example: '/ipfs/Qmarwkf7C9RuzDEJNnarT3WZ7kem5bk8DZAzx78acJjMFH/evidence.json'.
+     */
+    function submitEvidence(uint256 _evidenceGroupID, string calldata _evidence) external {
+        emit Evidence(core, _evidenceGroupID, msg.sender, _evidence);
     }
 
     // ************************************* //

--- a/contracts/src/evidence/EvidenceModule.sol
+++ b/contracts/src/evidence/EvidenceModule.sol
@@ -20,15 +20,17 @@ import "./IEvidence.sol";
 import "../arbitration/IArbitrator.sol";
 
 contract EvidenceModule is IEvidence {
-    IArbitrator private constant NULL_ARBITRATOR = IArbitrator(address(0x0));
+    IArbitrator public arbitrator;
 
-    constructor() {}
+    constructor(IArbitrator _arbitrator) {
+        arbitrator = _arbitrator;
+    }
 
     /** @dev Submits evidence.
      *  @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to. It's the submitter responsability to submit the right evidence group ID.
      *  @param _evidence IPFS path to evidence, example: '/ipfs/Qmarwkf7C9RuzDEJNnarT3WZ7kem5bk8DZAzx78acJjMFH/evidence.json'.
      */
     function submitEvidence(uint256 _evidenceGroupID, string calldata _evidence) external {
-        emit Evidence(NULL_ARBITRATOR, _evidenceGroupID, msg.sender, _evidence);
+        emit Evidence(arbitrator, _evidenceGroupID, msg.sender, _evidence);
     }
 }

--- a/contracts/src/evidence/IEvidence.sol
+++ b/contracts/src/evidence/IEvidence.sol
@@ -7,13 +7,6 @@ import "../arbitration/IArbitrator.sol";
  */
 interface IEvidence {
     /**
-     * @dev To be emitted when meta-evidence is submitted.
-     * @param _metaEvidenceID Unique identifier of meta-evidence.
-     * @param _evidence IPFS path to metaevidence, example: '/ipfs/Qmarwkf7C9RuzDEJNnarT3WZ7kem5bk8DZAzx78acJjMFH/metaevidence.json'
-     */
-    event MetaEvidence(uint256 indexed _metaEvidenceID, string _evidence);
-
-    /**
      * @dev To be raised when evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
      * @param _arbitrator The arbitrator of the contract.
      * @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to.
@@ -25,19 +18,5 @@ interface IEvidence {
         uint256 indexed _evidenceGroupID,
         address indexed _party,
         string _evidence
-    );
-
-    /**
-     * @dev To be emitted when a dispute is created to link the correct meta-evidence to the disputeID.
-     * @param _arbitrator The arbitrator of the contract.
-     * @param _disputeID ID of the dispute in the Arbitrator contract.
-     * @param _metaEvidenceID Unique identifier of meta-evidence.
-     * @param _evidenceGroupID Unique identifier of the evidence group that is linked to this dispute.
-     */
-    event Dispute(
-        IArbitrator indexed _arbitrator,
-        uint256 indexed _disputeID,
-        uint256 _metaEvidenceID,
-        uint256 _evidenceGroupID
     );
 }

--- a/contracts/src/evidence/IMetaEvidence.sol
+++ b/contracts/src/evidence/IMetaEvidence.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.8.0;
+
+import "../arbitration/IArbitrator.sol";
+import "./IEvidence.sol";
+
+/** @title IEvidence
+ *  ERC-1497: Evidence Standard
+ */
+interface IMetaEvidence is IEvidence {
+    /**
+     * @dev To be emitted when meta-evidence is submitted.
+     * @param _metaEvidenceID Unique identifier of meta-evidence.
+     * @param _evidence IPFS path to metaevidence, example: '/ipfs/Qmarwkf7C9RuzDEJNnarT3WZ7kem5bk8DZAzx78acJjMFH/metaevidence.json'
+     */
+    event MetaEvidence(uint256 indexed _metaEvidenceID, string _evidence);
+
+    /**
+     * @dev To be emitted when a dispute is created to link the correct meta-evidence to the disputeID.
+     * @param _arbitrator The arbitrator of the contract.
+     * @param _disputeID ID of the dispute in the Arbitrator contract.
+     * @param _metaEvidenceID Unique identifier of meta-evidence.
+     * @param _evidenceGroupID Unique identifier of the evidence group that is linked to this dispute.
+     */
+    event Dispute(
+        IArbitrator indexed _arbitrator,
+        uint256 indexed _disputeID,
+        uint256 _metaEvidenceID,
+        uint256 _evidenceGroupID
+    );
+}

--- a/contracts/src/evidence/ModeratedEvidenceModule.sol
+++ b/contracts/src/evidence/ModeratedEvidenceModule.sol
@@ -18,10 +18,10 @@ pragma solidity ^0.8;
 // TODO: standard interfaces should be placed in a separated repo (?)
 import "../arbitration/IArbitrable.sol";
 import "../arbitration/IArbitrator.sol";
-import "./IEvidence.sol";
+import "./IMetaEvidence.sol";
 import "../libraries/CappedMath.sol";
 
-contract ModeratedEvidenceModule is IArbitrable, IEvidence {
+contract ModeratedEvidenceModule is IArbitrable, IMetaEvidence {
     using CappedMath for uint256;
 
     uint256 public constant AMOUNT_OF_CHOICES = 2;

--- a/contracts/src/gateway/interfaces/IHomeGateway.sol
+++ b/contracts/src/gateway/interfaces/IHomeGateway.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import "../../arbitration/IArbitrable.sol";
-import "../../evidence/IEvidence.sol";
+import "../../evidence/IMetaEvidence.sol";
 
-interface IHomeGateway is IArbitrable, IEvidence {
+interface IHomeGateway is IArbitrable, IMetaEvidence {
     function chainID() external view returns (uint256);
 
     function relayCreateDispute(


### PR DESCRIPTION
Required splitting the IEvidence interface into 2: the MetaEvidence and Dispute events have been moved to an IMetaEvidence interface which extends IEvidence. Because IMetaEvidence is relevant only to the Arbitrable side but not IEvidence.

Resolves #46 

