### PR TITLE
fix: sha256 leaves to avoid 2nd pre-image attack

### DIFF
--- a/contracts/src/bridge/merkle/MerkleProof.sol
+++ b/contracts/src/bridge/merkle/MerkleProof.sol
@@ -39,7 +39,7 @@ contract MerkleProof {
         bytes memory data,
         bytes32 merkleRoot
     ) public pure returns (bool) {
-        return validateProof(proof, keccak256(data), merkleRoot);
+        return validateProof(proof, sha256(data), merkleRoot);
     }
 
     /** @dev Calculates merkle root from proof.

--- a/contracts/src/bridge/merkle/MerkleTreeHistory.sol
+++ b/contracts/src/bridge/merkle/MerkleTreeHistory.sol
@@ -40,7 +40,10 @@ contract MerkleTreeHistory {
      *  @param data The data to insert in the merkle tree.
      */
     function append(bytes memory data) public {
-        bytes32 leaf = keccak256(data);
+        // Differentiate leaves from interior nodes with different
+        // hash functions to prevent 2nd order pre-image attack.
+        // https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
+        bytes32 leaf = sha256(data);
         count += 1;
         uint256 size = count;
         uint256 hashBitField = (size ^ (size - 1)) & size;
@@ -98,8 +101,8 @@ contract MerkleTreeHistory {
         uint256 height = 0;
         bool isFirstHash = true;
         while (size > 0) {
-            // avoid redundant calculation
             if ((size & 1) == 1) {
+                // avoid redundant calculation
                 if (isFirstHash) {
                     node = branch[height];
                     isFirstHash = false;

--- a/contracts/src/bridge/merkle/MerkleTreeHistory.sol
+++ b/contracts/src/bridge/merkle/MerkleTreeHistory.sol
@@ -44,31 +44,30 @@ contract MerkleTreeHistory {
         // hash functions to prevent 2nd order pre-image attack.
         // https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
         bytes32 leaf = sha256(data);
-        count += 1;
-        uint256 size = count;
+        uint256 size = count + 1;
+        count = size;
         uint256 hashBitField = (size ^ (size - 1)) & size;
-
-        for (uint256 height = 0; height < 64; height++) {
-            if ((hashBitField & 1) == 1) {
-                branch[height] = leaf;
-                return;
-            }
+        uint256 height;
+        while ((hashBitField & 1) == 0) {
             bytes32 node = branch[height];
-            // effecient hash
             if (node > leaf)
                 assembly {
+                    // effecient hash
                     mstore(0x00, leaf)
                     mstore(0x20, node)
                     leaf := keccak256(0x00, 0x40)
                 }
             else
                 assembly {
+                    // effecient hash
                     mstore(0x00, node)
                     mstore(0x20, leaf)
                     leaf := keccak256(0x00, 0x40)
                 }
             hashBitField /= 2;
+            height = height + 1;
         }
+        branch[height] = leaf;
     }
 
     /** @dev Saves the merkle root state in history and resets.

--- a/contracts/test/bridge/merkle/MerkleTree.ts
+++ b/contracts/test/bridge/merkle/MerkleTree.ts
@@ -31,7 +31,7 @@ export class MerkleTree {
    * @return node The `sha3` (A.K.A. `keccak256`) hash of `first, ...params` as a 32-byte hex string.
    */
   public static makeLeafNode(data: string): string {
-    const result = ethers.utils.keccak256(data);
+    const result = ethers.utils.sha256(data);
 
     if (!result) {
       throw new Error("Leaf node must not be empty");

--- a/contracts/test/bridge/merkle/index.ts
+++ b/contracts/test/bridge/merkle/index.ts
@@ -61,7 +61,7 @@ describe("Merkle", function () {
     });
   it("Should correctly verify all nodes in the tree", async () => {
     for (var message of data)  {
-      const leaf = ethers.utils.keccak256(message);
+      const leaf = ethers.utils.sha256(message);
       proof = mt.getHexProof(leaf);
       const validation = await merkleProof.validateProof(proof, message,rootOnChain);
       expect(validation).equal(true);


### PR DESCRIPTION
Differentiate leaves from interior nodes with different hash functions to prevent 2nd order pre-image attack.
> https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/

This commit was supposed to have been included in the original PR.