### PR TITLE
chore: fixed the linters configuration

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.{js,ts}": "prettier --write",
+  "*.{js,jsx,ts,tsx}": "prettier --write",
   "*.{md,html,json}": "prettier --write",
   "*.sol": [
     "prettier --write",

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.js": "eslint --cache --fix",
+  "*.{js,ts}": "prettier --write",
   "*.{md,html,json}": "prettier --write",
   "*.sol": [
     "prettier --write",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
   "solidity.compileUsingRemoteVersion": "v0.8.10+commit.fc410830",
-  "mochaExplorer.files": "contracts/test/**/*.{j,t}s",
   "cSpell.words": [
     "arbitrum",
     "IERC",
-    "kleros"
-  ]
+    "kleros",
+    "typechain"
+  ],
+  "prettier.configPath": ".prettierrc.json",
+  "eslint.alwaysShowStatus": true,
+  "eslint.packageManager": "yarn"
 }

--- a/contracts/.eslintrc.js
+++ b/contracts/.eslintrc.js
@@ -6,12 +6,23 @@ module.exports = {
     node: true,
   },
   plugins: ["@typescript-eslint"],
-  extends: ["standard", "plugin:prettier/recommended", "plugin:node/recommended"],
+  extends: ["standard", "plugin:prettier/recommended", "plugin:node/recommended", "plugin:import/typescript"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 12,
   },
   rules: {
-    "node/no-unsupported-features/es-syntax": ["error", { ignores: ["modules"] }],
+    "node/no-unsupported-features/es-syntax": [
+      "error",
+      {
+        ignores: ["modules"],
+      },
+    ],
+    "node/no-missing-import": [
+      "error",
+      {
+        tryExtensions: [".js", ".ts", ".json", ".node"],
+      },
+    ],
   },
 };

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -13,7 +13,7 @@
     "./src",
     "./scripts",
     "./test",
-    "./typechain",
+    "./typechain-types",
     "./deploy"
   ],
   "files": [

--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
     "eslint-utils": "^3.0.0",
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
-    "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
     "prettier-plugin-solidity": "^1.0.0-beta.15",
-    "solhint": "^3.3.6",
     "solhint-plugin-prettier": "^0.0.5"
   },
   "resolutions": {
@@ -69,13 +67,6 @@
   "scripts": {
     "depcheck": "depcheck .",
     "changelog": "conventional-changelog --infile CHANGELOG.md --same-file --release-count 0 && prettier --write CHANGELOG.md",
-    "lint": "run-p -s lint:*",
-    "lint:js": "eslint .",
-    "lint:sol": "solhint 'contracts/**/*.sol'",
-    "fix": "run-p -s fix:*",
-    "fix:js": "eslint --fix '**/*.js'",
-    "fix:sol": "prettier --write 'contracts/**/*.sol'",
-    "prepare": "husky install",
     "postinstall": "husky install"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11650,7 +11650,7 @@ __metadata:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 0d41f2b054031b35c03e437462b69650c3ad48b13f0b9e0f3ae9871bb5dddbd757819db8447cdce6e1f08bd44d572b15d383a876a2c5ad994ebb00ca17a89104
+  checksum: 872685026db07ad1687056a78388f17c6a9bcd22bbf9d99d1e2b21e2d196c6e99a128bcff48063b3f0cf692a4365142fae9dd06cf8c532bc557a45f8ac853308
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11650,7 +11650,7 @@ __metadata:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 872685026db07ad1687056a78388f17c6a9bcd22bbf9d99d1e2b21e2d196c6e99a128bcff48063b3f0cf692a4365142fae9dd06cf8c532bc557a45f8ac853308
+  checksum: 0d41f2b054031b35c03e437462b69650c3ad48b13f0b9e0f3ae9871bb5dddbd757819db8447cdce6e1f08bd44d572b15d383a876a2c5ad994ebb00ca17a89104
   languageName: node
   linkType: hard
 
@@ -14088,10 +14088,8 @@ __metadata:
     eslint-utils: ^3.0.0
     husky: ^7.0.0
     lint-staged: ^11.0.0
-    npm-run-all: ^4.1.5
     prettier: ^2.4.1
     prettier-plugin-solidity: ^1.0.0-beta.15
-    solhint: ^3.3.6
     solhint-plugin-prettier: ^0.0.5
   languageName: unknown
   linkType: soft
@@ -19839,7 +19837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"solhint@npm:^3.3.6, solhint@npm:^3.3.7":
+"solhint@npm:^3.3.7":
   version: 3.3.7
   resolution: "solhint@npm:3.3.7"
   dependencies:


### PR DESCRIPTION
Typescript files were not linted by the pre-commit hook.

Two major changes:
- VS Code is going to use the top-level .prettierrc.json so it may affect the `web` and `subgraph` packages.
- The precommit hook does not run `eslint` anymore for .js files, only `prettier`.

What do you think? @alcercu @AndreiMVP 