### PR TITLE
feat: allow overriding a vote commitment

### DIFF
--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -269,7 +269,8 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
         }
     }
 
-    /** @dev Sets the caller's commit for the specified votes.
+    /** @dev Sets the caller's commit for the specified votes. It can be called multiple times during the
+     *  commit period, each call overrides the commits of the previous one.
      *  `O(n)` where
      *  `n` is the number of votes.
      *  @param _coreDisputeID The ID of the dispute in Kleros Core.
@@ -285,13 +286,11 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
             core.getCurrentPeriod(_coreDisputeID) == KlerosCore.Period.commit,
             "The dispute should be in Commit period."
         );
-        require(_commit != bytes32(0), "Empty commit.");
 
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
         for (uint256 i = 0; i < _voteIDs.length; i++) {
             require(round.votes[_voteIDs[i]].account == msg.sender, "The caller has to own the vote.");
-            require(round.votes[_voteIDs[i]].commit == bytes32(0), "Already committed this vote.");
             round.votes[_voteIDs[i]].commit = _commit;
         }
         round.totalCommitted += _voteIDs.length;

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -286,6 +286,7 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
             core.getCurrentPeriod(_coreDisputeID) == KlerosCore.Period.commit,
             "The dispute should be in Commit period."
         );
+        require(_commit != bytes32(0), "Empty commit.");
 
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -289,7 +289,8 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
         }
     }
 
-    /** @dev Sets the caller's commit for the specified votes.
+    /** @dev Sets the caller's commit for the specified votes. It can be called multiple times during the
+     *  commit period, each call overrides the commits of the previous one.
      *  `O(n)` where
      *  `n` is the number of votes.
      *  @param _coreDisputeID The ID of the dispute in Kleros Core.
@@ -305,13 +306,11 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
             core.getCurrentPeriod(_coreDisputeID) == KlerosCore.Period.commit,
             "The dispute should be in Commit period."
         );
-        require(_commit != bytes32(0), "Empty commit.");
 
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
         for (uint256 i = 0; i < _voteIDs.length; i++) {
             require(round.votes[_voteIDs[i]].account == msg.sender, "The caller has to own the vote.");
-            require(round.votes[_voteIDs[i]].commit == bytes32(0), "Already committed this vote.");
             round.votes[_voteIDs[i]].commit = _commit;
         }
         round.totalCommitted += _voteIDs.length;

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -306,6 +306,7 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
             core.getCurrentPeriod(_coreDisputeID) == KlerosCore.Period.commit,
             "The dispute should be in Commit period."
         );
+        require(_commit != bytes32(0), "Empty commit.");
 
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];


### PR DESCRIPTION
Removes validations from `castCommit` function to allow submitting votes multiple times overriding the previous ones as long as the current period is `Commit`.

This also has the positive side effect of making the `castCommit` function cheaper.

This PR is the implementation for issue #182.