### PR TITLE
fix(Arbitration): small bug fixes

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -675,8 +675,8 @@ contract KlerosCore is IArbitrator {
             if (drawnAddress != address(0)) {
                 // In case no one has staked at the court yet.
                 jurors[drawnAddress].lockedTokens[dispute.subcourtID] += round.tokensAtStakePerJuror;
+                emit Draw(drawnAddress, _disputeID, currentRound, round.drawnJurors.length);
                 round.drawnJurors.push(drawnAddress);
-                emit Draw(drawnAddress, _disputeID, currentRound, i);
             }
         }
     }
@@ -706,7 +706,7 @@ contract KlerosCore is IArbitrator {
         // Warning: the extra round must be created before calling disputeKit.createDispute()
         Round storage extraRound = dispute.rounds.push();
 
-        if (round.nbVotes >= courts[newDisputeKitID].jurorsForCourtJump) {
+        if (round.nbVotes >= courts[newSubcourtID].jurorsForCourtJump) {
             // Jump to parent subcourt.
             newSubcourtID = courts[newSubcourtID].parent;
 

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -654,7 +654,8 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
             core.getNumberOfRounds(_coreDisputeID) - 1
         );
         (uint256 stakedTokens, uint256 lockedTokens) = core.getJurorBalance(_juror, subcourtID);
-        return stakedTokens >= lockedTokens + lockedAmountPerJuror;
+        (, , uint256 minStake, , , ) = core.courts(subcourtID);
+        return stakedTokens >= lockedTokens + lockedAmountPerJuror && stakedTokens >= minStake;
     }
 
     /** @dev Retrieves a juror's address from the stake path ID.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -674,7 +674,8 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
             core.getNumberOfRounds(_coreDisputeID) - 1
         );
         (uint256 stakedTokens, uint256 lockedTokens) = core.getJurorBalance(_juror, subcourtID);
-        if (stakedTokens < lockedTokens + lockedAmountPerJuror) {
+        (, , uint256 minStake, , , ) = core.courts(subcourtID);
+        if (stakedTokens < lockedTokens + lockedAmountPerJuror || stakedTokens < minStake) {
             return false;
         } else {
             return proofOfHumanity(_juror);


### PR DESCRIPTION
Fixes 3 separate bugs:

1. VoteID desync in `Draw `event. Previously voteID was tied to `i` which was incorrect, since with this approach if you call `draw() `several times the event can emit the same voteID for the different jurors.
2. In `appeal()` the court used an ID of a dispute kit for some reason
3. If minStake was increased the jurors with the stake lower than minStake could still be drawn #295 