### PR TITLE
fix(web): links to socials

### DIFF
--- a/web/src/consts/community-elements.tsx
+++ b/web/src/consts/community-elements.tsx
@@ -56,7 +56,7 @@ export const firstSection: IElement[] = [
     urls: [
       {
         node: <StyledLabel>Kleros Forum</StyledLabel>,
-        link: "https://google.com",
+        link: "https://forum.kleros.io/",
       },
     ],
   },
@@ -66,7 +66,7 @@ export const firstSection: IElement[] = [
     urls: [
       {
         node: <StyledLabel>Snapshot</StyledLabel>,
-        link: "https://google.com",
+        link: "https://snapshot.org/#/kleros.eth/",
       },
     ],
   },
@@ -75,7 +75,7 @@ export const firstSection: IElement[] = [
     urls: [
       {
         node: <StyledLabel>Cooperative Kleros</StyledLabel>,
-        link: "https://google.com",
+        link: "https://kleros.io/coop/",
       },
     ],
   },
@@ -88,7 +88,7 @@ export const secondSection: IElement[] = [
     urls: [
       {
         node: <StyledLabel>Join</StyledLabel>,
-        link: "https://google.com",
+        link: "https://t.me/kleros",
       },
     ],
   },
@@ -98,15 +98,15 @@ export const secondSection: IElement[] = [
     urls: [
       {
         node: <StyledDiscordIcon />,
-        link: "https://google.com",
+        link: "https://discord.com/invite/cAvWk8B23f",
       },
       {
         node: <StyledTelegramIcon />,
-        link: "https://google.com",
+        link: "https://t.me/kleros",
       },
       {
         node: <StyledSlackIcon />,
-        link: "https://google.com",
+        link: "https://slack.kleros.io/",
       },
     ],
   },

--- a/web/src/consts/community-elements.tsx
+++ b/web/src/consts/community-elements.tsx
@@ -98,7 +98,7 @@ export const secondSection: IElement[] = [
     urls: [
       {
         node: <StyledDiscordIcon />,
-        link: "https://discord.com/invite/cAvWk8B23f",
+        link: "https://discord.gg/MhXQGCyHd9",
       },
       {
         node: <StyledTelegramIcon />,
@@ -106,7 +106,7 @@ export const secondSection: IElement[] = [
       },
       {
         node: <StyledSlackIcon />,
-        link: "https://slack.kleros.io/",
+        link: "https://kleros.slack.com/join/signup",
       },
     ],
   },


### PR DESCRIPTION
close #648
i have put all the links but only 2 left as I have not found the links one is "join the community calls" and cooperative kleros. 