### PR TITLE
Use a recent non-floating version of Solidity

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -19,7 +19,7 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.9",
+    version: "0.8.18",
     settings: {
       optimizer: {
         enabled: true,

--- a/contracts/src/arbitration/CentralizedArbitrator.sol
+++ b/contracts/src/arbitration/CentralizedArbitrator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitrator.sol";
 

--- a/contracts/src/arbitration/IArbitrable.sol
+++ b/contracts/src/arbitration/IArbitrable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitrator.sol";
 

--- a/contracts/src/arbitration/IArbitrator.sol
+++ b/contracts/src/arbitration/IArbitrator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitrable.sol";
 

--- a/contracts/src/arbitration/IDisputeKit.sol
+++ b/contracts/src/arbitration/IDisputeKit.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitrator.sol";
 

--- a/contracts/src/arbitration/ISortitionModule.sol
+++ b/contracts/src/arbitration/ISortitionModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 interface ISortitionModule {
     enum Phase {

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IArbitrator.sol";
@@ -1036,9 +1036,7 @@ contract KlerosCore is IArbitrator {
     /// @param _value Amount transferred.
     /// @return Whether transfer succeeded or not.
     function _safeTransfer(address _to, uint256 _value) internal returns (bool) {
-        (bool success, bytes memory data) = address(pinakion).call(
-            abi.encodeWithSelector(IERC20.transfer.selector, _to, _value)
-        );
+        (bool success, bytes memory data) = address(pinakion).call(abi.encodeCall(IERC20.transfer, (_to, _value)));
         return (success && (data.length == 0 || abi.decode(data, (bool))));
     }
 
@@ -1049,7 +1047,7 @@ contract KlerosCore is IArbitrator {
     /// @return Whether transfer succeeded or not.
     function _safeTransferFrom(address _from, address _to, uint256 _value) internal returns (bool) {
         (bool success, bytes memory data) = address(pinakion).call(
-            abi.encodeWithSelector(IERC20.transferFrom.selector, _from, _to, _value)
+            abi.encodeCall(IERC20.transferFrom, (_from, _to, _value))
         );
         return (success && (data.length == 0 || abi.decode(data, (bool))));
     }

--- a/contracts/src/arbitration/KlerosGovernor.sol
+++ b/contracts/src/arbitration/KlerosGovernor.sol
@@ -5,7 +5,7 @@
 /// @custom:auditors: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitrable.sol";
 import "../evidence/IMetaEvidence.sol";

--- a/contracts/src/arbitration/PolicyRegistry.sol
+++ b/contracts/src/arbitration/PolicyRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 /// @title PolicyRegistry
 /// @author Enrique Piqueras - <epiquerass@gmail.com>

--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -8,7 +8,7 @@
  *  @custom:deployments: []
  */
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "../arbitration/KlerosCore.sol";
 import "./ISortitionModule.sol";

--- a/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
+++ b/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../IArbitrable.sol";

--- a/contracts/src/arbitration/arbitrables/ArbitrableExampleEthFee.sol
+++ b/contracts/src/arbitration/arbitrables/ArbitrableExampleEthFee.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "../IArbitrable.sol";
 import "../../evidence/IMetaEvidence.sol";

--- a/contracts/src/arbitration/arbitrables/DisputeResolver.sol
+++ b/contracts/src/arbitration/arbitrables/DisputeResolver.sol
@@ -8,7 +8,7 @@
 import "../IArbitrable.sol";
 import "../../evidence/IMetaEvidence.sol";
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 /// @title DisputeResolver
 /// DisputeResolver contract adapted for V2 https://github.com/kleros/arbitrable-proxy-contracts/blob/master/contracts/ArbitrableProxy.sol.

--- a/contracts/src/arbitration/dispute-kits/BaseDisputeKit.sol
+++ b/contracts/src/arbitration/dispute-kits/BaseDisputeKit.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "../IDisputeKit.sol";
 import "../KlerosCore.sol";

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./BaseDisputeKit.sol";
 import "../../evidence/IEvidence.sol";

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./BaseDisputeKit.sol";
 import "../../evidence/IEvidence.sol";

--- a/contracts/src/evidence/EvidenceModule.sol
+++ b/contracts/src/evidence/EvidenceModule.sol
@@ -7,7 +7,7 @@
 /// @custom:deployments: []
 /// @custom:tools: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 // TODO: standard interfaces should be placed in a separated repo (?)
 import "../arbitration/IArbitrator.sol";

--- a/contracts/src/evidence/IEvidence.sol
+++ b/contracts/src/evidence/IEvidence.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../arbitration/IArbitrator.sol";
 

--- a/contracts/src/evidence/IMetaEvidence.sol
+++ b/contracts/src/evidence/IMetaEvidence.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../arbitration/IArbitrator.sol";
 

--- a/contracts/src/evidence/ModeratedEvidenceModule.sol
+++ b/contracts/src/evidence/ModeratedEvidenceModule.sol
@@ -7,7 +7,7 @@
 /// @custom:deployments: []
 /// @custom:tools: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 // TODO: standard interfaces should be placed in a separated repo (?)
 import "../arbitration/IArbitrable.sol";

--- a/contracts/src/gateway/ForeignGateway.sol
+++ b/contracts/src/gateway/ForeignGateway.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../arbitration/IArbitrable.sol";
 import "./interfaces/IForeignGateway.sol";

--- a/contracts/src/gateway/ForeignGatewayOnGnosis.sol
+++ b/contracts/src/gateway/ForeignGatewayOnGnosis.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../arbitration/IArbitrable.sol";
 import "./interfaces/IForeignGateway.sol";

--- a/contracts/src/gateway/HomeGateway.sol
+++ b/contracts/src/gateway/HomeGateway.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../arbitration/IArbitrator.sol";
 import "@kleros/vea-contracts/interfaces/IFastBridgeSender.sol";
@@ -141,9 +141,10 @@ contract HomeGateway is IHomeGateway {
         bytes32 disputeHash = disputeIDtoHash[_disputeID];
         RelayedData memory relayedData = disputeHashtoRelayedData[disputeHash];
 
-        bytes4 methodSelector = IForeignGateway.relayRule.selector;
-        bytes memory data = abi.encodeWithSelector(methodSelector, disputeHash, _ruling, relayedData.relayer);
-
+        bytes memory data = abi.encodeCall(
+            IForeignGateway.relayRule,
+            (address(this), disputeHash, _ruling, relayedData.relayer)
+        );
         fastBridgeSender.sendFast(receiverGateway, data);
     }
 

--- a/contracts/src/gateway/interfaces/IForeignGateway.sol
+++ b/contracts/src/gateway/interfaces/IForeignGateway.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../arbitration/IArbitrator.sol";
 import "@kleros/vea-contracts/interfaces/IReceiverGateway.sol";

--- a/contracts/src/gateway/interfaces/IHomeGateway.sol
+++ b/contracts/src/gateway/interfaces/IHomeGateway.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../arbitration/IArbitrable.sol";
 import "../../evidence/IMetaEvidence.sol";

--- a/contracts/src/gateway/mock/VeaMock.sol
+++ b/contracts/src/gateway/mock/VeaMock.sol
@@ -17,17 +17,8 @@ contract VeaMock is IFastBridgeSender, IFastBridgeReceiver {
     /// @param _receiver The cross-domain contract address which receives the calldata.
     /// @param _calldata The receiving domain encoded message data.
     function sendFast(address _receiver, bytes memory _calldata) external {
-        // Dirty workaround: Solidity does not support array slices for memory arrays and the sender interface cannot be changed.
-        (bytes4 selector, bytes memory payload) = this.decode(_calldata);
-
-        bytes32 sender = bytes32(uint256(uint160(msg.sender)));
-        bytes memory data = abi.encodePacked(selector, sender, payload);
-        (bool success, bytes memory res) = _receiver.call(data);
+        (bool success, bytes memory res) = _receiver.call(_calldata);
         require(success, "Call failure");
-    }
-
-    function decode(bytes calldata data) external pure returns (bytes4, bytes memory) {
-        return (bytes4(data[:4]), data[4:]);
     }
 
     /// Sends a batch of arbitrary message from one domain to another

--- a/contracts/src/gateway/mock/VeaMock.sol
+++ b/contracts/src/gateway/mock/VeaMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "@kleros/vea-contracts/interfaces/IFastBridgeSender.sol";
 import "@kleros/vea-contracts/interfaces/IFastBridgeReceiver.sol";

--- a/contracts/src/gateway/single-message/ForeignGatewayOnEthereum.sol
+++ b/contracts/src/gateway/single-message/ForeignGatewayOnEthereum.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../arbitration/IArbitrable.sol";
 import "@kleros/vea-contracts/interfaces/IFastBridgeReceiver.sol";

--- a/contracts/src/gateway/single-message/HomeGatewayToEthereum.sol
+++ b/contracts/src/gateway/single-message/HomeGatewayToEthereum.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../arbitration/IArbitrator.sol";
 import "@kleros/vea-contracts/single-message/interfaces/IFastBridgeSender.sol";
@@ -99,9 +99,10 @@ contract HomeGatewayToEthereum is IHomeGatewaySingleMessage {
         bytes32 disputeHash = disputeIDtoHash[_disputeID];
         RelayedData memory relayedData = disputeHashtoRelayedData[disputeHash];
 
-        bytes4 methodSelector = IForeignGatewaySingleMessage.relayRule.selector;
-        bytes memory data = abi.encodeWithSelector(methodSelector, disputeHash, _ruling, relayedData.relayer);
-
+        bytes memory data = abi.encodeCall(
+            IForeignGatewaySingleMessage.relayRule,
+            (disputeHash, _ruling, relayedData.relayer)
+        );
         fastbridge.sendFast(foreignGateway, data);
     }
 

--- a/contracts/src/gateway/single-message/interfaces/IForeignGatewaySingleMessage.sol
+++ b/contracts/src/gateway/single-message/interfaces/IForeignGatewaySingleMessage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../arbitration/IArbitrator.sol";
 

--- a/contracts/src/gateway/single-message/interfaces/IHomeGatewaySingleMessage.sol
+++ b/contracts/src/gateway/single-message/interfaces/IHomeGatewaySingleMessage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../arbitration/IArbitrable.sol";
 import "../../../evidence/IMetaEvidence.sol";

--- a/contracts/src/kleros-v1/interfaces/IArbitrableV1.sol
+++ b/contracts/src/kleros-v1/interfaces/IArbitrableV1.sol
@@ -5,7 +5,7 @@
 /// @custom:auditors: []
 /// @custom:bounties: []
 /// @custom:deployments: []
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitratorV1.sol";
 

--- a/contracts/src/kleros-v1/interfaces/IArbitratorV1.sol
+++ b/contracts/src/kleros-v1/interfaces/IArbitratorV1.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "./IArbitrableV1.sol";
 

--- a/contracts/src/kleros-v1/interfaces/IKlerosLiquid.sol
+++ b/contracts/src/kleros-v1/interfaces/IKlerosLiquid.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IArbitratorV1.sol";
 

--- a/contracts/src/kleros-v1/interfaces/ITokenController.sol
+++ b/contracts/src/kleros-v1/interfaces/ITokenController.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 /// @dev The token controller contract must implement these functions. See https://github.com/Giveth/minime/blob/master/contracts/TokenController.sol
 interface ITokenController {

--- a/contracts/src/kleros-v1/kleros-liquid-xdai/WrappedPinakion.sol
+++ b/contracts/src/kleros-v1/kleros-liquid-xdai/WrappedPinakion.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/IERC677.sol
+++ b/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/IERC677.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 interface IERC677 {
     function transfer(address _to, uint256 _value) external returns (bool);

--- a/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/IRandomAuRa.sol
+++ b/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/IRandomAuRa.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 interface IRandomAuRa {
     function currentSeed() external view returns (uint256);

--- a/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/ITokenBridge.sol
+++ b/contracts/src/kleros-v1/kleros-liquid-xdai/interfaces/ITokenBridge.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./IERC677.sol";
 

--- a/contracts/src/kleros-v1/kleros-liquid-xdai/xKlerosLiquidV2.sol
+++ b/contracts/src/kleros-v1/kleros-liquid-xdai/xKlerosLiquidV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/kleros-v1/kleros-liquid/KlerosLiquidToV2Governor.sol
+++ b/contracts/src/kleros-v1/kleros-liquid/KlerosLiquidToV2Governor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "../interfaces/IKlerosLiquid.sol";
 import "../interfaces/ITokenController.sol";
@@ -105,8 +105,7 @@ contract KlerosLiquidToV2Governor is IArbitrable, ITokenController {
 
         IKlerosLiquid.Dispute memory klerosLiquidDispute = klerosLiquid.disputes(dispute.klerosLiquidDisputeID);
 
-        bytes4 functionSelector = IArbitrable.rule.selector;
-        bytes memory data = abi.encodeWithSelector(functionSelector, dispute.klerosLiquidDisputeID, _ruling);
+        bytes memory data = abi.encodeCall(IArbitrable.rule, (dispute.klerosLiquidDisputeID, _ruling));
         klerosLiquid.executeGovernorProposal(klerosLiquidDispute.arbitrated, 0, data);
     }
 

--- a/contracts/src/libraries/CappedMath.sol
+++ b/contracts/src/libraries/CappedMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 /// @title CappedMath
 /// @dev Math operations with caps for under and overflow.

--- a/contracts/src/libraries/SortitionSumTreeFactory.sol
+++ b/contracts/src/libraries/SortitionSumTreeFactory.sol
@@ -6,7 +6,7 @@
 /// @custom:bounties: []
 /// @custom:deployments: []
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 /// @title SortitionSumTreeFactory
 /// @author Enrique Piqueras - <epiquerass@gmail.com>

--- a/contracts/src/rng/BlockhashRNG.sol
+++ b/contracts/src/rng/BlockhashRNG.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./RNG.sol";
 

--- a/contracts/src/rng/IRandomizer.sol
+++ b/contracts/src/rng/IRandomizer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 // Randomizer protocol interface
 interface IRandomizer {

--- a/contracts/src/rng/IncrementalNG.sol
+++ b/contracts/src/rng/IncrementalNG.sol
@@ -4,7 +4,7 @@
 /// @author JayBuidl <jb@kleros.io>
 /// @dev A Random Number Generator which returns a number incremented by 1 each time. Useful as a fallback method.
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 import "./RNG.sol";
 
 contract IncrementalNG is RNG {

--- a/contracts/src/rng/RNG.sol
+++ b/contracts/src/rng/RNG.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 interface RNG {
     /// @dev Request a random number.

--- a/contracts/src/rng/RandomizerRNG.sol
+++ b/contracts/src/rng/RandomizerRNG.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "./RNG.sol";
 import "./IRandomizer.sol";

--- a/contracts/src/rng/mock/RandomizerMock.sol
+++ b/contracts/src/rng/mock/RandomizerMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "../RandomizerRNG.sol";
 

--- a/contracts/src/token/Faucet.sol
+++ b/contracts/src/token/Faucet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/token/PNK.sol
+++ b/contracts/src/token/PNK.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/src/token/WETH.sol
+++ b/contracts/src/token/WETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/src/token/WrappedPinakionV2.sol
+++ b/contracts/src/token/WrappedPinakionV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8;
+pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/integration/index.ts
+++ b/contracts/test/integration/index.ts
@@ -161,17 +161,17 @@ describe("Integration tests", async () => {
     expect((await core.disputes(0)).period).to.equal(Period.execution);
     expect(await core.execute(0, 0, 1000)).to.emit(core, "TokenAndETHShift");
 
-    const tx4 = await core.executeRuling(0);
+    const tx4 = await core.executeRuling(0, { gasLimit: 10000000, gasPrice: 5000000000 });
     console.log("Ruling executed on KlerosCore");
     expect(tx4).to.emit(core, "Ruling").withArgs(homeGateway.address, 0, 0);
     expect(tx4).to.emit(arbitrable, "Ruling").withArgs(foreignGateway.address, 1, 0); // The ForeignGateway starts counting disputeID from 1.
   });
 
-  async function mineBlocks(n: number) {
+  const mineBlocks = async (n: number) => {
     for (let index = 0; index < n; index++) {
       await network.provider.send("evm_mine");
     }
-  }
+  };
 });
 
 const logJurorBalance = async (result) => {


### PR DESCRIPTION
Resolves #572 and implements https://github.com/kleros/builder-baseline/issues/1

Make use of the new [abi.encodeCall()](https://blog.soliditylang.org/2021/12/20/solidity-0.8.11-release-announcement/) to benefit from type checking.