### PR TITLE
chore: fix linter error

### DIFF
--- a/web/src/utils/uploadFormDataToIPFS.ts
+++ b/web/src/utils/uploadFormDataToIPFS.ts
@@ -2,7 +2,7 @@ import { toast } from "react-toastify";
 import { OPTIONS } from "utils/wrapWithToast";
 
 export function uploadFormDataToIPFS(formData: FormData): Promise<Response> {
-  return toast.promise<Response, Error, void>(
+  return toast.promise<Response, Error>(
     fetch("/.netlify/functions/uploadToIPFS?dapp=court&key=kleros-v2&operation=evidence", {
       method: "POST",
       body: formData,

--- a/web/src/utils/uploadFormDataToIPFS.ts
+++ b/web/src/utils/uploadFormDataToIPFS.ts
@@ -1,24 +1,24 @@
-import { toast, ToastContentProps } from "react-toastify";
+import { toast } from "react-toastify";
 import { OPTIONS } from "utils/wrapWithToast";
 
 export function uploadFormDataToIPFS(formData: FormData): Promise<Response> {
-  return toast.promise(
-    new Promise((resolve, reject) =>
-      fetch("/.netlify/functions/uploadToIPFS?dapp=court&key=kleros-v2&operation=evidence", {
-        method: "POST",
-        body: formData,
-      }).then(async (response) =>
-        response.status === 200
-          ? resolve(response)
-          : reject(await response.json().catch(() => ({ message: "Error uploading to IPFS" })))
-      )
-    ),
+  return toast.promise<Response, Error, void>(
+    fetch("/.netlify/functions/uploadToIPFS?dapp=court&key=kleros-v2&operation=evidence", {
+      method: "POST",
+      body: formData,
+    }).then(async (response) => {
+      if (response.status !== 200) {
+        const error = await response.json().catch(() => ({ message: "Error uploading to IPFS" }));
+        throw new Error(error.message);
+      }
+      return response;
+    }),
     {
       pending: "Uploading evidence to IPFS...",
       success: "Uploaded successfully!",
       error: {
-        render({ data }: ToastContentProps<{ message: string }>) {
-          return `Upload failed: ${data?.message}`;
+        render({ data: error }) {
+          return `Upload failed: ${error?.message}`;
         },
       },
     },


### PR DESCRIPTION
Fixes #920 

No bug, warning because the promise constructor was returning another promise (`fetch`), instead of returning `void`.
This can be fixed by just changing
`new Promise((resolve, reject) => fetch(...))` to
`new Promise((resolve, reject) => { fetch(...) })`

but we don't necessarily need another new promise, since `fetch` already returns a promise.
Here, it is semantically preferable to throw an `Error` type, so type annotations are also updated accordingly.