### PR TITLE
Refactor: events for voting, commitment and currency rate changes

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -472,6 +472,7 @@ contract KlerosCore is IArbitratorV2 {
         CurrencyRate storage rate = currencyRates[_feeToken];
         rate.rateInEth = _rateInEth;
         rate.rateDecimals = _rateDecimals;
+        emit NewCurrencyRate(_feeToken, _rateInEth, _rateDecimals);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -68,10 +68,25 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
     // *              Events               * //
     // ************************************* //
 
+    /// @dev To be emitted when a dispute is created.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _numberOfChoices The number of choices available in the dispute.
+    /// @param _extraData The extra data for the dispute.
     event DisputeCreation(uint256 indexed _coreDisputeID, uint256 _numberOfChoices, bytes _extraData);
 
-    event CommitCast(uint256 indexed _coreDisputeID, uint256[] _voteIDs, bytes32 _commit);
+    /// @dev To be emitted when a vote commitment is cast.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _juror The address of the juror casting the vote commitment.
+    /// @param _voteIDs The identifiers of the votes in the dispute.
+    /// @param _commit The commitment of the juror.
+    event CommitCast(uint256 indexed _coreDisputeID, address indexed _juror, uint256[] _voteIDs, bytes32 _commit);
 
+    /// @dev To be emitted when a funding contribution is made.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount contributed.
     event Contribution(
         uint256 indexed _coreDisputeID,
         uint256 indexed _coreRoundID,
@@ -80,6 +95,12 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
         uint256 _amount
     );
 
+    /// @dev To be emitted when the contributed funds are withdrawn.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount withdrawn.
     event Withdrawal(
         uint256 indexed _coreDisputeID,
         uint256 indexed _coreRoundID,
@@ -88,6 +109,10 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
         uint256 _amount
     );
 
+    /// @dev To be emitted when a choice is fully funded for an appeal.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
     event ChoiceFunded(uint256 indexed _coreDisputeID, uint256 indexed _coreRoundID, uint256 indexed _choice);
 
     // ************************************* //
@@ -200,7 +225,7 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
             round.votes[_voteIDs[i]].commit = _commit;
         }
         round.totalCommitted += _voteIDs.length;
-        emit CommitCast(_coreDisputeID, _voteIDs, _commit);
+        emit CommitCast(_coreDisputeID, msg.sender, _voteIDs, _commit);
     }
 
     /// @dev Sets the caller's choices for the specified votes.
@@ -258,7 +283,7 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
                 round.tied = false;
             }
         }
-        emit Justification(_coreDisputeID, msg.sender, _choice, _justification);
+        emit VoteCast(_coreDisputeID, msg.sender, _voteIDs, _choice, _justification);
     }
 
     /// @dev Manages contributions, and appeals a dispute if at least two choices are fully funded.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -78,10 +78,25 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
     // *              Events               * //
     // ************************************* //
 
+    /// @dev To be emitted when a dispute is created.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _numberOfChoices The number of choices available in the dispute.
+    /// @param _extraData The extra data for the dispute.
     event DisputeCreation(uint256 indexed _coreDisputeID, uint256 _numberOfChoices, bytes _extraData);
 
-    event CommitCast(uint256 indexed _coreDisputeID, uint256[] _voteIDs, bytes32 _commit);
+    /// @dev To be emitted when a vote commitment is cast.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _juror The address of the juror casting the vote commitment.
+    /// @param _voteIDs The identifiers of the votes in the dispute.
+    /// @param _commit The commitment of the juror.
+    event CommitCast(uint256 indexed _coreDisputeID, address indexed _juror, uint256[] _voteIDs, bytes32 _commit);
 
+    /// @dev To be emitted when a funding contribution is made.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount contributed.
     event Contribution(
         uint256 indexed _coreDisputeID,
         uint256 indexed _coreRoundID,
@@ -90,6 +105,12 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
         uint256 _amount
     );
 
+    /// @dev To be emitted when the contributed funds are withdrawn.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount withdrawn.
     event Withdrawal(
         uint256 indexed _coreDisputeID,
         uint256 indexed _coreRoundID,
@@ -98,6 +119,10 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
         uint256 _amount
     );
 
+    /// @dev To be emitted when a choice is fully funded for an appeal.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
     event ChoiceFunded(uint256 indexed _coreDisputeID, uint256 indexed _coreRoundID, uint256 indexed _choice);
 
     // ************************************* //
@@ -220,7 +245,7 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
             round.votes[_voteIDs[i]].commit = _commit;
         }
         round.totalCommitted += _voteIDs.length;
-        emit CommitCast(_coreDisputeID, _voteIDs, _commit);
+        emit CommitCast(_coreDisputeID, msg.sender, _voteIDs, _commit);
     }
 
     /// @dev Sets the caller's choices for the specified votes.
@@ -278,7 +303,7 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
                 round.tied = false;
             }
         }
-        emit Justification(_coreDisputeID, msg.sender, _choice, _justification);
+        emit VoteCast(_coreDisputeID, msg.sender, _voteIDs, _choice, _justification);
     }
 
     /// @dev Manages contributions, and appeals a dispute if at least two choices are fully funded.

--- a/contracts/src/arbitration/interfaces/IArbitratorV2.sol
+++ b/contracts/src/arbitration/interfaces/IArbitratorV2.sol
@@ -29,6 +29,12 @@ interface IArbitratorV2 {
     /// @param _accepted Whether the token is accepted or not.
     event AcceptedFeeToken(IERC20 indexed _token, bool indexed _accepted);
 
+    /// @dev To be emitted when the fee for a particular ERC20 token is updated.
+    /// @param _feeToken The ERC20 token.
+    /// @param _rateInEth The new rate of the fee token in ETH.
+    /// @param _rateDecimals The new decimals of the fee token rate.
+    event NewCurrencyRate(IERC20 indexed _feeToken, uint64 _rateInEth, uint8 _rateDecimals);
+
     /// @dev Create a dispute and pay for the fees in the native currency, typically ETH.
     ///      Must be called by the arbitrable contract.
     ///      Must pay at least arbitrationCost(_extraData).

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -19,13 +19,15 @@ interface IDisputeKit {
     // ************************************ //
 
     /// @dev Emitted when casting a vote to provide the justification of juror's choice.
-    /// @param _coreDisputeID ID of the dispute in the core contract.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
     /// @param _juror Address of the juror.
+    /// @param _voteIDs The identifiers of the votes in the dispute.
     /// @param _choice The choice juror voted for.
     /// @param _justification Justification of the choice.
-    event Justification(
+    event VoteCast(
         uint256 indexed _coreDisputeID,
         address indexed _juror,
+        uint256[] _voteIDs,
         uint256 indexed _choice,
         string _justification
     );

--- a/contracts/src/gateway/interfaces/IForeignGateway.sol
+++ b/contracts/src/gateway/interfaces/IForeignGateway.sol
@@ -16,6 +16,8 @@ interface IForeignGateway is IArbitratorV2, IReceiverGateway {
     /// @param _foreignBlockHash foreignBlockHash
     /// @param _foreignArbitrable The address of the Arbitrable contract.
     /// @param _foreignDisputeID The identifier of the dispute in the Arbitrable contract.
+    /// @param _choices The number of choices the arbitrator can choose from in this dispute.
+    /// @param _extraData Any extra data to attach.
     event CrossChainDisputeOutgoing(
         bytes32 _foreignBlockHash,
         address indexed _foreignArbitrable,


### PR DESCRIPTION
## Summary

### New event

```solidity
event NewCurrencyRate(IERC20 indexed _feeToken, uint64 _rateInEth, uint8 _rateDecimals);
```

### Modified events

**Before**
```solidity
Justification(_coreDisputeID, _juror, _choice, _justification);
CommitCast(_coreDisputeID, _voteIDs, _commit);
```

**After**
```solidity
VoteCast(_coreDisputeID, _juror, _voteIDs, _choice, _justification);
CommitCast(_coreDisputeID, _juror, _voteIDs, _commit);
```

**Changes**
- Justification => VoteCast
- Adding _voteIDs to the vote event
- Adding _juror to the commit event

**Rationale**
- Consistency
- Enables a more connected subgraph as right now there is no direct  connection between voteID and justification

## Todo

- Deploy the new contracts
- Update the subgraph
- Update the frontend