### PR TITLE
Feat/upgrade sortition module

### DIFF
--- a/contracts/deploy/00-home-chain-arbitration.ts
+++ b/contracts/deploy/00-home-chain-arbitration.ts
@@ -85,10 +85,16 @@ const deployArbitration: DeployFunction = async (hre: HardhatRuntimeEnvironment)
     proxy: {
       proxyContract: "UUPSProxy",
       proxyArgs: ["{implementation}", "{data}"],
+      checkProxyAdmin: false,
+      checkABIConflict: false,
       execute: {
         init: {
           methodName: "initialize",
           args: [deployer, KlerosCoreAddress, 1800, 1800, rng.address, RNG_LOOKAHEAD], // minStakingTime, maxFreezingTime
+        },
+        onUpgrade: {
+          methodName: "governor",
+          args: [],
         },
       },
     },

--- a/contracts/src/proxy/UUPSProxiable.sol
+++ b/contracts/src/proxy/UUPSProxiable.sol
@@ -1,0 +1,134 @@
+//SPDX-License-Identifier: MIT
+
+/**
+ *  @authors: [@malatrax]
+ *  @reviewers: []
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
+pragma solidity 0.8.18;
+
+/**
+ * @title UUPS Proxiable
+ * @author Simon Malatrait <simon.malatrait@grenoble-inp.org>
+ * @dev This contract implements an upgradeability mechanism designed for UUPS proxies.
+ * The functions included here can perform an upgrade of an UUPS Proxy, when this contract is set as the implementation behind such a proxy.
+ *
+ * IMPORTANT: A UUPS proxy requires its upgradeability functions to be in the implementation as opposed to the transparent proxy.
+ * This means that if the proxy is upgraded to an implementation that does not support this interface, it will no longer be upgradeable.
+ *
+ * A security mechanism ensures that an upgrade does not turn off upgradeability accidentally, although this risk is
+ * reinstated if the upgrade retains upgradeability but removes the security mechanism, e.g. by replacing
+ * `UUPSProxiable` with a custom implementation of upgrades.
+ *
+ * The `_authorizeUpgrade` function must be overridden to include access restriction to the upgrade mechanism.
+ */
+abstract contract UUPSProxiable {
+    // ************************************* //
+    // *             Event                 * //
+    // ************************************* //
+
+    /**
+     * Emitted when the `implementation` has been successfully upgraded.
+     * @param newImplementation Address of the new implementation the proxy is now forwarding calls to.
+     */
+    event Upgraded(address indexed newImplementation);
+
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     * NOTE: bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+     */
+    bytes32 private constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /**
+     * @dev Storage variable of the proxiable contract address.
+     * It is used to check whether or not the current call is from the proxy.
+     */
+    address private immutable __self = address(this);
+
+    // ************************************* //
+    // *             Governance            * //
+    // ************************************* //
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * @dev Called by {upgradeToAndCall}.
+     */
+    function _authorizeUpgrade(address newImplementation) internal virtual;
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /// The `implementation` is not UUPS-compliant
+    error InvalidImplementation(address implementation);
+
+    /**
+     * @dev Upgrade mechanism including access control and UUPS-compliance.
+     * @param newImplementation Address of the new implementation contract.
+     * @param data Data used in a delegate call to `newImplementation` if non-empty. This will typically be an encoded
+     * function call, and allows initializing the storage of the proxy like a Solidity constructor.
+     *
+     * @dev Reverts if the execution is not performed via delegatecall or the execution
+     * context is not of a proxy with an ERC1967-compliant implementation pointing to self.
+     */
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable virtual {
+        _authorizeUpgrade(newImplementation);
+
+        /* Check that the execution is being performed through a delegatecall call and that the execution context is
+        a proxy contract with an implementation (as defined in ERC1967) pointing to self. */
+        require(address(this) != __self, "Must be called through delegatecall");
+        require(_getImplementation() == __self, "Must be called through an active proxy");
+
+        try UUPSProxiable(newImplementation).proxiableUUID() returns (bytes32 slot) {
+            require(slot == IMPLEMENTATION_SLOT, "Unsupported Proxiable UUID");
+            // Store the new implementation address to the implementation storage slot.
+            assembly {
+                sstore(IMPLEMENTATION_SLOT, newImplementation)
+            }
+            emit Upgraded(newImplementation);
+
+            if (data.length != 0) {
+                // The return data is not checked (checking, in case of success, that the newImplementation code is non-empty if the return data is empty) because the authorized callee is trusted.
+                (bool success, ) = newImplementation.delegatecall(data);
+                require(success, "Unsuccessful delegatecall");
+            }
+        } catch {
+            revert InvalidImplementation(newImplementation);
+        }
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /**
+     * @dev Implementation of the ERC1822 `proxiableUUID` function. This returns the storage slot used by the
+     * implementation. It is used to validate the implementation's compatibility when performing an upgrade.
+     *
+     * IMPORTANT: A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
+     * bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
+     * function revert if invoked through a proxy. This is guaranteed by the require statement.
+     */
+    function proxiableUUID() external view virtual returns (bytes32) {
+        require(address(this) == __self, "Must not be called through delegatecall");
+        return IMPLEMENTATION_SLOT;
+    }
+
+    // ************************************* //
+    // *           Internal Views          * //
+    // ************************************* //
+
+    function _getImplementation() internal view returns (address implementation) {
+        assembly {
+            implementation := sload(IMPLEMENTATION_SLOT)
+        }
+    }
+}

--- a/contracts/src/proxy/UUPSProxy.sol
+++ b/contracts/src/proxy/UUPSProxy.sol
@@ -1,0 +1,108 @@
+//SPDX-License-Identifier: MIT
+
+/**
+ *  @authors: [@malatrax]
+ *  @reviewers: []
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
+pragma solidity 0.8.18;
+
+/**
+ * @title UUPS Proxy
+ * @author Simon Malatrait <simon.malatrait@grenoble-inp.org>
+ * @dev This contract implements a UUPS Proxy compliant with ERC-1967 & ERC-1822.
+ * @dev This contract delegates all calls to another contract (UUPS Proxiable) through a fallback function and the use of the `delegatecall` EVM instruction.
+ * @dev We refer to the Proxiable contract (as per ERC-1822) with `implementation`.
+ */
+contract UUPSProxy {
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     * NOTE: bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+     */
+    bytes32 private constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /**
+     * @dev Initializes the upgradeable proxy with an initial implementation specified by `_implementation`.
+     *
+     * If `_data` is nonempty, it's used as data in a delegate call to `_implementation`. This will typically be an encoded
+     * function call, and allows initializing the storage of the proxy like a Solidity constructor.
+     */
+    constructor(address _implementation, bytes memory _data) {
+        assembly {
+            sstore(IMPLEMENTATION_SLOT, _implementation)
+        }
+
+        if (_data.length != 0) {
+            (bool success, ) = _implementation.delegatecall(_data);
+            require(success, "Proxy Constructor failed");
+        }
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * NOTE: This function does not return to its internal call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    // ************************************* //
+    // *           Internal Views            * //
+    // ************************************* //
+
+    function _getImplementation() internal view returns (address implementation) {
+        assembly {
+            implementation := sload(IMPLEMENTATION_SLOT)
+        }
+    }
+
+    // ************************************* //
+    // *           Fallback                * //
+    // ************************************* //
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback() external payable {
+        _delegate(_getImplementation());
+    }
+
+    receive() external payable {
+        _delegate(_getImplementation());
+    }
+}

--- a/contracts/src/proxy/mock/MockImplementations.sol
+++ b/contracts/src/proxy/mock/MockImplementations.sol
@@ -1,0 +1,62 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.18;
+
+import "../UUPSProxiable.sol";
+
+contract NonUpgradeableMock {
+    uint256 public _counter;
+
+    function counter() external view returns (uint256) {
+        return _counter;
+    }
+
+    function increment() external {
+        _counter++;
+    }
+
+    function version() external pure virtual returns (string memory) {
+        return "NonUpgradeableMock 0.0.0";
+    }
+}
+
+contract UUPSUpgradeableMock is UUPSProxiable, NonUpgradeableMock {
+    bool private initialized;
+    address public governor;
+
+    uint256[50] __gap;
+
+    constructor() {
+        initialized = true;
+    }
+
+    function initialize(address _governor) external {
+        require(!initialized, "Contract instance has already been initialized");
+        governor = _governor;
+        initialized = true;
+    }
+
+    function _authorizeUpgrade(address) internal view override {
+        require(governor == msg.sender, "No privilege to upgrade");
+    }
+
+    function version() external pure virtual override returns (string memory) {
+        return "UUPSUpgradeableMock 1.0.0";
+    }
+}
+
+contract UUPSUpgradeableMockV2 is UUPSUpgradeableMock {
+    function version() external pure override returns (string memory) {
+        return "UUPSUpgradeableMock 2.0.0";
+    }
+}
+
+contract UUPSUnsupportedProxiableUUID is UUPSUpgradeableMock {
+    function proxiableUUID() external pure override returns (bytes32) {
+        return keccak256("invalid UUID");
+    }
+
+    function version() external pure override returns (string memory) {
+        return "UUPSUnsupportedProxiableUUID 1.0.0";
+    }
+}

--- a/contracts/test/arbitration/index.ts
+++ b/contracts/test/arbitration/index.ts
@@ -97,6 +97,10 @@ async function deployContracts(deployer) {
           methodName: "initialize",
           args: [deployer.address, KlerosCoreAddress, 120, 120, rng.address, LOOKAHEAD], // minStakingTime, maxFreezingTime
         },
+        onUpgrade: {
+          methodName: "governor",
+          args: [],
+        },
       },
     },
     log: true,

--- a/contracts/test/proxy/index.ts
+++ b/contracts/test/proxy/index.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { ethers, deployments, getNamedAccounts } from "hardhat";
+const hre = require("hardhat");
+
+let deployer;
+let user1;
+
+let uupsProxyDeployment;
+let uupsProxy;
+let uupsImplementationInit;
+
+describe("Mock Implementation Proxy", async () => {
+  beforeEach("Setup Contracts", async () => {
+    [deployer, user1] = await ethers.getSigners();
+    // uupsProxyDeployment = await deployments.get("UUPSUpgradeableMock");
+
+    // Deploy Proxy with hardhat-deploy
+    uupsProxyDeployment = await deployments.deploy("UUPSUpgradeableMock", {
+      from: deployer.address,
+      proxy: {
+        proxyContract: "UUPSProxy",
+        execute: {
+          init: {
+            methodName: "initialize",
+            args: [deployer.address],
+          },
+        },
+        proxyArgs: ["{implementation}", "{data}"],
+      },
+      log: true,
+      args: [],
+    });
+    uupsProxy = await ethers.getContractAt("UUPSUpgradeableMock", uupsProxyDeployment.address);
+    uupsImplementationInit = await ethers.getContractAt("UUPSUpgradeableMock", uupsProxyDeployment.implementation);
+    // console.log(uupsProxyDeployment.implementation);
+  });
+
+  describe("Initialization", async () => {
+    it("Governor cannot re-initialize the proxy", async () => {
+      await expect(uupsProxy.connect(deployer).initialize(deployer.address)).to.be.revertedWith(
+        "Contract instance has already been initialized"
+      );
+    });
+    it("User cannot re-initialize the proxy", async () => {
+      await expect(uupsProxy.connect(user1).initialize(user1.address)).to.be.revertedWith(
+        "Contract instance has already been initialized"
+      );
+    });
+    it("Implementation cannot be directly upgraded", async () => {
+      await expect(uupsImplementationInit.initialize(user1.address)).to.be.revertedWith(
+        "Contract instance has already been initialized"
+      );
+    });
+    // it("Unauthorized user cannot upgrade", async () => {});
+  });
+  describe("Upgrade", async () => {
+    describe("Security", async () => {
+      it("Should revert if implementation has a broken UUID", async () => {
+        const UUPSUnsupportedProxiableUUIDFactory = await ethers.getContractFactory("UUPSUnsupportedProxiableUUID");
+        const uupsUnsupportedUUID = await UUPSUnsupportedProxiableUUIDFactory.deploy();
+        await expect(
+          uupsProxy.connect(deployer).upgradeToAndCall(uupsUnsupportedUUID.address, "0x")
+        ).to.be.revertedWith("Unsupported Proxiable UUID");
+      });
+      it("Should revert on upgrades to non UUPS-compliant implementation", async () => {
+        const NonUpgradeableMockFactory = await ethers.getContractFactory("NonUpgradeableMock");
+        const nonUpgradeableMock = await NonUpgradeableMockFactory.deploy();
+        await expect(uupsProxy.upgradeToAndCall(nonUpgradeableMock.address, "0x"))
+          .to.be.revertedWithCustomError(uupsProxy, "InvalidImplementation")
+          .withArgs(nonUpgradeableMock.address);
+      });
+
+      // If the `governor` storage slot is not initialized in the constructor, trying to directly upgrade the implementation as `governor === address(0)`
+      //   it("Should revert if upgrade is performed directly through the implementation", async () => {
+      //     const UUPSUpgradeableMockV2Factory = await ethers.getContractFactory("UUPSUpgradeableMockV2");
+      //     const newImplementation = await UUPSUpgradeableMockV2Factory.connect(deployer).deploy();
+
+      //     await expect(uupsImplementationInit.connect(deployer).upgradeToAndCall(newImplementation.address, "0x")).to.be.revertedWith(
+      //       "Must be called through delegatecall"
+      //     );
+      //   })
+    });
+
+    describe("Governance", async () => {
+      it("Only the governor (deployer here) can perform upgrades", async () => {
+        // Unauthorized user try to upgrade the implementation
+        const UUPSUpgradeableMockV2Factory = await ethers.getContractFactory("UUPSUpgradeableMockV2");
+        const newUserImplementation = await UUPSUpgradeableMockV2Factory.connect(user1).deploy();
+
+        await expect(uupsProxy.connect(user1).upgradeToAndCall(newUserImplementation.address, "0x")).to.be.revertedWith(
+          "No privilege to upgrade"
+        );
+
+        // Governor updates the implementation
+        const newGovernorImplementation = await UUPSUpgradeableMockV2Factory.connect(deployer).deploy();
+        console.log("Version: ", await uupsProxy.version());
+
+        await expect(uupsProxy.connect(deployer).upgradeToAndCall(newGovernorImplementation.address, "0x"))
+          .to.emit(uupsProxy, "Upgraded")
+          .withArgs(newGovernorImplementation.address);
+
+        console.log("Version: ", await uupsProxy.version());
+      });
+    });
+  });
+
+  describe("After Test", async () => {
+    it("Reset  implementation to deployment's implementation address", async () => {
+      await uupsProxy.upgradeToAndCall(uupsProxyDeployment.implementation, "0x");
+      console.log("Version: ", await uupsProxy.version());
+    });
+  });
+});

--- a/contracts/test/proxy/index.ts
+++ b/contracts/test/proxy/index.ts
@@ -24,6 +24,10 @@ describe("Mock Implementation Proxy", async () => {
             methodName: "initialize",
             args: [deployer.address],
           },
+          onUpgrade: {
+            methodName: "counter",
+            args: [],
+          },
         },
         proxyArgs: ["{implementation}", "{data}"],
       },


### PR DESCRIPTION
This PR implements an ERC-1822-compliant (UUPS) & ERC-1967-compliant proxy, and make the SortitionModule upgradeable.

# Proxy & Proxiable
## Contracts

The UUPS Proxy and Proxiable contracts implementation are custom, based on OpenZeppelin, Andrei & Synthetix work, as described [here]([https://gist.github.com/zmalatrax/e3e46044611d57befaf12c9f437b2e0f](https://gist.github.com/zmalatrax/e3e46044611d57befaf12c9f437b2e0f)).

They can be found [here](https://github.com/kleros/kleros-v2/tree/feat/upgrade-sortition-module/contracts/src/proxy). No review has been done yet.
## Testing

In order to test the proxy mechanisms (forwarding, upgrading...), I made different [mock implementations](https://github.com/kleros/kleros-v2/blob/feat/upgrade-sortition-module/contracts/src/proxy/mock/MockImplementations.sol), inspired by OpenZeppelin's tests.

The tests can be found [here](https://github.com/kleros/kleros-v2/blob/feat/upgrade-sortition-module/contracts/test/proxy/index.ts).  
# SortitionModule

## Transition to Upgradeable
Making a contract upgradeable requires a few steps:
- Inherit from `UUPSProxiable`
- Move the constructor to an `initialize` function
	- Add an `bool private initialized` storage variable, to allow initializing only once.
	- For security purposes, initializing the implementation when deployed (in the constructor) is needed to avoid someone taking over the implementation and potentially bricking the proxy (UUPS-related issue)
- Override the `_authorizeUpgrade(address)` function to define access control for upgradeability.
- Add an arbitrary gap (`uint256[50] __gap`)  if this contract is to be inherited from (a Parent contract), to allow updating the storage layout without causing storage collision with Child storage. Further explained [here](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps)
  It is actually not needed for the SortitionModule.
## Testing

I haven't written specific tests for the upgradeability mechanism of the newly upgradeable SortitionModule but it passes the already made test suite. To run tests, the deployment script had to be modified to deploy the proxy and the implementation, thanks to hardhat-deploy. 

The [DisputeKitClassic test](https://github.com/kleros/kleros-v2/commit/eccad1a45a762fd494f87ccac53a386bb66608b4#diff-b717549f72be055210da965a49674276de00dfbd2aa5ac96a1bff8875c2b419a) had to be modified, as it deploys a SortitionModule in it.
# Deployment Script

The SortitionModule is deployed by [`00-home-chain-arbitration.ts`](https://github.com/kleros/kleros-v2/blob/feat/upgrade-sortition-module/contracts/deploy/00-home-chain-arbitration.ts).

The UUPS proxy deployment requires 2 transactions:
1. Deploying the implementation contract
2. Deploying the proxy contract (and initializing it)

As the `KlerosCoreAddress` is computed in advance, based on the nonce to be set for the SortitionModule, the used nonce will be `+2` rather than the previous `+1`.
## hardhat-deploy

Deploying a custom UUPS proxy is not well documented in hardhat-deploy, here is the process:

```typescript
const sortitionModuleDeployment = await deploy("SortitionModule", {
    from: deployer,
    proxy: {
      proxyContract: "UUPSProxy",
      proxyArgs: ["{implementation}", "{data}"],
      execute: {
        init: {
          methodName: "initialize",
          args: [deployer, KlerosCoreAddress, 1800, 1800, rng.address, RNG_LOOKAHEAD], // minStakingTime, maxFreezingTime
        },
      },
    },
    log: true,
    args: [],
  });
```

- The first argument of `deploy` is the deployment name. If it matches a contract name, it will deploy this contract, but it is not necessary to match a contract. If the deployment name doesn't match a contract, the property `contractName` must be defined with the implementation to be deployed in the second argument object. It is necessary if you want to deploy multiple instances of the same contract (e.g in [DisputeKitClassic](https://github.com/kleros/kleros-v2/commit/eccad1a45a762fd494f87ccac53a386bb66608b4#diff-b717549f72be055210da965a49674276de00dfbd2aa5ac96a1bff8875c2b419a))

- The `proxy` object enables the proxy deployment instead of a direct deployment.

- `proxyContract`: The proxy contract name.
- `proxyArgs`: The arguments template of the proxy constructor.  If not specified, it relies on a [default value](https://github.com/wighawag/hardhat-deploy/blob/1a216e1584fd10262b365fa0469d099cd094ead4/src/helpers.ts#L1178) `proxyArgsTemplate = ["{implementation}", '{admin}', "{data}"]` which doesn't suit UUPS Proxies.
  The only UUPS proxy natively supported by hardhat-deploy is a version of the OpenZeppelin's one, the `proxyArgsTemplate` is updated along other parameters. See this [snippet](https://github.com/wighawag/hardhat-deploy/blob/1a216e1584fd10262b365fa0469d099cd094ead4/src/helpers.ts#L1259-L1264).
  - `execute` object with two properties, `init` & `onUpgrade` to define methods to call respectively on first deployment and other deployments of the proxy.
    These two objects, `init` & `onUpgrade` have the same structure:
    - `methodName`: name of the function to be called
    - `args`: Array containing the different arguments used when calling `methodName`.

`onUpgrade` hasn't been defined for the SortitionModule.
## Known limitations


# Misc