### PR TITLE
Fix/staking bug

### DIFF
--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -268,7 +268,7 @@ contract SortitionModule is ISortitionModule {
     /// Note that this function reverts if the sum of all values in the tree is 0.
     /// @param _key The key of the tree.
     /// @param _coreDisputeID Index of the dispute in Kleros Core.
-    /// @param _voteID ID of the voter.
+    /// @param _nonce Nonce to hash with random number.
     /// @return drawnAddress The drawn address.
     /// `O(k * log_k(n))` where
     /// `k` is the maximum number of children per node in the tree,
@@ -276,7 +276,7 @@ contract SortitionModule is ISortitionModule {
     function draw(
         bytes32 _key,
         uint256 _coreDisputeID,
-        uint256 _voteID
+        uint256 _nonce
     ) public view override returns (address drawnAddress) {
         require(phase == Phase.drawing, "Wrong phase.");
         SortitionSumTree storage tree = sortitionSumTrees[_key];
@@ -285,7 +285,7 @@ contract SortitionModule is ISortitionModule {
             return address(0); // No jurors staked.
         }
 
-        uint256 currentDrawnNumber = uint256(keccak256(abi.encodePacked(randomNumber, _coreDisputeID, _voteID))) %
+        uint256 currentDrawnNumber = uint256(keccak256(abi.encodePacked(randomNumber, _coreDisputeID, _nonce))) %
             tree.nodes[0];
 
         // While it still has children

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -181,9 +181,11 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
     /// @dev Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
     /// Note: Access restricted to Kleros Core only.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _nonce Nonce of the drawing iteration.
     /// @return drawnAddress The drawn address.
     function draw(
-        uint256 _coreDisputeID
+        uint256 _coreDisputeID,
+        uint256 _nonce
     ) external override onlyByCore notJumped(_coreDisputeID) returns (address drawnAddress) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
@@ -193,7 +195,7 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
         bytes32 key = bytes32(uint256(courtID)); // Get the ID of the tree.
 
         // TODO: Handle the situation when no one has staked yet.
-        drawnAddress = sortitionModule.draw(key, _coreDisputeID, round.votes.length);
+        drawnAddress = sortitionModule.draw(key, _coreDisputeID, _nonce);
 
         if (_postDrawCheck(_coreDisputeID, drawnAddress)) {
             round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -558,7 +558,13 @@ contract DisputeKitClassic is BaseDisputeKit, IEvidence {
     // ************************************* //
 
     /// @inheritdoc BaseDisputeKit
-    function _postDrawCheck(uint256 /*_coreDisputeID*/, address /*_juror*/) internal pure override returns (bool) {
-        return true;
+    function _postDrawCheck(uint256 _coreDisputeID, address _juror) internal view override returns (bool) {
+        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
+        (, uint256 lockedAmountPerJuror, , , , , , , , ) = core.getRoundInfo(
+            _coreDisputeID,
+            core.getNumberOfRounds(_coreDisputeID) - 1
+        );
+        (uint256 totalStaked, uint256 totalLocked, , ) = core.getJurorBalance(_juror, courtID);
+        return totalStaked >= totalLocked + lockedAmountPerJuror;
     }
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -200,9 +200,11 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
     /// @dev Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
     /// Note: Access restricted to Kleros Core only.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _nonce Nonce of the drawing iteration.
     /// @return drawnAddress The drawn address.
     function draw(
-        uint256 _coreDisputeID
+        uint256 _coreDisputeID,
+        uint256 _nonce
     ) external override onlyByCore notJumped(_coreDisputeID) returns (address drawnAddress) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
@@ -212,7 +214,7 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
         bytes32 key = bytes32(uint256(courtID)); // Get the ID of the tree.
 
         // TODO: Handle the situation when no one has staked yet.
-        drawnAddress = sortitionModule.draw(key, _coreDisputeID, round.votes.length);
+        drawnAddress = sortitionModule.draw(key, _coreDisputeID, _nonce);
 
         if (_postDrawCheck(_coreDisputeID, drawnAddress) && !round.alreadyDrawn[drawnAddress]) {
             round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -587,9 +587,8 @@ contract DisputeKitSybilResistant is BaseDisputeKit, IEvidence {
             _coreDisputeID,
             core.getNumberOfRounds(_coreDisputeID) - 1
         );
-        (uint256 staked, uint256 locked, ) = core.getJurorBalance(_juror, courtID);
-        (, , uint256 minStake, , , , ) = core.courts(courtID);
-        if (staked < locked + lockedAmountPerJuror || staked < minStake) {
+        (uint256 totalStaked, uint256 totalLocked, , ) = core.getJurorBalance(_juror, courtID);
+        if (totalStaked < totalLocked + lockedAmountPerJuror) {
             return false;
         } else {
             return _proofOfHumanity(_juror);

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -51,8 +51,9 @@ interface IDisputeKit {
     /// @dev Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
     /// Note: Access restricted to Kleros Core only.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _nonce Nonce.
     /// @return drawnAddress The drawn address.
-    function draw(uint256 _coreDisputeID) external returns (address drawnAddress);
+    function draw(uint256 _coreDisputeID, uint256 _nonce) external returns (address drawnAddress);
 
     // ************************************* //
     // *           Public Views            * //

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -24,7 +24,7 @@ interface ISortitionModule {
 
     function notifyRandomNumber(uint256 _drawnNumber) external;
 
-    function draw(bytes32 _court, uint256 _coreDisputeID, uint256 _voteID) external view returns (address);
+    function draw(bytes32 _court, uint256 _coreDisputeID, uint256 _nonce) external view returns (address);
 
     function preStakeHook(address _account, uint96 _courtID, uint256 _stake) external returns (preStakeHookResult);
 

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -26,12 +26,7 @@ interface ISortitionModule {
 
     function draw(bytes32 _court, uint256 _coreDisputeID, uint256 _voteID) external view returns (address);
 
-    function preStakeHook(
-        address _account,
-        uint96 _courtID,
-        uint256 _stake,
-        uint256 _penalty
-    ) external returns (preStakeHookResult);
+    function preStakeHook(address _account, uint96 _courtID, uint256 _stake) external returns (preStakeHookResult);
 
     function createDisputeHook(uint256 _disputeID, uint256 _roundID) external;
 

--- a/contracts/test/integration/index.ts
+++ b/contracts/test/integration/index.ts
@@ -67,29 +67,29 @@ describe("Integration tests", async () => {
 
     await core.setStake(1, ONE_THOUSAND_PNK);
     await core.getJurorBalance(deployer, 1).then((result) => {
-      expect(result.staked).to.equal(ONE_THOUSAND_PNK);
-      expect(result.locked).to.equal(0);
+      expect(result.totalStaked).to.equal(ONE_THOUSAND_PNK);
+      expect(result.totalLocked).to.equal(0);
       logJurorBalance(result);
     });
 
     await core.setStake(1, ONE_HUNDRED_PNK.mul(5));
     await core.getJurorBalance(deployer, 1).then((result) => {
-      expect(result.staked).to.equal(ONE_HUNDRED_PNK.mul(5));
-      expect(result.locked).to.equal(0);
+      expect(result.totalStaked).to.equal(ONE_HUNDRED_PNK.mul(5));
+      expect(result.totalLocked).to.equal(0);
       logJurorBalance(result);
     });
 
     await core.setStake(1, 0);
     await core.getJurorBalance(deployer, 1).then((result) => {
-      expect(result.staked).to.equal(0);
-      expect(result.locked).to.equal(0);
+      expect(result.totalStaked).to.equal(0);
+      expect(result.totalLocked).to.equal(0);
       logJurorBalance(result);
     });
 
     await core.setStake(1, ONE_THOUSAND_PNK.mul(4));
     await core.getJurorBalance(deployer, 1).then((result) => {
-      expect(result.staked).to.equal(ONE_THOUSAND_PNK.mul(4));
-      expect(result.locked).to.equal(0);
+      expect(result.totalStaked).to.equal(ONE_THOUSAND_PNK.mul(4));
+      expect(result.totalLocked).to.equal(0);
       logJurorBalance(result);
     });
     const tx = await arbitrable.functions["createDispute(string)"]("future of france", {
@@ -183,5 +183,9 @@ describe("Integration tests", async () => {
 });
 
 const logJurorBalance = async (result) => {
-  console.log("staked=%s, locked=%s", ethers.utils.formatUnits(result.staked), ethers.utils.formatUnits(result.locked));
+  console.log(
+    "staked=%s, locked=%s",
+    ethers.utils.formatUnits(result.totalStaked),
+    ethers.utils.formatUnits(result.totalLocked)
+  );
 };

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -5,6 +5,7 @@
     "update:arbitrum-goerli": "./scripts/update.sh arbitrumGoerli arbitrum-goerli",
     "update:arbitrum-goerli-devnet": "./scripts/update.sh arbitrumGoerliDevnet arbitrum-goerli",
     "update:arbitrum": "./scripts/update.sh arbitrum arbitrum",
+    "update:local": "./scripts/update.sh localhost mainnet",
     "codegen": "graph codegen",
     "build": "graph build",
     "clean": "graph clean && rm subgraph.yaml.bak.*",
@@ -14,7 +15,7 @@
     "create-local": "graph create --node http://localhost:8020/ kleros/kleros-v2-core-local",
     "remove-local": "graph remove --node http://localhost:8020/ kleros/kleros-v2-core-local",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 kleros/kleros-v2-core-local --version-label v$(date +%s)",
-    "rebuild-deploy-local": "./scripts/update.sh localhost mainnet && yarn codegen && yarn create-local && yarn deploy-local",
+    "rebuild-deploy-local": "yarn update:local && yarn codegen && yarn create-local && yarn deploy-local",
     "start-local-indexer": "docker compose -f ../services/graph-node/docker-compose.yml up -d && docker compose -f ../services/graph-node/docker-compose.yml logs -f",
     "stop-local-indexer": "docker compose -f ../services/graph-node/docker-compose.yml down && rm -rf ../services/graph-node/data"
   },

--- a/subgraph/scripts/update.sh
+++ b/subgraph/scripts/update.sh
@@ -2,18 +2,33 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-function update() #file #dataSourceIndex #graphNetwork
+function update() #hardhatNetwork #graphNetwork #dataSourceIndex #contract
 {
-    local f="$1"
-    local dataSourceIndex="$2"
+    local hardhatNetwork="$1"
+    local graphNetwork="$2"
+    local dataSourceIndex="$3"
+    local contract="$4"
+    local artifact="$SCRIPT_DIR/../../contracts/deployments/$hardhatNetwork/$contract.json"
 
-    graphNetwork=$3 yq -i  ".dataSources[$dataSourceIndex].network=env(graphNetwork)" "$SCRIPT_DIR"/../subgraph.yaml
-
-    address=$(cat "$f" | jq '.address')
-    yq -i  ".dataSources[$dataSourceIndex].source.address=$address" "$SCRIPT_DIR"/../subgraph.yaml
+    # Set the address
+    address=$(cat "$artifact" | jq '.address')
+    yq -i ".dataSources[$dataSourceIndex].source.address=$address" "$SCRIPT_DIR"/../subgraph.yaml
     
-    blockNumber="$(cat "$f" | jq '.receipt.blockNumber')"
-    yq -i  ".dataSources[$dataSourceIndex].source.startBlock=$blockNumber" "$SCRIPT_DIR"/../subgraph.yaml
+    # Set the start block
+    blockNumber="$(cat "$artifact" | jq '.receipt.blockNumber')"
+    yq -i ".dataSources[$dataSourceIndex].source.startBlock=$blockNumber" "$SCRIPT_DIR"/../subgraph.yaml
+
+    # Set the Graph network
+    graphNetwork=$graphNetwork yq -i  ".dataSources[$dataSourceIndex].network=env(graphNetwork)" "$SCRIPT_DIR"/../subgraph.yaml
+    
+    # Set the ABIs path for this Hardhat network
+    abiIndex=0
+    for f in $(yq e .dataSources[$dataSourceIndex].mapping.abis[].file subgraph.yaml -o json -I 0 | jq -sr '.[]')
+    do
+        f2=$(echo $f | sed "s|\(.*\/deployments\/\).*\/|\1$hardhatNetwork\/|")
+        yq -i ".dataSources[$dataSourceIndex].mapping.abis[$abiIndex].file=\"$f2\"" "$SCRIPT_DIR"/../subgraph.yaml
+        (( ++abiIndex ))
+    done
 }
 
 # as per ../contracts/hardhat.config.js
@@ -28,6 +43,6 @@ cp "$SCRIPT_DIR"/../subgraph.yaml "$SCRIPT_DIR"/../subgraph.yaml.bak.$(date +%s)
 
 for contract in $(yq .dataSources[].name "$SCRIPT_DIR"/../subgraph.yaml)
 do
-    update "$SCRIPT_DIR/../../contracts/deployments/$hardhatNetwork/$contract.json" $i $graphNetwork
+    update $hardhatNetwork $graphNetwork $i $contract
     (( ++i ))
 done

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -48,7 +48,7 @@ dataSources:
           handler: handleDisputeKitEnabled
         - event: StakeSet(indexed address,uint256,uint256)
           handler: handleStakeSet
-        - event: StakeDelayed(indexed address,uint256,uint256,uint256)
+        - event: StakeDelayed(indexed address,uint256,uint256)
           handler: handleStakeDelayed
         - event: TokenAndETHShift(indexed address,indexed uint256,indexed uint256,uint256,int256,int256,address)
           handler: handleTokenAndETHShift


### PR DESCRIPTION
List of changes made in this PR:

- Previously drawing iterations were capped with required number of jurors and the argument `_iterations` didn't really do anything. It makes sense in the old version where we don't have post-draw check and each iteration will draw someone anyway. But in this version we skip jurors, so I decided to remove this cap and use an iteration number (which is ever-increasing) as a nonce for obtaining a drawing number, thus each time you call draw() function it'll draw different jurors in the process, unlike before, since each call will use different nonces.

- Staking logic now considers the implicit staking in parent courts, thus insolvency is now checked not by the stake in a particular court but by the total number of tokens deposited by the juror.  If this number is lower than the total number of locked tokens the juror won't pass the post-draw check. 
Also penalty now doesn't update the stake, instead it simply removes tokens from total juror's balance, which is actually closer to V1 logic-wise.
So in short, we now have 3 closely related, but different entities: 
       **1. totalStaked**, which reflects the number of tokens deposited by the juror. If the juror is fully unstaked, or for some reason has `totalLocked > totalStaked`, then locked tokens will reflect it instead 
       **2. stakedPnkByCourt** - number of tokens that were explicitely staked in a particular court. We need it as a duplication of sortition stakes, in case the sortition module is replaced 
       **3. Sortition Stakes** - includes all, explicit stakes and implicit stakes in parent courts.

- Locked tokens are now taken into account during staking. E.g. if a juror has 0 tokens staked and 150 locked then to stake 1000 he'll only need to transfer 850 tokens. It only applies when total locked amount is higher than total staked
- Staking 0 isn't allowed if `currentStake == 0` to avoid some unexpected behaviour