### PR TITLE
fix(web): crashing appeal tab

### DIFF
--- a/web/src/hooks/useClassicAppealContext.tsx
+++ b/web/src/hooks/useClassicAppealContext.tsx
@@ -99,11 +99,15 @@ export const useFundingContext = () => useContext(FundingContext);
 export const useOptionsContext = () => useContext(OptionsContext);
 
 const getCurrentLocalRound = (dispute?: ClassicAppealQuery["dispute"]) => {
-  const period = dispute?.period;
-  const currentLocalRoundIndex = dispute?.disputeKitDispute?.currentLocalRoundIndex;
-  return getLocalRounds(dispute?.disputeKitDispute)[
-    ["appeal", "execution"].includes(period ?? "") ? currentLocalRoundIndex : currentLocalRoundIndex - 1
-  ];
+  if (!dispute) return undefined;
+
+  const period = dispute.period;
+  const currentLocalRoundIndex = dispute.disputeKitDispute?.currentLocalRoundIndex;
+  const adjustedRoundIndex = ["appeal", "execution"].includes(period)
+    ? currentLocalRoundIndex
+    : currentLocalRoundIndex - 1;
+
+  return getLocalRounds(dispute.disputeKitDispute)[adjustedRoundIndex];
 };
 
 const getPaidFees = (dispute?: ClassicAppealQuery["dispute"]) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Refactored the `getCurrentLocalRound` function in `useClassicAppealContext.tsx` to handle cases where `dispute` is undefined.
- Added a check for `dispute` being undefined at the beginning of the function and returning `undefined` in that case.
- Adjusted the logic for calculating `adjustedRoundIndex` based on the value of `period`.
- Returned the result of `getLocalRounds` based on the adjusted `currentLocalRoundIndex`.

Note: There are no notable changes mentioned for `getPaidFees` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->