### PR TITLE
feat(web/dashboard/mycases): Add dynamic total pages calculation

### DIFF
--- a/web/src/pages/Dashboard/index.tsx
+++ b/web/src/pages/Dashboard/index.tsx
@@ -54,6 +54,7 @@ const Dashboard: React.FC = () => {
   );
   const { data: userData } = useUserQuery(address, decodedFilter);
   const totalCases = userData?.user?.disputes.length;
+  const totalPages = Math.ceil(totalCases / casesPerPage);
 
   return (
     <Container>
@@ -66,7 +67,7 @@ const Dashboard: React.FC = () => {
             disputes={disputesData?.user?.disputes as DisputeDetailsFragment[]}
             numberDisputes={totalCases}
             numberClosedDisputes={0}
-            totalPages={10}
+            totalPages={totalPages}
             currentPage={pageNumber}
             setCurrentPage={(newPage: number) => navigate(`${location}/${newPage}/${order}/${filter}`)}
             {...{ casesPerPage }}


### PR DESCRIPTION
In this commit, I've added the logic to calculate the total number of pages dynamically for the "My Cases" section on the dashboard. The total number of cases is now divided by the cases per page to determine the correct number of pages to display.

Fixes #1285

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added calculation for `totalPages` based on `totalCases` and `casesPerPage`.
- Updated the `totalPages` prop in the `Dashboard` component to use the calculated value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->