### PR TITLE
feat(web): share juror score on x

### DIFF
--- a/web/src/pages/Dashboard/JurorInfo/Header.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/Header.tsx
@@ -46,7 +46,7 @@ interface IHeader {
 const Header: React.FC<IHeader> = ({ levelTitle, levelNumber, totalCoherent, totalResolvedDisputes }) => {
   const coherencePercentage = parseFloat(((totalCoherent / Math.max(totalResolvedDisputes, 1)) * 100).toFixed(2));
   const courtUrl = window.location.origin;
-  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: \n\nLevel: ${levelNumber} (${levelTitle})\nCoherent Votes: ${totalCoherent}/${totalResolvedDisputes}\nCoherence Percentage: ${coherencePercentage}%\n\nBe a juror with me -> ${courtUrl}`;
+  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: \n\nLevel: ${levelNumber} (${levelTitle})\nCoherence Percentage: ${coherencePercentage}%\nCoherent Votes: ${totalCoherent}/${totalResolvedDisputes}\n\nBe a juror with me -> ${courtUrl}`;
   const xShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(xPostText)}`;
 
   return (

--- a/web/src/pages/Dashboard/JurorInfo/Header.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/Header.tsx
@@ -46,7 +46,7 @@ interface IHeader {
 const Header: React.FC<IHeader> = ({ levelTitle, levelNumber, totalCoherent, totalResolvedDisputes }) => {
   const coherencePercentage = parseFloat(((totalCoherent / Math.max(totalResolvedDisputes, 1)) * 100).toFixed(2));
   const courtUrl = window.location.origin;
-  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: \n\nLevel: ${levelNumber} (${levelTitle})\nCoherence Percentage: ${coherencePercentage}%\nCoherent Votes: ${totalCoherent}/${totalResolvedDisputes}\n\nBe a juror with me -> ${courtUrl}`;
+  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: \n\nLevel: ${levelNumber} (${levelTitle})\nCoherence Percentage: ${coherencePercentage}%\nCoherent Votes: ${totalCoherent}/${totalResolvedDisputes}\n\nBe a juror with me! ➡️ ${courtUrl}`;
   const xShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(xPostText)}`;
 
   return (

--- a/web/src/pages/Dashboard/JurorInfo/Header.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/Header.tsx
@@ -36,9 +36,17 @@ const StyledLink = styled.a`
   }
 `;
 
-const Header: React.FC = () => {
+interface IHeader {
+  levelTitle: string;
+  levelNumber: number;
+  totalCoherent: number;
+  totalResolvedDisputes: number;
+}
+
+const Header: React.FC<IHeader> = ({ levelTitle, levelNumber, totalCoherent, totalResolvedDisputes }) => {
+  const coherencePercentage = parseFloat(((totalCoherent / Math.max(totalResolvedDisputes, 1)) * 100).toFixed(2));
   const courtUrl = window.location.origin;
-  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: Level: 2 (Diogenes). Coherence score: 8. Be a juror with me -> ${courtUrl}`;
+  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: \n\nLevel: ${levelNumber} (${levelTitle})\nCoherent Votes: ${totalCoherent}/${totalResolvedDisputes}\nCoherence Percentage: ${coherencePercentage}%\n\nBe a juror with me -> ${courtUrl}`;
   const xShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(xPostText)}`;
 
   return (

--- a/web/src/pages/Dashboard/JurorInfo/Header.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/Header.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import XIcon from "svgs/socialmedia/x.svg";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledTitle = styled.h1`
+  margin-bottom: calc(16px + (48 - 16) * (min(max(100vw, 375px), 1250px) - 375px) / 875);
+`;
+
+const XLinkContainer = styled.div`
+  display: flex;
+  color: ${({ theme }) => theme.primaryBlue};
+  margin-bottom: calc(16px + (48 - 16) * (min(max(100vw, 375px), 1250px) - 375px) / 875);
+`;
+
+const StyledXIcon = styled(XIcon)`
+  fill: ${({ theme }) => theme.primaryBlue};
+  width: 16px;
+  height: 16px;
+`;
+
+const StyledLink = styled.a`
+  display: flex;
+  border: 0px;
+  align-items: center;
+  gap: 8px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const Header: React.FC = () => {
+  const courtUrl = window.location.origin;
+  const xPostText = `Hey I've been busy as a Juror on the Kleros court, check out my score: Level: 2 (Diogenes). Coherence score: 8. Be a juror with me -> ${courtUrl}`;
+  const xShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(xPostText)}`;
+
+  return (
+    <Container>
+      <StyledTitle>Juror Dashboard</StyledTitle>
+      <XLinkContainer>
+        <StyledLink href={xShareUrl} target="_blank" rel="noreferrer">
+          <StyledXIcon /> <span>Share your juror score</span>
+        </StyledLink>
+      </XLinkContainer>
+    </Container>
+  );
+};
+
+export default Header;

--- a/web/src/pages/Dashboard/JurorInfo/index.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 import { landscapeStyle } from "styles/landscapeStyle";
 import { Card as _Card } from "@kleros/ui-components-library";
+import Header from "./Header";
 import Coherency from "./Coherency";
 import JurorRewards from "./JurorRewards";
 import PixelArt from "./PixelArt";
@@ -10,10 +11,6 @@ import { useUserQuery } from "queries/useUser";
 // import StakingRewards from "./StakingRewards";
 
 const Container = styled.div``;
-
-const Header = styled.h1`
-  margin-bottom: calc(16px + (48 - 16) * (min(max(100vw, 375px), 1250px) - 375px) / 875);
-`;
 
 const Card = styled(_Card)`
   display: flex;
@@ -61,7 +58,7 @@ const JurorInfo: React.FC = () => {
 
   return (
     <Container>
-      <Header>Juror Dashboard</Header>
+      <Header />
       <Card>
         <PixelArt level={userLevelData.level} />
         <Coherency

--- a/web/src/pages/Dashboard/JurorInfo/index.tsx
+++ b/web/src/pages/Dashboard/JurorInfo/index.tsx
@@ -44,7 +44,12 @@ const JurorInfo: React.FC = () => {
 
   return (
     <Container>
-      <Header />
+      <Header
+        levelTitle={userLevelData.title}
+        levelNumber={userLevelData.level}
+        totalCoherent={totalCoherent}
+        totalResolvedDisputes={totalResolvedDisputes}
+      />
       <Card>
         <PixelArt level={userLevelData.level} width="189px" height="189px" />
         <Coherency


### PR DESCRIPTION
Special mention and thanks to @ptdatta for starting this effort

Can't continue until #1290 is merged

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new component called `Header` to the `JurorInfo` page in the Dashboard. The `Header` component displays the juror's level title, level number, total coherence, and total resolved disputes. It also includes a link to share the juror's score on Twitter.

### Detailed summary:
- Added a new component called `Header` to the `JurorInfo` page.
- Imported `Header` component in the `JurorInfo` page.
- Added styles and layout for the `Header` component.
- Passed necessary props to the `Header` component.
- Added a link to share the juror's score on Twitter in the `Header` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->