### PR TITLE
fix(web): appeal-tab-not-displaying-options

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -19,6 +19,7 @@ interface DisputeKitDispute {
   coreDispute: Dispute!
   localRounds: [DisputeKitRound!]! @derivedFrom(field: "localDispute")
   currentLocalRoundIndex: BigInt!
+  timestamp: BigInt!
 }
 
 interface DisputeKitRound {
@@ -236,6 +237,7 @@ type ClassicDispute implements DisputeKitDispute @entity {
   coreDispute: Dispute!
   localRounds: [DisputeKitRound!]! @derivedFrom(field: "localDispute")
   currentLocalRoundIndex: BigInt!
+  timestamp: BigInt!
 
   numberOfChoices: BigInt!
   extraData: Bytes!

--- a/subgraph/src/entities/ClassicDispute.ts
+++ b/subgraph/src/entities/ClassicDispute.ts
@@ -9,5 +9,6 @@ export function createClassicDisputeFromEvent(event: DisputeCreation): void {
   classicDispute.currentLocalRoundIndex = ZERO;
   classicDispute.numberOfChoices = event.params._numberOfChoices;
   classicDispute.extraData = event.params._extraData;
+  classicDispute.timestamp = event.block.timestamp;
   classicDispute.save();
 }

--- a/web/src/hooks/queries/useClassicAppealQuery.ts
+++ b/web/src/hooks/queries/useClassicAppealQuery.ts
@@ -5,7 +5,7 @@ import { graphqlQueryFnHelper } from "utils/graphqlQueryFnHelper";
 export type { ClassicAppealQuery };
 
 const classicAppealQuery = graphql(`
-  query ClassicAppeal($disputeID: ID!) {
+  query ClassicAppeal($disputeID: ID!, $orderBy: DisputeKitDispute_orderBy, $orderDirection: OrderDirection) {
     dispute(id: $disputeID) {
       period
       court {
@@ -16,7 +16,7 @@ const classicAppealQuery = graphql(`
         id
       }
       lastPeriodChange
-      disputeKitDispute {
+      disputeKitDispute(orderBy: $orderBy, orderDirection: $orderDirection) {
         id
         currentLocalRoundIndex
         localRounds {
@@ -37,6 +37,13 @@ export const useClassicAppealQuery = (id?: string | number) => {
   return useQuery<ClassicAppealQuery>({
     queryKey: ["refetchOnBlock", `classicAppealQuery${id}`],
     enabled: isEnabled,
-    queryFn: async () => await graphqlQueryFnHelper(classicAppealQuery, { disputeID: id?.toString() }),
+    queryFn: async () =>
+      isEnabled
+        ? await graphqlQueryFnHelper(classicAppealQuery, {
+            disputeID: id?.toString(),
+            orderBy: "timestamp",
+            orderDirection: "asc",
+          })
+        : undefined,
   });
 };

--- a/web/src/hooks/useClassicAppealContext.tsx
+++ b/web/src/hooks/useClassicAppealContext.tsx
@@ -102,7 +102,7 @@ const getCurrentLocalRound = (dispute?: ClassicAppealQuery["dispute"]) => {
   if (!dispute) return undefined;
 
   const period = dispute.period;
-  const currentLocalRoundIndex = dispute.disputeKitDispute?.currentLocalRoundIndex;
+  const currentLocalRoundIndex = dispute.disputeKitDispute[0]?.currentLocalRoundIndex;
   const adjustedRoundIndex = ["appeal", "execution"].includes(period)
     ? currentLocalRoundIndex
     : currentLocalRoundIndex - 1;

--- a/web/src/hooks/useClassicAppealContext.tsx
+++ b/web/src/hooks/useClassicAppealContext.tsx
@@ -102,7 +102,7 @@ const getCurrentLocalRound = (dispute?: ClassicAppealQuery["dispute"]) => {
   if (!dispute) return undefined;
 
   const period = dispute.period;
-  const currentLocalRoundIndex = dispute.disputeKitDispute[0]?.currentLocalRoundIndex;
+  const currentLocalRoundIndex = dispute.disputeKitDispute.at(-1)?.currentLocalRoundIndex;
   const adjustedRoundIndex = ["appeal", "execution"].includes(period)
     ? currentLocalRoundIndex
     : currentLocalRoundIndex - 1;

--- a/web/src/pages/Cases/CaseDetails/Appeal/Classic/Options/StageOne.tsx
+++ b/web/src/pages/Cases/CaseDetails/Appeal/Classic/Options/StageOne.tsx
@@ -8,6 +8,7 @@ import {
   useOptionsContext,
   useSelectedOptionContext,
 } from "hooks/useClassicAppealContext";
+import { isUndefined } from "utils/index";
 import { formatUnitsWei } from "utils/format";
 
 const Container = styled.div`
@@ -30,14 +31,15 @@ const StageOne: React.FC<IStageOne> = ({ setAmount }) => {
   const options = useOptionsContext();
   const loserSideCountdown = useLoserSideCountdownContext();
   const { selectedOption, setSelectedOption } = useSelectedOptionContext();
+
   return (
     <Container>
       <StageExplainer {...{ loserSideCountdown }} />
       <label> Which option do you want to fund? </label>
       <OptionsContainer>
-        {typeof paidFees !== "undefined" &&
-          typeof winnerRequiredFunding !== "undefined" &&
-          typeof loserRequiredFunding !== "undefined" &&
+        {!isUndefined(paidFees) &&
+          !isUndefined(winnerRequiredFunding) &&
+          !isUndefined(loserRequiredFunding) &&
           options?.map((answer: string, i: number) => {
             const requiredFunding = i.toString() === winningChoice ? winnerRequiredFunding : loserRequiredFunding;
             return (


### PR DESCRIPTION
**subgraph needs redeployment** 

<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new `timestamp` field to the `ClassicDispute` entity and making changes to the `useClassicAppealContext` hook, `useClassicAppealQuery` query, and `StageOne` component.

### Detailed summary:
- Added `timestamp` field to the `ClassicDispute` entity in `subgraph/src/entities/ClassicDispute.ts`
- Updated `currentLocalRoundIndex` assignment in `useClassicAppealContext.tsx`
- Added `timestamp` field to the `DisputeKitRound` interface in `subgraph/schema.graphql`
- Updated `useClassicAppealQuery` query in `web/src/hooks/queries/useClassicAppealQuery.ts`
- Imported `isUndefined` function in `web/src/pages/Cases/CaseDetails/Appeal/Classic/Options/StageOne.tsx`
- Made changes to the `StageOne` component in `web/src/pages/Cases/CaseDetails/Appeal/Classic/Options/StageOne.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->