### PR TITLE
Dispute kit structure simplification

### DIFF
--- a/contracts/test/arbitration/index.ts
+++ b/contracts/test/arbitration/index.ts
@@ -18,7 +18,6 @@ describe("DisputeKitClassic", async () => {
     expect(events.length).to.equal(1);
     expect(events[0].args._disputeKitID).to.equal(1);
     expect(events[0].args._disputeKitAddress).to.equal(disputeKit.address);
-    expect(events[0].args._parent).to.equal(0);
 
     // Reminder: the Forking court will be added which will break these expectations.
     events = await core.queryFilter(core.filters.CourtCreated());

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -198,10 +198,7 @@ type Draw @entity(immutable: true) {
 type DisputeKit @entity {
   id: ID!
   address: Bytes
-  parent: DisputeKit
-  children: [DisputeKit!]! @derivedFrom(field: "parent")
   needsFreezing: Boolean!
-  depthLevel: BigInt!
   rounds: [Round!]! @derivedFrom(field: "disputeKit")
   courts: [Court!]! @derivedFrom(field: "supportedDisputeKits")
 }

--- a/subgraph/src/entities/DisputeKit.ts
+++ b/subgraph/src/entities/DisputeKit.ts
@@ -4,21 +4,14 @@ import { ZERO, ONE } from "../utils";
 
 export function createDisputeKitFromEvent(event: DisputeKitCreated): void {
   const disputeKit = new DisputeKit(event.params._disputeKitID.toString());
-  disputeKit.parent = event.params._parent.toString();
   disputeKit.address = event.params._disputeKitAddress;
   disputeKit.needsFreezing = false;
-  const parent = DisputeKit.load(event.params._parent.toString());
-  disputeKit.depthLevel = parent ? parent.depthLevel.plus(ONE) : ZERO;
   disputeKit.save();
 }
 
-export function filterSupportedDisputeKits(
-  supportedDisputeKits: string[],
-  disputeKitID: string
-): string[] {
+export function filterSupportedDisputeKits(supportedDisputeKits: string[], disputeKitID: string): string[] {
   let result: string[] = [];
   for (let i = 0; i < supportedDisputeKits.length; i++)
-    if (supportedDisputeKits[i] !== disputeKitID)
-      result = result.concat([supportedDisputeKits[i]]);
+    if (supportedDisputeKits[i] !== disputeKitID) result = result.concat([supportedDisputeKits[i]]);
   return result;
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -42,7 +42,7 @@ dataSources:
           handler: handleCourtCreated
         - event: CourtModified(indexed uint96,bool,uint256,uint256,uint256,uint256,uint256[4])
           handler: handleCourtModified
-        - event: DisputeKitCreated(indexed uint256,indexed address,indexed uint256)
+        - event: DisputeKitCreated(indexed uint256,indexed address)
           handler: handleDisputeKitCreated
         - event: DisputeKitEnabled(indexed uint96,indexed uint256,indexed bool)
           handler: handleDisputeKitEnabled


### PR DESCRIPTION
1. `disputeKitNodes[]` and `DisputeKitNode` structure replaced with simple `disputeKits[]` array that stores the addresses of all added dispute kits.
2. Preemptively added `disabled` boolean was also removed. It was added earlier in case of future upgrades but since the struct doesn't exist anymore it can be added with a simple mapping, if needed.
3. Previously the main requirement for new dispute kits was that the root dispute kit must always be supported by General court, but that actually was a mistake since even Sybil resistant dispute kit can't possibly be supported by General court simply because its disputes can go up to 511 jurors. On the other hand we could make Sybil resistant DK the child of Classic DK but in any case this type of structure adds complexity and can lead to human errors, esp for more nuanced cases. So right now the main requirement for all dispute kits is the support of Classic dispute kit which actually makes it feature parity with V1. So if in case of a court jump during appeal the parent court doesn't support the current DK it will simply switch to Classic and continue from there.
4. Following the previous point, `SEARCH_ITERATIONS ` is removed as not needed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the DisputeKit functionality and adding support for new dispute kits. 

### Detailed summary
- Refactored the DisputeKit functionality by removing the DisputeKitNode struct and replacing it with an array of IDisputeKit.
- Added support for new dispute kits by adding a new function `addNewDisputeKit` and modifying the `enableDisputeKits` function.
- Updated the event `DisputeKitCreated` to remove the `_parent` parameter.
- Added checks to ensure that the Classic dispute kit is always supported by all courts.

> The following files were skipped due to too many changes: `contracts/src/arbitration/KlerosCore.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->