### PR TITLE
fix(web)/cases-in-progress-and-pagination-overflow

### DIFF
--- a/web/src/pages/Cases/CasesFetcher.tsx
+++ b/web/src/pages/Cases/CasesFetcher.tsx
@@ -61,6 +61,7 @@ const CasesFetcher: React.FC = () => {
     () => calculateStats(isCourtFilter, courtData?.court, counterData?.counter, decodedFilter),
     [isCourtFilter, courtData?.court, counterData?.counter, decodedFilter]
   );
+  const totalPages = !isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1;
 
   return (
     <CasesDisplay
@@ -69,7 +70,7 @@ const CasesFetcher: React.FC = () => {
       numberClosedDisputes={ruledCases}
       currentPage={pageNumber}
       setCurrentPage={(newPage: number) => navigate(`${location}/${newPage}/${order}/${filter}`)}
-      totalPages={!isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1}
+      totalPages={totalPages}
       {...{ casesPerPage }}
     />
   );

--- a/web/src/pages/Cases/CasesFetcher.tsx
+++ b/web/src/pages/Cases/CasesFetcher.tsx
@@ -61,7 +61,10 @@ const CasesFetcher: React.FC = () => {
     () => calculateStats(isCourtFilter, courtData?.court, counterData?.counter, decodedFilter),
     [isCourtFilter, courtData?.court, counterData?.counter, decodedFilter]
   );
-  const totalPages = !isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1;
+  const totalPages = useMemo(
+    () => (!isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1),
+    [totalCases, casesPerPage]
+  );
 
   return (
     <CasesDisplay

--- a/web/src/pages/Courts/CourtDetails/Stats.tsx
+++ b/web/src/pages/Courts/CourtDetails/Stats.tsx
@@ -87,7 +87,7 @@ const stats: IStat[] = [
   },
   {
     title: "In Progress",
-    getText: (data) => data?.numberDisputes,
+    getText: (data) => data?.numberDisputes - data?.numberClosedDisputes,
     color: "orange",
     icon: BalanceIcon,
   },

--- a/web/src/pages/Dashboard/index.tsx
+++ b/web/src/pages/Dashboard/index.tsx
@@ -65,7 +65,7 @@ const Dashboard: React.FC = () => {
           <Courts />
           <StyledCasesDisplay
             title="My Cases"
-            disputes={disputesData?.user?.disputes as DisputeDetailsFragment[]}
+            disputes={userData?.user !== null ? (disputesData?.user?.disputes as DisputeDetailsFragment[]) : []}
             numberDisputes={totalCases}
             numberClosedDisputes={0}
             totalPages={totalPages}

--- a/web/src/pages/Dashboard/index.tsx
+++ b/web/src/pages/Dashboard/index.tsx
@@ -6,6 +6,7 @@ import { OrderDirection } from "src/graphql/graphql";
 import { DisputeDetailsFragment, useMyCasesQuery } from "queries/useCasesQuery";
 import { useUserQuery } from "queries/useUser";
 import { decodeURIFilter, useRootPath } from "utils/uri";
+import { isUndefined } from "utils/index";
 import CasesDisplay from "components/CasesDisplay";
 import ConnectWallet from "components/ConnectWallet";
 import JurorInfo from "./JurorInfo";
@@ -54,6 +55,7 @@ const Dashboard: React.FC = () => {
   );
   const { data: userData } = useUserQuery(address, decodedFilter);
   const totalCases = userData?.user?.disputes.length;
+  const totalPages = !isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1;
 
   return (
     <Container>
@@ -66,7 +68,7 @@ const Dashboard: React.FC = () => {
             disputes={disputesData?.user?.disputes as DisputeDetailsFragment[]}
             numberDisputes={totalCases}
             numberClosedDisputes={0}
-            totalPages={10}
+            totalPages={totalPages}
             currentPage={pageNumber}
             setCurrentPage={(newPage: number) => navigate(`${location}/${newPage}/${order}/${filter}`)}
             {...{ casesPerPage }}

--- a/web/src/pages/Dashboard/index.tsx
+++ b/web/src/pages/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAccount } from "wagmi";
@@ -55,7 +55,10 @@ const Dashboard: React.FC = () => {
   );
   const { data: userData } = useUserQuery(address, decodedFilter);
   const totalCases = userData?.user?.disputes.length;
-  const totalPages = !isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1;
+  const totalPages = useMemo(
+    () => (!isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1),
+    [totalCases, casesPerPage]
+  );
 
   return (
     <Container>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The `getText` function in the `Stats.tsx` file has been modified to subtract the number of closed disputes from the total number of disputes.
- A new constant `totalPages` has been added in the `CasesFetcher.tsx` and `Dashboard/index.tsx` files to calculate the total number of pages based on the total number of cases and cases per page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->