### PR TITLE
fix(web): increased draw query results up to 1000

### DIFF
--- a/web/src/hooks/queries/useDrawQuery.ts
+++ b/web/src/hooks/queries/useDrawQuery.ts
@@ -6,7 +6,7 @@ export type { DrawQuery };
 
 const drawQuery = graphql(`
   query Draw($address: String, $disputeID: String, $roundID: String) {
-    draws(where: { dispute: $disputeID, juror: $address, round: $roundID }) {
+    draws(first: 1000, where: { dispute: $disputeID, juror: $address, round: $roundID }) {
       voteIDNum
     }
   }


### PR DESCRIPTION
closes #1208

after investigating, we were actually only voting up to 100 voteIDs. so the frontend value was displaying it correctly.
I could've put `first: 512` instead but It doesn't hurt to put the maximum and forget about it

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on modifying the `useDrawQuery` hook in the `web/src/hooks/queries` directory to fetch the first 1000 draws instead of all draws.

### Detailed summary:
- Modified the `draws` query in the `useDrawQuery` hook to fetch the first 1000 draws instead of all draws.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->