### PR TITLE
fix(subgraph): casting-fixes

### DIFF
--- a/subgraph/DisputeTemplateRegistry/src/DisputeTemplateRegistry.ts
+++ b/subgraph/DisputeTemplateRegistry/src/DisputeTemplateRegistry.ts
@@ -4,7 +4,7 @@ import { DisputeTemplate } from "../generated/schema";
 export function handleDisputeTemplate(event: DisputeTemplateEvent): void {
   const disputeTemplateId = event.params._templateId.toString();
   const disputeTemplate = new DisputeTemplate(disputeTemplateId);
-  disputeTemplate.templateTag = event.params._templateTag.toString();
+  disputeTemplate.templateTag = event.params._templateTag.toHexString();
   disputeTemplate.templateData = event.params._templateData.toString();
   disputeTemplate.templateDataMappings = event.params._templateDataMappings.toString();
   disputeTemplate.save();

--- a/subgraph/src/entities/Penalty.ts
+++ b/subgraph/src/entities/Penalty.ts
@@ -6,7 +6,7 @@ export function updatePenalty(event: TokenAndETHShift): void {
   const disputeID = event.params._disputeID.toString();
   const roundIndex = event.params._roundID.toString();
   const roundID = `${disputeID}-${roundIndex}`;
-  const jurorAddress = event.params._account;
+  const jurorAddress = event.params._account.toHexString();
   const penaltyID = `${roundID}-${jurorAddress}`;
   const penalty = Penalty.load(penaltyID);
   if (penalty) {


### PR DESCRIPTION
1. Kleros core
    - appears when` Execute` function is called and `TokenAndEthShift` event is fired.
    - stack :-` handleTokenAndETHShift -> updatePenalty -> entities/Penalty.ts/line-9 `, jurorAddress not being casted to 
    HexString, fixed that

2. Dispute Template
    - _templateTag is a indexed string , so it is being hashed(keccak256)
    - when handling in handleDisputeTemplate , toString is being used instead of toHexString(since it's a hash) to convert 
    _templateTag


Cross checked the weird characters for both the subgraphs and confirmed the above.

For cross checking, these are the event logs https://goerli.arbiscan.io/tx/0x0f2b2c6a2b145f5e8889a262db0a3fb2ebb72566f924746d6a3819ff6e2380ac#eventlog
that were triggering the code and resulting in warnings

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the code to use the `toHexString()` method when assigning values to `jurorAddress` and `disputeTemplate.templateTag` variables.
- This PR also updates the `disputeTemplate.templateDataMappings` variable to be assigned as a string value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->