### PR TITLE
Subgraph: added SortitionModule to data sources

### DIFF
--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -1,0 +1,48 @@
+import {
+  SortitionModule,
+  StakeDelayedAlreadyTransferred,
+  StakeDelayedAlreadyTransferredWithdrawn,
+  StakeDelayedNotTransferred,
+  StakeLocked,
+  StakeSet,
+} from "../generated/SortitionModule/SortitionModule";
+
+import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
+import { ensureUser } from "./entities/User";
+import { ZERO } from "./utils";
+
+export function handleStakeDelayedAlreadyTransferred(event: StakeDelayedAlreadyTransferred): void {
+  const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
+  const courtID = event.params._courtID.toString();
+
+  updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
+
+  //stake is updated instantly so no delayed amount, set delay amount to zero
+  updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+}
+
+export function handleStakeDelayedAlreadyTransferredWithdrawn(event: StakeDelayedAlreadyTransferredWithdrawn): void {
+  const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
+  const courtID = event.params._courtID.toString();
+
+  updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
+
+  updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+}
+
+export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferred): void {
+  updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
+}
+
+export function handleStakeSet(event: StakeSet): void {
+  const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
+  const courtID = event.params._courtID.toString();
+
+  updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
+  //stake is updated instantly so no delayed amount, set delay amount to zero
+  updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+}
+export function handleStakeLocked(event: StakeLocked): void {}

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -133,11 +133,11 @@ dataSources:
       file: ./src/EvidenceModule.ts
   - kind: ethereum
     name: SortitionModule
-    network: mainnet
+    network: arbitrum-sepolia
     source:
-      address: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c"
+      address: "0xf327200420F21BAafce8F1C03B1EEdF926074B95"
       abi: SortitionModule
-      startBlock: 20
+      startBlock: 3084593
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -146,7 +146,7 @@ dataSources:
         - JurorTokensPerCourt
       abis:
         - name: SortitionModule
-          file: ../contracts/deployments/localhost/SortitionModule.json
+          file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json
       eventHandlers:
         - event: StakeDelayedAlreadyTransferred(indexed address,uint256,uint256)
           handler: handleStakeDelayedAlreadyTransferred

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -46,11 +46,6 @@ dataSources:
           handler: handleDisputeKitCreated
         - event: DisputeKitEnabled(indexed uint96,indexed uint256,indexed bool)
           handler: handleDisputeKitEnabled
-        # TODO: index the sortition module and handle these events there
-        # - event: StakeSet(indexed address,uint256,uint256)
-        #   handler: handleStakeSet
-        # - event: StakeDelayedNotTransferred(indexed address,uint256,uint256)
-        #   handler: handleStakeDelayedNotTransferred
         - event: TokenAndETHShift(indexed address,indexed uint256,indexed uint256,uint256,int256,int256,address)
           handler: handleTokenAndETHShift
         - event: Ruling(indexed address,indexed uint256,uint256)
@@ -136,3 +131,31 @@ dataSources:
         - event: Evidence(indexed uint256,indexed address,string)
           handler: handleEvidenceEvent
       file: ./src/EvidenceModule.ts
+  - kind: ethereum
+    name: SortitionModule
+    network: mainnet
+    source:
+      address: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c"
+      abi: SortitionModule
+      startBlock: 20
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - JurorTokensPerCourt
+      abis:
+        - name: SortitionModule
+          file: ../contracts/deployments/localhost/SortitionModule.json
+      eventHandlers:
+        - event: StakeDelayedAlreadyTransferred(indexed address,uint256,uint256)
+          handler: handleStakeDelayedAlreadyTransferred
+        - event: StakeDelayedAlreadyTransferredWithdrawn(indexed address,indexed uint96,uint256)
+          handler: handleStakeDelayedAlreadyTransferredWithdrawn
+        - event: StakeDelayedNotTransferred(indexed address,uint256,uint256)
+          handler: handleStakeDelayedNotTransferred
+        - event: StakeLocked(indexed address,uint256,bool)
+          handler: handleStakeLocked
+        - event: StakeSet(indexed address,uint256,uint256)
+          handler: handleStakeSet
+      file: ./src/SortitionModule.ts

--- a/subgraph/core/tests/sortition-module-utils.ts
+++ b/subgraph/core/tests/sortition-module-utils.ts
@@ -1,0 +1,101 @@
+import { newMockEvent } from "matchstick-as";
+import { ethereum, BigInt, Address } from "@graphprotocol/graph-ts";
+import {
+  StakeDelayedAlreadyTransferred,
+  StakeDelayedAlreadyTransferredWithdrawn,
+  StakeDelayedNotTransferred,
+  StakeLocked,
+  StakeSet,
+} from "../generated/SortitionModule/SortitionModule";
+
+export function createStakeDelayedAlreadyTransferredEvent(
+  _address: Address,
+  _courtID: BigInt,
+  _amount: BigInt
+): StakeDelayedAlreadyTransferred {
+  let stakeDelayedAlreadyTransferredEvent: StakeDelayedAlreadyTransferred = newMockEvent();
+
+  stakeDelayedAlreadyTransferredEvent.parameters = new Array();
+
+  stakeDelayedAlreadyTransferredEvent.parameters.push(
+    new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address))
+  );
+  stakeDelayedAlreadyTransferredEvent.parameters.push(
+    new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID))
+  );
+  stakeDelayedAlreadyTransferredEvent.parameters.push(
+    new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount))
+  );
+
+  return stakeDelayedAlreadyTransferredEvent;
+}
+
+export function createStakeDelayedAlreadyTransferredWithdrawnEvent(
+  _address: Address,
+  _courtID: BigInt,
+  _amount: BigInt
+): StakeDelayedAlreadyTransferredWithdrawn {
+  let stakeDelayedAlreadyTransferredWithdrawnEvent = newMockEvent();
+
+  stakeDelayedAlreadyTransferredWithdrawnEvent.parameters = new Array();
+
+  stakeDelayedAlreadyTransferredWithdrawnEvent.parameters.push(
+    new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address))
+  );
+  stakeDelayedAlreadyTransferredWithdrawnEvent.parameters.push(
+    new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID))
+  );
+  stakeDelayedAlreadyTransferredWithdrawnEvent.parameters.push(
+    new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount))
+  );
+
+  return stakeDelayedAlreadyTransferredWithdrawnEvent;
+}
+
+export function createStakeDelayedNotTransferredEvent(
+  _address: Address,
+  _courtID: BigInt,
+  _amount: BigInt
+): StakeDelayedNotTransferred {
+  let stakeDelayedNotTransferredEvent = newMockEvent();
+
+  stakeDelayedNotTransferredEvent.parameters = new Array();
+
+  stakeDelayedNotTransferredEvent.parameters.push(
+    new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address))
+  );
+  stakeDelayedNotTransferredEvent.parameters.push(
+    new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID))
+  );
+  stakeDelayedNotTransferredEvent.parameters.push(
+    new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount))
+  );
+
+  return stakeDelayedNotTransferredEvent;
+}
+
+export function createStakeLockedEvent(_address: Address, _relativeAmount: BigInt, _unlock: boolean): StakeLocked {
+  let stakeLockedEvent = newMockEvent();
+
+  stakeLockedEvent.parameters = new Array();
+
+  stakeLockedEvent.parameters.push(new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address)));
+  stakeLockedEvent.parameters.push(
+    new ethereum.EventParam("_relativeAmount", ethereum.Value.fromUnsignedBigInt(_relativeAmount))
+  );
+  stakeLockedEvent.parameters.push(new ethereum.EventParam("_unlock", ethereum.Value.fromBoolean(_unlock)));
+
+  return stakeLockedEvent;
+}
+
+export function createStakeSetEvent(_address: Address, _courtID: BigInt, _amount: BigInt): StakeSet {
+  let stakeSetEvent = newMockEvent();
+
+  stakeSetEvent.parameters = new Array();
+
+  stakeSetEvent.parameters.push(new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address)));
+  stakeSetEvent.parameters.push(new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID)));
+  stakeSetEvent.parameters.push(new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount)));
+
+  return stakeSetEvent;
+}

--- a/subgraph/core/tests/sortition-module.test.ts
+++ b/subgraph/core/tests/sortition-module.test.ts
@@ -1,0 +1,39 @@
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+import { BigInt, Address } from "@graphprotocol/graph-ts";
+import { handleStakeSet } from "../src/SortitionModule";
+import { createStakeSetEvent } from "./sortition-module-utils";
+
+// Tests structure (matchstick-as >=0.5.0)
+// https://thegraph.com/docs/en/developer/matchstick/#tests-structure-0-5-0
+
+describe("Describe event", () => {
+  beforeAll(() => {
+    let courtId = BigInt.fromI32(1);
+    let amount = BigInt.fromI32(1000);
+    let jurorAddress = Address.fromString("0x922911F4f80a569a4425fa083456239838F7F003");
+    let newStakeSetEvent = createStakeSetEvent(jurorAddress, courtId, amount);
+    handleStakeSet(newStakeSetEvent);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  // For more test scenarios, see:
+  // https://thegraph.com/docs/en/developer/matchstick/#write-a-unit-test
+
+  test("Initialized created and stored", () => {
+    assert.entityCount("Initialized", 1);
+
+    // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
+    // assert.fieldEquals(
+    //   "Initialized",
+    //   "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
+    //   "version",
+    //   "234"
+    // )
+
+    // More assert options:
+    // https://thegraph.com/docs/en/developer/matchstick/#asserts
+  });
+});


### PR DESCRIPTION
1. Added `sortitionModule` as dataSource to subgraph
2. updated the `UpdateJurorStake` function to use `SortitionModule` as contract , since `getJurorBalance` is now a function in SortitionModule.
3. Updated the events and handlers, StakeSet. ,etc now handled in `./src/SortitionModule.ts`
4. Tried to test locally , but local stack fails, upon calling "`yarn simulate:local`" in contracts directory the command fails due to "ArbitrationExampleEthFee" not existing as the contract is not in the arbitration/examples.
5. Trying to test the subgraph with "yarn test" but thats running into errors too.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding test cases for the SortitionModule and making updates to the JurorTokensPerCourt and SortitionModule files. 

### Detailed summary
- Added test cases for the SortitionModule in the `sortition-module.test.ts` file.
- Imported necessary dependencies in the test file.
- Created a new function `createStakeSetEvent` in the `sortition-module-utils.ts` file.
- Updated the `JurorTokensPerCourt` file to import the `SortitionModule` contract.
- Updated the `updateJurorStake` function in the `JurorTokensPerCourt` file to use the `SortitionModule` contract.
- Updated the `handleStakeSet` function in the `SortitionModule` file to use the `SortitionModule` contract.

> The following files were skipped due to too many changes: `subgraph/tests/sortition-module-utils.ts`, `subgraph/subgraph.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->