### PR TITLE
fix(subgraph): fix-stake-handlers

### DIFF
--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -12,24 +12,11 @@ import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
 export function handleStakeDelayedAlreadyTransferred(event: StakeDelayedAlreadyTransferred): void {
-  const jurorAddress = event.params._address.toHexString();
-  ensureUser(jurorAddress);
-  const courtID = event.params._courtID.toString();
-
-  updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
-
-  //stake is updated instantly so no delayed amount, set delay amount to zero
-  updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+  updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 
 export function handleStakeDelayedAlreadyTransferredWithdrawn(event: StakeDelayedAlreadyTransferredWithdrawn): void {
-  const jurorAddress = event.params._address.toHexString();
-  ensureUser(jurorAddress);
-  const courtID = event.params._courtID.toString();
-
-  updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
-
-  updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+  updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 
 export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferred): void {

--- a/subgraph/core/src/entities/JurorTokensPerCourt.ts
+++ b/subgraph/core/src/entities/JurorTokensPerCourt.ts
@@ -42,21 +42,21 @@ export function updateJurorStake(
   const jurorTokens = ensureJurorTokensPerCourt(jurorAddress, courtID);
 
   // TODO: index the sortition module and handle these events there
-  // const jurorBalance = contract.getJurorBalance(Address.fromString(jurorAddress), BigInt.fromString(courtID));
-  // const previousStake = jurorTokens.staked;
-  // const previousTotalStake = juror.totalStake;
-  // jurorTokens.staked = jurorBalance.value2;
-  // jurorTokens.locked = jurorBalance.value1;
-  // jurorTokens.save();
-  // const stakeDelta = getDelta(previousStake, jurorTokens.staked);
-  // const newTotalStake = juror.totalStake.plus(stakeDelta);
-  // juror.totalStake = newTotalStake;
-  // court.stake = court.stake.plus(stakeDelta);
-  // updateStakedPNK(stakeDelta, timestamp);
-  // const activeJurorsDelta = getActivityDelta(previousTotalStake, newTotalStake);
-  // const stakedJurorsDelta = getActivityDelta(previousStake, jurorBalance.value2);
-  // court.numberStakedJurors = court.numberStakedJurors.plus(stakedJurorsDelta);
-  // updateActiveJurors(activeJurorsDelta, timestamp);
+  const jurorBalance = contract.getJurorBalance(Address.fromString(jurorAddress), BigInt.fromString(courtID));
+  const previousStake = jurorTokens.staked;
+  const previousTotalStake = juror.totalStake;
+  jurorTokens.staked = jurorBalance.value2;
+  jurorTokens.locked = jurorBalance.value1;
+  jurorTokens.save();
+  const stakeDelta = getDelta(previousStake, jurorTokens.staked);
+  const newTotalStake = juror.totalStake.plus(stakeDelta);
+  juror.totalStake = newTotalStake;
+  court.stake = court.stake.plus(stakeDelta);
+  updateStakedPNK(stakeDelta, timestamp);
+  const activeJurorsDelta = getActivityDelta(previousTotalStake, newTotalStake);
+  const stakedJurorsDelta = getActivityDelta(previousStake, jurorBalance.value2);
+  court.numberStakedJurors = court.numberStakedJurors.plus(stakedJurorsDelta);
+  updateActiveJurors(activeJurorsDelta, timestamp);
   juror.save();
   court.save();
 }

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -25,6 +25,8 @@ dataSources:
         - DisputeKit
         - Counter
       abis:
+        - name: SortitionModule
+          file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json
         - name: DisputeKitClassic
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/DisputeKitClassic.json
         - name: KlerosCore


### PR DESCRIPTION
1. This fixes the stake info not showing in the courts UI.
    The stake updating logic was commented 
2. Also fixes subgraph breaking due to  sortitionModule ABI not present in KlerosCore datasource.
3. Updated the handlers, we can index the sortitionModule separately ,but it makes more sense as a dataSource in core and intertvines with other functions too (Both `KlerosCore` and `SortitionModule` trigger `JurorTokensPerCourt` entitity update)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the `handleStakeDelayedAlreadyTransferred` and `handleStakeDelayedAlreadyTransferredWithdrawn` functions in `SortitionModule.ts` to use the `event.params._amount` instead of zero for updating the delayed stake.
- Removed commented out code in `JurorTokensPerCourt.ts` related to updating juror stakes and court information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->