### PR TITLE
fix(web): fix-filter-stats-not-showing-correct-in-progress-cases

### DIFF
--- a/web/src/pages/Dashboard/index.tsx
+++ b/web/src/pages/Dashboard/index.tsx
@@ -54,6 +54,8 @@ const Dashboard: React.FC = () => {
   );
   const { data: userData } = useUserQuery(address, decodedFilter);
   const totalCases = userData?.user?.disputes.length;
+  const totalResolvedCases = parseInt(userData?.user?.totalResolvedDisputes);
+
   const totalPages = useMemo(
     () => (!isUndefined(totalCases) ? Math.ceil(totalCases / casesPerPage) : 1),
     [totalCases, casesPerPage]
@@ -69,7 +71,7 @@ const Dashboard: React.FC = () => {
             title="My Cases"
             disputes={userData?.user !== null ? (disputesData?.user?.disputes as DisputeDetailsFragment[]) : []}
             numberDisputes={totalCases}
-            numberClosedDisputes={0}
+            numberClosedDisputes={totalResolvedCases}
             totalPages={totalPages}
             currentPage={pageNumber}
             setCurrentPage={(newPage: number) => navigate(`${location}/${newPage}/${order}/${filter}`)}


### PR DESCRIPTION
closes #1405 

- Fixes "In Progress" and "Closed" stats in Filter stats not showing correctly

`numberClosedDisputes` props in `CaseDisplay` , used in` Dashboard/index.tsx` was hardcoded to 0.
Updated that to use, `totalResolvedDisputes` from `userQuery` data

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new variable `totalResolvedCases` to store the total number of resolved disputes.
- Updated the `numberClosedDisputes` prop in the `Dashboard` component to use the `totalResolvedCases` variable instead of a hardcoded value of 0.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->