### PR TITLE
Fix(web)/evidence skeleton overflowing and info card loading UI

### DIFF
--- a/web/src/components/StyledSkeleton.tsx
+++ b/web/src/components/StyledSkeleton.tsx
@@ -32,9 +32,13 @@ const StyledSkeletonDisputeListItem = styled(Skeleton)`
   height: 62px;
 `;
 
-const StyledSkeletonEvidenceCard = styled(Skeleton)`
-  height: 146px;
-  width: 76vw;
+const StyledSkeletonEvidenceContainer = styled.div`
+  width: 100%;
+  span {
+    width: 100%;
+    height: 146px;
+    display: flex;
+  }
 `;
 
 export const SkeletonDisputeCard = () => (
@@ -45,4 +49,8 @@ export const SkeletonDisputeCard = () => (
 
 export const SkeletonDisputeListItem = () => <StyledSkeletonDisputeListItem />;
 
-export const SkeletonEvidenceCard = () => <StyledSkeletonEvidenceCard />;
+export const SkeletonEvidenceCard = () => (
+  <StyledSkeletonEvidenceContainer>
+    <Skeleton />
+  </StyledSkeletonEvidenceContainer>
+);

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -18,6 +18,7 @@ import { getPeriodEndTimestamp } from "components/DisputeCard";
 import InfoCard from "components/InfoCard";
 import Classic from "./Classic";
 import VotingHistory from "./VotingHistory";
+import Skeleton from "react-loading-skeleton";
 
 const Container = styled.div`
   padding: ${responsiveSize(16, 32)};
@@ -40,7 +41,11 @@ const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
   const { id } = useParams();
   const { data: disputeData } = useDisputeDetailsQuery(id);
   const { data: appealCost } = useAppealCost(id);
-  const { data: drawData } = useDrawQuery(address?.toLowerCase(), id, disputeData?.dispute?.currentRound.id);
+  const { data: drawData, isLoading: isDrawDataLoading } = useDrawQuery(
+    address?.toLowerCase(),
+    id,
+    disputeData?.dispute?.currentRound.id
+  );
   const roundId = disputeData?.dispute?.currentRoundIndex;
   const voteId = drawData?.draws?.[0]?.voteIDNum;
   const { data: voted } = useDisputeKitClassicIsVoteActive({
@@ -68,7 +73,12 @@ const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
           <br />
         </>
       )}
-      {!userWasDrawn ? (
+      {isDrawDataLoading ? (
+        <>
+          <Skeleton width={300} height={20} />
+          <br />
+        </>
+      ) : !userWasDrawn ? (
         <>
           <InfoCard msg="You were not drawn in current round." />
           <br />

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -73,17 +73,17 @@ const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
           <br />
         </>
       )}
-      {isDrawDataLoading ? (
+
+      {userWasDrawn ? null : (
         <>
-          <Skeleton width={300} height={20} />
+          {isDrawDataLoading ? (
+            <Skeleton width={300} height={20} />
+          ) : (
+            <InfoCard msg="You were not drawn in current round." />
+          )}
           <br />
         </>
-      ) : !userWasDrawn ? (
-        <>
-          <InfoCard msg="You were not drawn in current round." />
-          <br />
-        </>
-      ) : null}
+      )}
 
       {isPopupOpen && (
         <Popup


### PR DESCRIPTION
closes #1397  #1398 

1. Added loading ui to "You were not drawn" Info Card

2. Fixed evidence skleton loader overflowing

-  To reproduce 2. : open devtools in browser and set viewport width to a high value (> 2000px)
-  Reason: width of loader was set to 76vw, breaking the width
-  Fix: Added a wrapper around loader, since percentages dont work with Skeleton Loader

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed the styling of `StyledSkeletonEvidenceCard` to `StyledSkeletonEvidenceContainer` in `StyledSkeleton.tsx`.
- Added a `Skeleton` component to the `SkeletonEvidenceCard` in `StyledSkeleton.tsx`.
- Imported `Skeleton` component in `index.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->