### PR TITLE
fix(web): incorrect-locked-pnk-display-in-dashboard

### DIFF
--- a/web/src/pages/Dashboard/Courts/index.tsx
+++ b/web/src/pages/Dashboard/Courts/index.tsx
@@ -6,6 +6,7 @@ import Skeleton from "react-loading-skeleton";
 import CourtCard from "./CourtCard";
 import Header from "./Header";
 import { useJurorStakeDetailsQuery } from "queries/useJurorStakeDetailsQuery";
+import { useSortitionModuleGetJurorBalance } from "hooks/contracts/generated";
 
 const Container = styled.div`
   margin-top: 64px;
@@ -31,13 +32,16 @@ const StyledLabel = styled.label`
 const Courts: React.FC = () => {
   const { address } = useAccount();
   const { data: stakeData, isLoading } = useJurorStakeDetailsQuery(address?.toLowerCase() as `0x${string}`);
+  const { data: jurorBalance } = useSortitionModuleGetJurorBalance({
+    args: [address as `0x${string}`, BigInt(1)],
+  });
   const stakedCourts = stakeData?.jurorTokensPerCourts?.filter(({ staked }) => staked > 0);
   const isStaked = stakedCourts && stakedCourts.length > 0;
-  const lockedStake = stakeData?.jurorTokensPerCourts?.[0]?.locked;
+  const lockedStake = jurorBalance?.[1].toString();
 
   return (
     <Container>
-      <Header lockedStake={lockedStake} />
+      <Header lockedStake={lockedStake ?? ""} />
       {isLoading ? <Skeleton /> : null}
       {!isStaked && !isLoading ? <StyledLabel>You are not staked in any court</StyledLabel> : null}
       {isStaked && !isLoading ? (


### PR DESCRIPTION
in-directly related to issue #1415 

- Issue : Locked PNK in `Dashboard` is incorrect

- Reproduce : stake in a sub court, it will not reflect in `Dashboard`, until a stake is made in General Court
- Fix: switched the data source of locked PNK to `getJurorBalance` on `SortitionModule`, as that is more reliable and gives global lockedPNK
