### PR TITLE
refactor(web): update-verdict-button-in-dispute-overview

### DIFF
--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -11,6 +11,7 @@ import VerdictBanner from "./VerdictBanner";
 import { responsiveSize } from "styles/responsiveSize";
 import { useVotingContext } from "hooks/useVotingContext";
 import Skeleton from "react-loading-skeleton";
+import { useAccount } from "wagmi";
 
 const Container = styled.div`
   width: 100%;
@@ -86,6 +87,7 @@ interface IFinalDecision {
 
 const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const { id } = useParams();
+  const { isDisconnected } = useAccount();
   const { data: disputeTemplate } = useDisputeTemplate(id, arbitrable);
   const { data: disputeDetails } = useDisputeDetailsQuery(id);
   const { wasDrawn, hasVoted, isLoading, isCommitPeriod, isVotingPeriod, commited } = useVotingContext();
@@ -95,7 +97,7 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const currentRuling = Number(currentRulingArray?.[0]);
   const answer = disputeTemplate?.answers?.[currentRuling! - 1];
   const buttonText = useMemo(() => {
-    if (!wasDrawn) return "Check how the jury voted";
+    if (!wasDrawn || isDisconnected) return "Check how the jury voted";
     if (disputeDetails?.dispute?.period === "evidence") return "You were drawn";
     if (isCommitPeriod) return commited ? "You have committed" : "Commit your vote";
     if (isVotingPeriod && !commited) return "You failed to commit";
@@ -135,7 +137,7 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
           <Divider />
         </>
       )}
-      {isLoading ? (
+      {isLoading && !isDisconnected ? (
         <Skeleton width={250} height={20} />
       ) : (
         <StyledButton

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -90,7 +90,7 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const { isDisconnected } = useAccount();
   const { data: disputeTemplate } = useDisputeTemplate(id, arbitrable);
   const { data: disputeDetails } = useDisputeDetailsQuery(id);
-  const { wasDrawn, hasVoted, isLoading, isCommitPeriod, isVotingPeriod, commited } = useVotingContext();
+  const { wasDrawn, hasVoted, isLoading, isCommitPeriod, isVotingPeriod, commited, isHiddenVotes } = useVotingContext();
   const ruled = disputeDetails?.dispute?.ruled ?? false;
   const navigate = useNavigate();
   const { data: currentRulingArray } = useKlerosCoreCurrentRuling({ args: [BigInt(id ?? 0)], watch: true });
@@ -98,12 +98,11 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const answer = disputeTemplate?.answers?.[currentRuling! - 1];
   const buttonText = useMemo(() => {
     if (!wasDrawn || isDisconnected) return "Check how the jury voted";
-    if (disputeDetails?.dispute?.period === "evidence") return "You were drawn";
-    if (isCommitPeriod) return commited ? "You have committed" : "Commit your vote";
-    if (isVotingPeriod && !commited) return "You failed to commit";
-    if (isVotingPeriod && !hasVoted) return "Cast your vote";
-    return hasVoted ? "You have voted" : "You have not appeared for juror duty";
-  }, [wasDrawn, hasVoted, isCommitPeriod, isVotingPeriod, commited]);
+    if (isCommitPeriod && !commited) return "Commit your vote";
+    if (isVotingPeriod && isHiddenVotes && commited && !hasVoted) return "Reveal your vote";
+    if (isVotingPeriod && !isHiddenVotes && !hasVoted) return "Cast your vote";
+    return "Check how the jury voted";
+  }, [wasDrawn, hasVoted, isCommitPeriod, isVotingPeriod, commited, isHiddenVotes]);
 
   return (
     <Container>

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -102,7 +102,7 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
     if (isCommitPeriod) return commited ? "You have committed" : "Commit your vote";
     if (isVotingPeriod && !commited) return "You failed to commit";
     if (isVotingPeriod && !hasVoted) return "Cast your vote";
-    return hasVoted ? "You have voted" : "You failed to vote";
+    return hasVoted ? "You have voted" : "You have not appeared for juror duty";
   }, [wasDrawn, hasVoted, isCommitPeriod, isVotingPeriod, commited]);
 
   return (

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -88,7 +88,7 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const { id } = useParams();
   const { data: disputeTemplate } = useDisputeTemplate(id, arbitrable);
   const { data: disputeDetails } = useDisputeDetailsQuery(id);
-  const { wasDrawn, hasVoted, isLoading } = useVotingContext();
+  const { wasDrawn, hasVoted, isLoading, isCommitPeriod, isVotingPeriod, commited } = useVotingContext();
   const ruled = disputeDetails?.dispute?.ruled ?? false;
   const navigate = useNavigate();
   const { data: currentRulingArray } = useKlerosCoreCurrentRuling({ args: [BigInt(id ?? 0)], watch: true });
@@ -96,8 +96,13 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const answer = disputeTemplate?.answers?.[currentRuling! - 1];
   const buttonText = useMemo(() => {
     if (!wasDrawn) return "Check how the jury voted";
-    return hasVoted ? "You have voted" : "Cast you vote";
-  }, [wasDrawn, hasVoted]);
+    if (disputeDetails?.dispute?.period === "evidence") return "You were drawn";
+    if (isCommitPeriod) return commited ? "You have committed" : "Commit your vote";
+    if (isVotingPeriod && !commited) return "You failed to commit";
+    if (isVotingPeriod && !hasVoted) return "Cast your vote";
+    return hasVoted ? "You have voted" : "You failed to vote";
+  }, [wasDrawn, hasVoted, isCommitPeriod, isVotingPeriod, commited]);
+
   return (
     <Container>
       <VerdictBanner ruled={ruled} />

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -94,10 +94,10 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
   const { data: currentRulingArray } = useKlerosCoreCurrentRuling({ args: [BigInt(id ?? 0)], watch: true });
   const currentRuling = Number(currentRulingArray?.[0]);
   const answer = disputeTemplate?.answers?.[currentRuling! - 1];
-  const buttonText = useMemo(
-    () => (wasDrawn ? (hasVoted ? "You have voted" : "Cast your vote") : "Check how the jury voted"),
-    [wasDrawn, hasVoted]
-  );
+  const buttonText = useMemo(() => {
+    if (!wasDrawn) return "Check how the jury voted";
+    return hasVoted ? "You have voted" : "Cast you vote";
+  }, [wasDrawn, hasVoted]);
   return (
     <Container>
       <VerdictBanner ruled={ruled} />

--- a/web/src/hooks/useVotingContext.tsx
+++ b/web/src/hooks/useVotingContext.tsx
@@ -1,0 +1,48 @@
+import React, { useContext } from "react";
+import { createContext, useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useAccount } from "wagmi";
+import { useDisputeDetailsQuery } from "./queries/useDisputeDetailsQuery";
+import { useDrawQuery } from "./queries/useDrawQuery";
+import { useDisputeKitClassicIsVoteActive } from "./contracts/generated";
+import { isUndefined } from "~src/utils";
+
+interface IVotingContext {
+  wasDrawn: boolean;
+  hasVoted: boolean | undefined;
+  isLoading: boolean;
+}
+
+const VotingContext = createContext<IVotingContext>({ wasDrawn: false, hasVoted: false, isLoading: false });
+export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { id } = useParams();
+  const { address } = useAccount();
+  const { data: disputeData } = useDisputeDetailsQuery(id);
+  const { data: drawData, isLoading: isDrawDataLoading } = useDrawQuery(
+    address?.toLowerCase(),
+    id,
+    disputeData?.dispute?.currentRound.id
+  );
+  const roundId = disputeData?.dispute?.currentRoundIndex;
+  const voteId = drawData?.draws?.[0]?.voteIDNum;
+  const { data: hasVoted } = useDisputeKitClassicIsVoteActive({
+    enabled: !isUndefined(roundId) && !isUndefined(voteId),
+    args: [BigInt(id ?? 0), roundId, voteId],
+    watch: true,
+  });
+
+  const wasDrawn = useMemo(() => !isUndefined(drawData) && drawData.draws.length > 0, [drawData]);
+
+  return (
+    <VotingContext.Provider
+      value={useMemo(
+        () => ({ wasDrawn, hasVoted, isLoading: isDrawDataLoading }),
+        [wasDrawn, hasVoted, isDrawDataLoading]
+      )}
+    >
+      {children}
+    </VotingContext.Provider>
+  );
+};
+
+export const useVotingContext = () => useContext(VotingContext);

--- a/web/src/hooks/useVotingContext.tsx
+++ b/web/src/hooks/useVotingContext.tsx
@@ -1,5 +1,4 @@
-import React, { useContext } from "react";
-import { createContext, useMemo } from "react";
+import React, { useContext, createContext, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { useAccount } from "wagmi";
 import { useDisputeDetailsQuery } from "./queries/useDisputeDetailsQuery";

--- a/web/src/hooks/useVotingContext.tsx
+++ b/web/src/hooks/useVotingContext.tsx
@@ -4,24 +4,32 @@ import { useAccount } from "wagmi";
 import { useDisputeDetailsQuery } from "./queries/useDisputeDetailsQuery";
 import { useDrawQuery } from "./queries/useDrawQuery";
 import { useDisputeKitClassicIsVoteActive } from "./contracts/generated";
-import { isUndefined } from "~src/utils";
+import { isUndefined } from "utils/index";
 
 interface IVotingContext {
   wasDrawn: boolean;
   hasVoted: boolean | undefined;
   isLoading: boolean;
+  isHiddenVotes: boolean;
+  isCommitPeriod: boolean;
+  isVotingPeriod: boolean;
+  commited?: boolean;
+  commit?: string;
 }
 
-const VotingContext = createContext<IVotingContext>({ wasDrawn: false, hasVoted: false, isLoading: false });
+const VotingContext = createContext<IVotingContext>({
+  wasDrawn: false,
+  hasVoted: false,
+  isLoading: false,
+  isHiddenVotes: false,
+  isCommitPeriod: false,
+  isVotingPeriod: false,
+});
 export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { id } = useParams();
   const { address } = useAccount();
   const { data: disputeData } = useDisputeDetailsQuery(id);
-  const { data: drawData, isLoading: isDrawDataLoading } = useDrawQuery(
-    address?.toLowerCase(),
-    id,
-    disputeData?.dispute?.currentRound.id
-  );
+  const { data: drawData, isLoading } = useDrawQuery(address?.toLowerCase(), id, disputeData?.dispute?.currentRound.id);
   const roundId = disputeData?.dispute?.currentRoundIndex;
   const voteId = drawData?.draws?.[0]?.voteIDNum;
   const { data: hasVoted } = useDisputeKitClassicIsVoteActive({
@@ -31,12 +39,26 @@ export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({
   });
 
   const wasDrawn = useMemo(() => !isUndefined(drawData) && drawData.draws.length > 0, [drawData]);
+  const isHiddenVotes = useMemo(() => disputeData?.dispute?.court.hiddenVotes, [disputeData]);
+  const isCommitPeriod = useMemo(() => disputeData?.dispute?.period === "commit", [disputeData]);
+  const isVotingPeriod = useMemo(() => disputeData?.dispute?.period === "vote", [disputeData]);
 
+  const commited = useMemo(() => !isUndefined(drawData) && drawData?.draws?.[0]?.vote?.commited, [drawData]);
+  const commit = useMemo(() => drawData?.draws?.[0]?.vote?.commit, [drawData]);
   return (
     <VotingContext.Provider
       value={useMemo(
-        () => ({ wasDrawn, hasVoted, isLoading: isDrawDataLoading }),
-        [wasDrawn, hasVoted, isDrawDataLoading]
+        () => ({
+          wasDrawn,
+          hasVoted,
+          isLoading,
+          isHiddenVotes,
+          isCommitPeriod,
+          isVotingPeriod,
+          commited,
+          commit,
+        }),
+        [wasDrawn, hasVoted, isLoading, isHiddenVotes, isCommitPeriod, isVotingPeriod, commit, commited]
       )}
     >
       {children}

--- a/web/src/pages/Cases/CaseDetails/Voting/Classic/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/Classic/index.tsx
@@ -6,6 +6,7 @@ import { useDrawQuery } from "hooks/queries/useDrawQuery";
 import Vote from "./Vote";
 import Commit from "./Commit";
 import Reveal from "./Reveal";
+import { useVotingContext } from "hooks/useVotingContext";
 
 interface IClassic {
   arbitrable: `0x${string}`;
@@ -17,11 +18,9 @@ const Classic: React.FC<IClassic> = ({ arbitrable, setIsOpen }) => {
   const { address } = useAccount();
   const { data: disputeData } = useDisputeDetailsQuery(id);
   const { data: drawData, refetch } = useDrawQuery(address?.toLowerCase(), id, disputeData?.dispute?.currentRound.id);
-  const isHiddenVotes = useMemo(() => disputeData?.dispute?.court.hiddenVotes, [disputeData]);
-  const isCommitPeriod = useMemo(() => disputeData?.dispute?.period === "commit", [disputeData]);
-  const commited = useMemo(() => drawData?.draws[0].vote?.commited, [drawData]);
-  const commit = useMemo(() => drawData?.draws[0].vote?.commit, [drawData]);
+  const { isHiddenVotes, isCommitPeriod, commit, commited } = useVotingContext();
   const voteIDs = useMemo(() => drawData?.draws?.map((draw) => draw.voteIDNum) as string[], [drawData]);
+
   return id && isHiddenVotes ? (
     isCommitPeriod && !commited ? (
       <Commit {...{ arbitrable, setIsOpen, voteIDs, refetch }} />

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -1,14 +1,11 @@
 import React, { useMemo, useState } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
-import { useAccount } from "wagmi";
 import { responsiveSize } from "styles/responsiveSize";
 import VoteIcon from "assets/svgs/icons/voted.svg";
 import { Periods } from "consts/periods";
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
-import { useDisputeKitClassicIsVoteActive } from "hooks/contracts/generated";
 import { useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
-import { useDrawQuery } from "queries/useDrawQuery";
 import { useAppealCost } from "queries/useAppealCost";
 import { isUndefined } from "utils/index";
 import { isLastRound } from "utils/isLastRound";
@@ -19,6 +16,7 @@ import InfoCard from "components/InfoCard";
 import Classic from "./Classic";
 import VotingHistory from "./VotingHistory";
 import Skeleton from "react-loading-skeleton";
+import { useVotingContext } from "hooks/useVotingContext";
 
 const Container = styled.div`
   padding: ${responsiveSize(16, 32)};
@@ -37,29 +35,16 @@ interface IVoting {
 }
 
 const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
-  const { address } = useAccount();
   const { id } = useParams();
   const { data: disputeData } = useDisputeDetailsQuery(id);
   const { data: appealCost } = useAppealCost(id);
-  const { data: drawData, isLoading: isDrawDataLoading } = useDrawQuery(
-    address?.toLowerCase(),
-    id,
-    disputeData?.dispute?.currentRound.id
-  );
-  const roundId = disputeData?.dispute?.currentRoundIndex;
-  const voteId = drawData?.draws?.[0]?.voteIDNum;
-  const { data: voted } = useDisputeKitClassicIsVoteActive({
-    enabled: !isUndefined(roundId) && !isUndefined(voteId),
-    args: [BigInt(id ?? 0), roundId, voteId],
-    watch: true,
-  });
+  const { wasDrawn: userWasDrawn, hasVoted: voted, isLoading: isDrawDataLoading } = useVotingContext();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   useLockOverlayScroll(isPopupOpen);
   const lastPeriodChange = disputeData?.dispute?.lastPeriodChange;
   const timesPerPeriod = disputeData?.dispute?.court?.timesPerPeriod;
   const finalDate = useFinalDate(lastPeriodChange, currentPeriodIndex, timesPerPeriod);
 
-  const userWasDrawn = useMemo(() => !isUndefined(drawData) && drawData.draws.length > 0, [drawData]);
   const isCommitOrVotePeriod = useMemo(
     () => [Periods.vote, Periods.commit].includes(currentPeriodIndex),
     [currentPeriodIndex]

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -17,6 +17,7 @@ import Classic from "./Classic";
 import VotingHistory from "./VotingHistory";
 import Skeleton from "react-loading-skeleton";
 import { useVotingContext } from "hooks/useVotingContext";
+import { useAccount } from "wagmi";
 
 const Container = styled.div`
   padding: ${responsiveSize(16, 32)};
@@ -36,6 +37,7 @@ interface IVoting {
 
 const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
   const { id } = useParams();
+  const { isDisconnected } = useAccount();
   const { data: disputeData } = useDisputeDetailsQuery(id);
   const { data: appealCost } = useAppealCost(id);
   const { wasDrawn: userWasDrawn, hasVoted: voted, isLoading: isDrawDataLoading } = useVotingContext();
@@ -59,7 +61,7 @@ const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex }) => {
         </>
       )}
 
-      {userWasDrawn ? null : (
+      {userWasDrawn || isDisconnected ? null : (
         <>
           {isDrawDataLoading ? (
             <Skeleton width={300} height={20} />

--- a/web/src/pages/Cases/CaseDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/index.tsx
@@ -11,6 +11,7 @@ import Tabs from "./Tabs";
 import Timeline from "./Timeline";
 import Voting from "./Voting";
 import { responsiveSize } from "styles/responsiveSize";
+import { VotingContextProvider } from "hooks/useVotingContext";
 
 const Container = styled.div``;
 
@@ -32,25 +33,27 @@ const CaseDetails: React.FC = () => {
   const arbitrable = dispute?.arbitrated.id as `0x${string}`;
 
   return (
-    <Container>
-      <Header>Case #{id}</Header>
-      <Tabs />
-      <Timeline {...{ currentPeriodIndex, dispute }} />
-      <StyledCard>
-        <Routes>
-          <Route
-            path="overview"
-            element={
-              <Overview currentPeriodIndex={currentPeriodIndex} courtID={dispute?.court.id} {...{ arbitrable }} />
-            }
-          />
-          <Route path="evidence" element={<Evidence {...{ arbitrable }} />} />
-          <Route path="voting" element={<Voting {...{ arbitrable, currentPeriodIndex }} />} />
-          <Route path="appeal" element={<Appeal {...{ currentPeriodIndex }} />} />
-          <Route path="*" element={<Navigate to="overview" replace />} />
-        </Routes>
-      </StyledCard>
-    </Container>
+    <VotingContextProvider>
+      <Container>
+        <Header>Case #{id}</Header>
+        <Tabs />
+        <Timeline {...{ currentPeriodIndex, dispute }} />
+        <StyledCard>
+          <Routes>
+            <Route
+              path="overview"
+              element={
+                <Overview currentPeriodIndex={currentPeriodIndex} courtID={dispute?.court.id} {...{ arbitrable }} />
+              }
+            />
+            <Route path="evidence" element={<Evidence {...{ arbitrable }} />} />
+            <Route path="voting" element={<Voting {...{ arbitrable, currentPeriodIndex }} />} />
+            <Route path="appeal" element={<Appeal {...{ currentPeriodIndex }} />} />
+            <Route path="*" element={<Navigate to="overview" replace />} />
+          </Routes>
+        </StyledCard>
+      </Container>
+    </VotingContextProvider>
   );
 };
 


### PR DESCRIPTION
closes #1423
Added the following with :

1.  "You were drawn" : shown in evidence period to the juror if drawn
2. "Commit your vote": shown in commit period, if juror has not already committed
3. "You have committed": shown in commit period, if juror has already committed
4. "You failed to commit": show when juror failed to commit in commit period
5. "Cast your vote": shown in voting period, if juror hasn't already voted
6. "You have voted": shown if juror has already voted
7. "You failed to vote": shown if juror failed to vote during voting period

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on introducing a `VotingContext` to manage voting-related data and logic. It includes the following changes:

- Added `VotingContextProvider` component
- Created `useVotingContext` hook to access voting context data
- Refactored code to use `useVotingContext` instead of individual hooks
- Updated imports and dependencies

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->