### PR TITLE
Fix(web)/dispute overview component tweaks

### DIFF
--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -147,7 +147,7 @@ type Dispute @entity {
   id: ID!
   disputeID: BigInt!
   court: Court!
-  createdOn: BigInt
+  createdAt: BigInt
   arbitrated: Arbitrable!
   period: Period!
   ruled: Boolean!

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -147,6 +147,7 @@ type Dispute @entity {
   id: ID!
   disputeID: BigInt!
   court: Court!
+  createdOn: BigInt
   arbitrated: Arbitrable!
   period: Period!
   ruled: Boolean!
@@ -183,6 +184,7 @@ type Round @entity {
   dispute: Dispute!
   court: Court!
   feeToken: FeeToken
+  timeline: [BigInt!]!
 }
 
 type Draw @entity(immutable: true) {

--- a/subgraph/core/src/KlerosCore.ts
+++ b/subgraph/core/src/KlerosCore.ts
@@ -17,7 +17,7 @@ import { ZERO, ONE } from "./utils";
 import { createCourtFromEvent } from "./entities/Court";
 import { createDisputeKitFromEvent, filterSupportedDisputeKits } from "./entities/DisputeKit";
 import { createDisputeFromEvent } from "./entities/Dispute";
-import { createRoundFromRoundInfo } from "./entities/Round";
+import { createRoundFromRoundInfo, updateRoundTimeline } from "./entities/Round";
 import { updateCases, updateCasesAppealing, updateCasesRuled, updateCasesVoting } from "./datapoint";
 import { addUserActiveDispute, ensureUser } from "./entities/User";
 import { updateJurorStake } from "./entities/JurorTokensPerCourt";
@@ -135,6 +135,7 @@ export function handleNewPeriod(event: NewPeriod): void {
   } else {
     dispute.periodDeadline = BigInt.fromU64(U64.MAX_VALUE);
   }
+  updateRoundTimeline(disputeID.toString(), newPeriod, event.block.timestamp);
   dispute.save();
   court.save();
 }

--- a/subgraph/core/src/entities/Dispute.ts
+++ b/subgraph/core/src/entities/Dispute.ts
@@ -10,6 +10,7 @@ export function createDisputeFromEvent(event: DisputeCreation): void {
   const courtID = disputeContractState.value0.toString();
   dispute.court = courtID;
   dispute.disputeID = disputeID;
+  dispute.createdOn = event.block.timestamp;
   dispute.arbitrated = event.params._arbitrable.toHexString();
   dispute.period = "evidence";
   dispute.ruled = false;

--- a/subgraph/core/src/entities/Dispute.ts
+++ b/subgraph/core/src/entities/Dispute.ts
@@ -10,7 +10,7 @@ export function createDisputeFromEvent(event: DisputeCreation): void {
   const courtID = disputeContractState.value0.toString();
   dispute.court = courtID;
   dispute.disputeID = disputeID;
-  dispute.createdOn = event.block.timestamp;
+  dispute.createdAt = event.block.timestamp;
   dispute.arbitrated = event.params._arbitrable.toHexString();
   dispute.period = "evidence";
   dispute.ruled = false;

--- a/subgraph/core/src/entities/Round.ts
+++ b/subgraph/core/src/entities/Round.ts
@@ -1,6 +1,7 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 import { KlerosCore, KlerosCore__getRoundInfoResultValue0Struct } from "../../generated/KlerosCore/KlerosCore";
-import { Round } from "../../generated/schema";
+import { Dispute, Round } from "../../generated/schema";
+import { ONE } from "../utils";
 
 export function createRoundFromRoundInfo(
   contract: KlerosCore,
@@ -22,5 +23,31 @@ export function createRoundFromRoundInfo(
   round.dispute = disputeID.toString();
   const courtID = contract.disputes(disputeID).value0.toString();
   round.court = courtID;
+  round.timeline = new Array<BigInt>(4).fill(new BigInt(0));
+  round.save();
+}
+
+function getIndexByPeriodName(periodName: string): i32 {
+  const periodArray = ["evidence", "commit", "vote", "appeal", "execution"];
+  return periodArray.indexOf(periodName);
+}
+
+export function updateRoundTimeline(disputeId: string, newPeriod: string, timestamp: BigInt): void {
+  const dispute = Dispute.load(disputeId);
+  if (!dispute) return;
+  //explanation: this to handle new round,since AppealDecision is emitted before NewPeriod, which changes the currentRoundIndex ,
+  //hence when round changes we subtract 1 from current round index
+  const currentRoundIndex =
+    dispute.period.includes("appeal") && newPeriod === "evidence"
+      ? dispute.currentRoundIndex.minus(ONE)
+      : dispute.currentRoundIndex;
+  const roundID = `${disputeId}-${currentRoundIndex.toString()}`;
+  const round = Round.load(roundID);
+  if (!round) return;
+
+  let timeline = round.timeline;
+  const period = getIndexByPeriodName(dispute.period);
+  timeline[period] = timestamp;
+  round.timeline = timeline;
   round.save();
 }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "update:core:arbitrum-sepolia-devnet": "./scripts/update.sh arbitrumSepoliaDevnet arbitrum-sepolia core/subgraph.yaml",

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -50,7 +50,9 @@ const getCaseEventTimes = (
   isCreation: boolean
 ) => {
   const options: Intl.DateTimeFormatOptions = { year: "numeric", month: "long", day: "numeric" };
-  const durationCurrentPeriod = parseInt(timesPerPeriod[currentPeriodIndex - 1]);
+  const durationCurrentPeriod = parseInt(
+    timesPerPeriod[(currentPeriodIndex - 1 + timesPerPeriod.length) % timesPerPeriod.length]
+  );
   const startingDate = new Date(
     (parseInt(lastPeriodChange) + (isCreation ? -durationCurrentPeriod : durationCurrentPeriod)) * 1000
   );

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -73,19 +73,17 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
           const parsedRoundChoice = parseInt(winningChoice);
           const isOngoing = index === localRounds.length - 1 && currentPeriodIndex < 3;
           const roundTimeline = rounds?.[index].timeline;
-          const previousRoundEnd =
-            index > 0 ? rounds?.[index - 1].timeline?.[Periods.appeal] : votingHistory?.dispute?.createdOn;
-          console.log(previousRoundEnd, index, roundTimeline);
 
           const icon = dispute.ruled && !rulingOverride && index === localRounds.length - 1 ? ClosedCaseIcon : "";
           const answers = disputeTemplate?.answers;
           acc.push({
             title: `Jury Decision - Round ${index + 1}`,
             party: isOngoing ? "Voting is ongoing" : getVoteChoice(parsedRoundChoice, answers),
-            //previous rounds endtime (appeal end) or dispute creation time if round 1 , if not ongoing the voteEnd time
-            subtitle: `${formatDate(isOngoing ? previousRoundEnd : roundTimeline?.[Periods.vote])} / ${
-              votingHistory?.dispute?.rounds.at(index)?.court.name
-            }`,
+            subtitle: isOngoing
+              ? ""
+              : `${formatDate(roundTimeline?.[Periods.vote])} / ${
+                  votingHistory?.dispute?.rounds.at(index)?.court.name
+                }`,
             rightSided: true,
             variant: theme.secondaryPurple,
             Icon: icon !== "" ? icon : undefined,
@@ -115,7 +113,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
           {
             title: "Dispute created",
             party: "",
-            subtitle: formatDate(votingHistory?.dispute?.createdOn),
+            subtitle: formatDate(votingHistory?.dispute?.createdAt),
             rightSided: true,
             variant: theme.secondaryPurple,
           },

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -73,15 +73,19 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
           const parsedRoundChoice = parseInt(winningChoice);
           const isOngoing = index === localRounds.length - 1 && currentPeriodIndex < 3;
           const roundTimeline = rounds?.[index].timeline;
+          const previousRoundEnd =
+            index > 0 ? rounds?.[index - 1].timeline?.[Periods.appeal] : votingHistory?.dispute?.createdOn;
+          console.log(previousRoundEnd, index, roundTimeline);
 
           const icon = dispute.ruled && !rulingOverride && index === localRounds.length - 1 ? ClosedCaseIcon : "";
           const answers = disputeTemplate?.answers;
           acc.push({
             title: `Jury Decision - Round ${index + 1}`,
             party: isOngoing ? "Voting is ongoing" : getVoteChoice(parsedRoundChoice, answers),
-            subtitle: `${formatDate(roundTimeline?.[Periods.evidence])} / ${
+            //previous rounds endtime (appeal end) or dispute creation time if round 1 , if not ongoing the voteEnd time
+            subtitle: `${formatDate(isOngoing ? previousRoundEnd : roundTimeline?.[Periods.vote])} / ${
               votingHistory?.dispute?.rounds.at(index)?.court.name
-            }`, //evidence period end
+            }`,
             rightSided: true,
             variant: theme.secondaryPurple,
             Icon: icon !== "" ? icon : undefined,
@@ -91,7 +95,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
             acc.push({
               title: "Appealed",
               party: "",
-              subtitle: formatDate(roundTimeline?.[Periods.vote]), //voting period end
+              subtitle: formatDate(roundTimeline?.[Periods.appeal]),
               rightSided: true,
               Icon: AppealedCaseIcon,
             });
@@ -99,7 +103,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
             acc.push({
               title: "Won by Appeal",
               party: getVoteChoice(parsedDisputeFinalRuling, answers),
-              subtitle: formatDate(roundTimeline?.[Periods.appeal]), //appeal period end
+              subtitle: formatDate(roundTimeline?.[Periods.appeal]),
               rightSided: true,
               Icon: ClosedCaseIcon,
             });

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -43,19 +43,9 @@ const StyledCalendarIcon = styled(CalendarIcon)`
   height: 14px;
 `;
 
-const getCaseEventTimes = (
-  lastPeriodChange: string,
-  currentPeriodIndex: number,
-  timesPerPeriod: string[],
-  isCreation: boolean
-) => {
+const formatDate = (date: string) => {
   const options: Intl.DateTimeFormatOptions = { year: "numeric", month: "long", day: "numeric" };
-  const durationCurrentPeriod = parseInt(
-    timesPerPeriod[(currentPeriodIndex - 1 + timesPerPeriod.length) % timesPerPeriod.length]
-  );
-  const startingDate = new Date(
-    (parseInt(lastPeriodChange) + (isCreation ? -durationCurrentPeriod : durationCurrentPeriod)) * 1000
-  );
+  const startingDate = new Date(parseInt(date) * 1000);
 
   const formattedDate = startingDate.toLocaleDateString("en-US", options);
   return formattedDate;
@@ -68,7 +58,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
   const { data: votingHistory } = useVotingHistory(id);
   const { data: disputeTemplate } = useDisputeTemplate(id, arbitrable);
   const localRounds: ClassicRound[] = getLocalRounds(votingHistory?.dispute?.disputeKitDispute) as ClassicRound[];
-
+  const rounds = votingHistory?.dispute?.rounds;
   const theme = useTheme();
 
   return useMemo<TimelineItems | undefined>(() => {
@@ -77,19 +67,21 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
       const rulingOverride = dispute.overridden;
       const parsedDisputeFinalRuling = parseInt(dispute.currentRuling);
       const currentPeriodIndex = Periods[dispute.period];
-      const lastPeriodChange = dispute.lastPeriodChange;
-      const courtTimePeriods = dispute.court.timesPerPeriod;
+
       return localRounds?.reduce<TimelineItems>(
         (acc, { winningChoice }, index) => {
           const parsedRoundChoice = parseInt(winningChoice);
           const isOngoing = index === localRounds.length - 1 && currentPeriodIndex < 3;
-          const eventDate = getCaseEventTimes(lastPeriodChange, currentPeriodIndex, courtTimePeriods, false);
+          const roundTimeline = rounds?.[index].timeline;
+
           const icon = dispute.ruled && !rulingOverride && index === localRounds.length - 1 ? ClosedCaseIcon : "";
           const answers = disputeTemplate?.answers;
           acc.push({
             title: `Jury Decision - Round ${index + 1}`,
             party: isOngoing ? "Voting is ongoing" : getVoteChoice(parsedRoundChoice, answers),
-            subtitle: `${eventDate} / ${votingHistory?.dispute?.rounds.at(index)?.court.name}`,
+            subtitle: `${formatDate(roundTimeline?.[Periods.evidence])} / ${
+              votingHistory?.dispute?.rounds.at(index)?.court.name
+            }`, //evidence period end
             rightSided: true,
             variant: theme.secondaryPurple,
             Icon: icon !== "" ? icon : undefined,
@@ -99,7 +91,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
             acc.push({
               title: "Appealed",
               party: "",
-              subtitle: eventDate,
+              subtitle: formatDate(roundTimeline?.[Periods.vote]), //voting period end
               rightSided: true,
               Icon: AppealedCaseIcon,
             });
@@ -107,7 +99,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
             acc.push({
               title: "Won by Appeal",
               party: getVoteChoice(parsedDisputeFinalRuling, answers),
-              subtitle: eventDate,
+              subtitle: formatDate(roundTimeline?.[Periods.appeal]), //appeal period end
               rightSided: true,
               Icon: ClosedCaseIcon,
             });
@@ -119,7 +111,7 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
           {
             title: "Dispute created",
             party: "",
-            subtitle: getCaseEventTimes(lastPeriodChange, currentPeriodIndex, courtTimePeriods, true),
+            subtitle: formatDate(votingHistory?.dispute?.createdOn),
             rightSided: true,
             variant: theme.secondaryPurple,
           },

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -112,18 +112,6 @@ const FinalDecision: React.FC<IFinalDecision> = ({ arbitrable }) => {
         )}
       </JuryContainer>
       <Divider />
-      {disputeTemplate?.aliases && (
-        <>
-          <UserContainer>
-            <StyledIdenticon size="24" />
-            <AliasTag>
-              {disputeTemplate?.aliases?.challenger && <small>Alice.eth</small>}
-              <Title>Claimant</Title>
-            </AliasTag>
-          </UserContainer>
-          <Divider />
-        </>
-      )}
       <StyledButton
         onClick={() => navigate(`/cases/${id?.toString()}/voting`)}
         text={"Check how the jury voted"}

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
-import Identicon from "react-identicons";
 import ArrowIcon from "assets/svgs/icons/arrow.svg";
 import { useKlerosCoreCurrentRuling } from "hooks/contracts/generated";
 import { useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
@@ -27,32 +26,6 @@ const JuryContainer = styled.div`
 const JuryDecisionTag = styled.small`
   font-weight: 400;
   line-height: 19px;
-  color: ${({ theme }) => theme.secondaryText};
-`;
-
-const UserContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 22px 0px;
-  gap: 10px;
-`;
-
-const AliasTag = styled.div`
-  display: flex;
-  flex-direction: column;
-  small {
-    font-weight: 400;
-    line-height: 19px;
-  }
-`;
-
-const StyledIdenticon = styled(Identicon)`
-  width: 24px;
-  height: 24px;
-  border-radius: 100%;
-`;
-
-const Title = styled.small`
   color: ${({ theme }) => theme.secondaryText};
 `;
 

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -8,12 +8,14 @@ const votingHistoryQuery = graphql(`
   query VotingHistory($disputeID: ID!) {
     dispute(id: $disputeID) {
       id
+      createdOn
       rounds {
         nbVotes
         court {
           id
           name
         }
+        timeline
       }
       disputeKitDispute {
         localRounds {

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -8,7 +8,7 @@ const votingHistoryQuery = graphql(`
   query VotingHistory($disputeID: ID!) {
     dispute(id: $disputeID) {
       id
-      createdOn
+      createdAt
       rounds {
         nbVotes
         court {

--- a/web/src/pages/Cases/CaseDetails/Overview/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Overview/index.tsx
@@ -5,7 +5,6 @@ import { formatEther } from "viem";
 import { useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
 import { useDisputeTemplate } from "queries/useDisputeTemplate";
 import { useCourtPolicy } from "queries/useCourtPolicy";
-import { Periods } from "consts/periods";
 
 import DisputeInfo from "components/DisputeCard/DisputeInfo";
 import Verdict from "components/Verdict/index";

--- a/web/src/pages/Cases/CaseDetails/Overview/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Overview/index.tsx
@@ -57,12 +57,8 @@ const Overview: React.FC<IOverview> = ({ arbitrable, courtID, currentPeriodIndex
         <DisputeContext disputeTemplate={disputeTemplate} />
         <Divider />
 
-        {currentPeriodIndex !== Periods.evidence && (
-          <>
-            <Verdict arbitrable={arbitrable} />
-            <Divider />
-          </>
-        )}
+        <Verdict arbitrable={arbitrable} />
+        <Divider />
 
         <DisputeInfo
           isOverview={true}


### PR DESCRIPTION
Warning ⚠️  : Requires subgraph redeploy

This PR fixes :

1.  Removes hardcoded Alias UI from Verdict component.
2. Dispute Timeline now shows on evidence period.
3.  Dispute Timeline dates have been fixed, we now have a `timeline` field in `Round` entity , that maps the Period ends

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on adding the `createdAt` field to the `Round` entity in the GraphQL schema and updating the corresponding code to handle the new field. It also removes unused code related to user information and updates the timeline display in the `DisputeTimeline` component. Notable changes include:

- Added `createdAt` field to the `Round` entity in the GraphQL schema.
- Updated the `useVotingHistory` hook to include the `createdAt` field in the query.
- Updated the `createRoundFromRoundInfo` function to set the `createdAt` field for new rounds.
- Updated the `updateRoundTimeline` function to handle the `createdAt` field update.
- Removed unused code related to user information in the `Verdict` component.
- Updated the timeline display in the `DisputeTimeline` component to use formatted dates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->