### PR TITLE
fix(web): truncate-long-titles-in-Dispute-info-card

### DIFF
--- a/web/src/components/DisputeCard/index.tsx
+++ b/web/src/components/DisputeCard/index.tsx
@@ -98,11 +98,6 @@ const DisputeCard: React.FC<IDisputeCard> = ({ id, arbitrated, period, lastPerio
       ? lastPeriodChange
       : getPeriodEndTimestamp(lastPeriodChange, currentPeriodIndex, court.timesPerPeriod);
   const { data: disputeTemplate } = useDisputeTemplate(id, arbitrated.id as `0x${string}`);
-  const title = isUndefined(disputeTemplate) ? (
-    <StyledSkeleton />
-  ) : (
-    disputeTemplate?.title ?? "The dispute's template is not correct please vote refuse to arbitrate"
-  );
   const { data: courtPolicy } = useCourtPolicy(court.id);
   const courtName = courtPolicy?.name;
   const category = disputeTemplate ? disputeTemplate.category : undefined;
@@ -115,7 +110,14 @@ const DisputeCard: React.FC<IDisputeCard> = ({ id, arbitrated, period, lastPerio
         <StyledCard hover onClick={() => navigate(`/cases/${id.toString()}`)}>
           <PeriodBanner id={parseInt(id)} period={currentPeriodIndex} />
           <CardContainer>
-            <h3>{title}</h3>
+            {isUndefined(disputeTemplate) ? (
+              <StyledSkeleton />
+            ) : (
+              <TruncatedTitle
+                text={disputeTemplate?.title ?? "The dispute's template is not correct please vote refuse to arbitrate"}
+                maxLength={100}
+              />
+            )}
             <DisputeInfo
               courtId={court?.id}
               court={courtName}


### PR DESCRIPTION
closes #1430 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the display of the dispute card by truncating the title and adding a skeleton loader. 

### Detailed summary
- Truncates the title of the dispute card if it exceeds a certain length
- Adds a skeleton loader for the title while the data is being fetched

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->