### PR TITLE
Chore(subgraph): update package version

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "scripts": {
     "update:core:arbitrum-sepolia-devnet": "./scripts/update.sh arbitrumSepoliaDevnet arbitrum-sepolia core/subgraph.yaml",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `@kleros/kleros-v2-subgraph` package to `0.3.5` and updating the `update:core:arbitrum-sepolia-devnet` script in the `package.json` file.

### Detailed summary
- Updated the version of the `@kleros/kleros-v2-subgraph` package to `0.3.5`.
- Updated the `update:core:arbitrum-sepolia-devnet` script in the `package.json` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->