### PR TITLE
feat(web): add-home-link-in-header

### DIFF
--- a/web/src/layout/Header/navbar/Explore.tsx
+++ b/web/src/layout/Header/navbar/Explore.tsx
@@ -49,6 +49,7 @@ const StyledLink = styled(Link)<{ isActive: boolean }>`
 `;
 
 const links = [
+  { to: "/", text: "Home" },
   { to: "/cases/display/1/desc/all", text: "Cases" },
   { to: "/courts", text: "Courts" },
   { to: "/dashboard/1/desc/all", text: "Dashboard" },
@@ -63,7 +64,11 @@ const Explore: React.FC = () => {
       <Title>Explore</Title>
       {links.map(({ to, text }) => (
         <LinkContainer key={text}>
-          <StyledLink to={to} onClick={toggleIsOpen} isActive={location.pathname.startsWith(to)}>
+          <StyledLink
+            to={to}
+            onClick={toggleIsOpen}
+            isActive={to === "/" ? location.pathname === "/" : location.pathname.startsWith(to)}
+          >
             {text}
           </StyledLink>
         </LinkContainer>


### PR DESCRIPTION
Adds `Home` in Navbar
closes #1442 
<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new link to the navbar for the "Home" page
- Modified the isActive logic for the links in the navbar to correctly highlight the active link based on the current location pathname.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->