### PR TITLE
chore(actions): update node version on subgraph deploy

### DIFF
--- a/.github/workflows/deploy-subgraph.yml
+++ b/.github/workflows/deploy-subgraph.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install Yarn if running locally
         if: ${{ env.ACT }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the node version used in the deploy-subgraph.yml workflow. 

### Detailed summary
- Updated node version from 16 to 20 in the deploy-subgraph.yml workflow.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->