### PR TITLE
fix(web): fix-prop-name-changed

### DIFF
--- a/web/src/pages/Resolver/Preview/index.tsx
+++ b/web/src/pages/Resolver/Preview/index.tsx
@@ -64,7 +64,7 @@ const Preview: React.FC = () => {
       <Header>Preview</Header>
       <StyledCard>
         <PreviewContainer>
-          <DisputeContext disputeTemplate={disputeTemplate} />
+          <DisputeContext disputeDetails={disputeTemplate} />
           <Divider />
 
           <DisputeInfo


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Renamed the prop `disputeTemplate` to `disputeDetails` in the `DisputeContext` component in the `Preview` page of the `Resolver` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->