### PR TITLE
fix(web): move-template-population-to-use-dispute-template-hook

### DIFF
--- a/web/src/components/DisputeCard/index.tsx
+++ b/web/src/components/DisputeCard/index.tsx
@@ -14,8 +14,6 @@ import DisputeInfo from "./DisputeInfo";
 import PeriodBanner from "./PeriodBanner";
 import { isUndefined } from "utils/index";
 import { responsiveSize } from "styles/responsiveSize";
-import { populateTemplate } from "@kleros/kleros-sdk/src/dataMappings/utils/populateTemplate";
-import { DisputeDetails } from "@kleros/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes";
 import { INVALID_DISPUTE_DATA_ERROR } from "consts/index";
 
 const StyledCard = styled(Card)`
@@ -106,18 +104,11 @@ const DisputeCard: React.FC<IDisputeCard> = ({
     currentPeriodIndex === 4
       ? lastPeriodChange
       : getPeriodEndTimestamp(lastPeriodChange, currentPeriodIndex, court.timesPerPeriod);
-  const { data: disputeTemplate } = useDisputeTemplate(id, arbitrated.id as `0x${string}`);
-  let disputeDetails: DisputeDetails | undefined;
-  try {
-    if (disputeTemplate) {
-      disputeDetails = populateTemplate(disputeTemplate.templateData, {});
-    }
-  } catch (e) {
-    console.error(e);
-  }
+  const { data: disputeDetails } = useDisputeTemplate(id, arbitrated.id as `0x${string}`);
+
   const { data: courtPolicy } = useCourtPolicy(court.id);
   const courtName = courtPolicy?.name;
-  const category = disputeTemplate?.category;
+  const category = disputeDetails?.category;
   const navigate = useNavigate();
   return (
     <>
@@ -125,7 +116,7 @@ const DisputeCard: React.FC<IDisputeCard> = ({
         <StyledCard hover onClick={() => navigate(`/cases/${id.toString()}`)}>
           <PeriodBanner id={parseInt(id)} period={currentPeriodIndex} />
           <CardContainer>
-            {isUndefined(disputeTemplate) ? (
+            {isUndefined(disputeDetails) ? (
               <StyledSkeleton />
             ) : (
               <TruncatedTitle text={disputeDetails?.title ?? INVALID_DISPUTE_DATA_ERROR} maxLength={100} />

--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -7,6 +7,7 @@ import { Answer as IAnswer } from "context/NewDisputeContext";
 import AliasDisplay from "./Alias";
 import { responsiveSize } from "styles/responsiveSize";
 import { DisputeDetails } from "@kleros/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes";
+import { INVALID_DISPUTE_DATA_ERROR } from "consts/index";
 
 const StyledH1 = styled.h1`
   margin: 0;
@@ -65,11 +66,7 @@ export const DisputeContext: React.FC<IDisputeContext> = ({ disputeDetails }) =>
   return (
     <>
       <StyledH1>
-        {isUndefined(disputeDetails) ? (
-          <StyledSkeleton />
-        ) : (
-          disputeDetails?.title ?? "The dispute's template is not correct please vote refuse to arbitrate"
-        )}
+        {isUndefined(disputeDetails) ? <StyledSkeleton /> : disputeDetails?.title ?? INVALID_DISPUTE_DATA_ERROR}
       </StyledH1>
       {!isUndefined(disputeDetails) && (
         <QuestionAndDescription>

--- a/web/src/pages/Cases/CaseDetails/Overview/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Overview/index.tsx
@@ -1,15 +1,10 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { formatEther } from "viem";
 import { useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
 import { useDisputeTemplate } from "queries/useDisputeTemplate";
 import { useCourtPolicy } from "queries/useCourtPolicy";
-import { populateTemplate } from "@kleros/kleros-sdk/src/dataMappings/utils/populateTemplate";
-import { executeActions } from "@kleros/kleros-sdk/src/dataMappings/executeActions";
-import { configureSDK } from "@kleros/kleros-sdk/src/sdk";
-import { alchemyApiKey } from "context/Web3Provider";
-import { DisputeDetails } from "@kleros/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes";
 import DisputeInfo from "components/DisputeCard/DisputeInfo";
 import Verdict from "components/Verdict/index";
 import { useVotingHistory } from "hooks/queries/useVotingHistory";
@@ -44,48 +39,15 @@ interface IOverview {
 
 const Overview: React.FC<IOverview> = ({ arbitrable, courtID, currentPeriodIndex }) => {
   const { id } = useParams();
-  const { data: disputeTemplate } = useDisputeTemplate(id, arbitrable);
+  const { data: disputeDetails } = useDisputeTemplate(id, arbitrable);
   const { data: dispute } = useDisputeDetailsQuery(id);
   const { data: courtPolicy } = useCourtPolicy(courtID);
   const { data: votingHistory } = useVotingHistory(id);
-  const [disputeDetails, setDisputeDetails] = useState<DisputeDetails | undefined>(undefined);
   const localRounds = getLocalRounds(votingHistory?.dispute?.disputeKitDispute);
   const courtName = courtPolicy?.name;
   const court = dispute?.dispute?.court;
   const rewards = useMemo(() => (court ? `≥ ${formatEther(court.feeForJuror)} ETH` : undefined), [court]);
-  const category = disputeTemplate?.category ?? undefined;
-  const disputeTemplateInput = disputeTemplate?.templateData;
-  const dataMappingsInput = disputeTemplate?.templateDataMappings;
-
-  useEffect(() => {
-    configureSDK({ apiKey: alchemyApiKey });
-    const initialContext = {
-      disputeID: id,
-      arbitrable: arbitrable,
-    };
-
-    if (!disputeTemplateInput) return;
-
-    const fetchData = async () => {
-      try {
-        console.log("dataMappingsInput", dataMappingsInput);
-        let data = {};
-        if (dataMappingsInput) {
-          const parsedMappings = JSON.parse(dataMappingsInput);
-          console.log("parsedMappings", parsedMappings);
-          data = await executeActions(parsedMappings, initialContext);
-        }
-        console.log("data", data);
-        const finalDisputeDetails = populateTemplate(disputeTemplateInput, data);
-        setDisputeDetails(finalDisputeDetails);
-      } catch (e) {
-        console.error(e);
-        setDisputeDetails(undefined);
-      }
-    };
-
-    fetchData();
-  }, [disputeTemplateInput, dataMappingsInput, arbitrable, id]);
+  const category = disputeDetails?.category;
 
   return (
     <>


### PR DESCRIPTION
- Moved the template population logic to the `useDisputeTemplate` hook itself

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added `INVALID_DISPUTE_DATA_ERROR` constant.
- Replaced the condition for rendering the dispute title in `DisputeContext` and `DisputeCard` components with the use of the constant.
- Removed unused imports and code in `DisputeCard` and `useDisputeTemplate` components.
- Modified the implementation of `useDisputeTemplate` to populate the dispute details using the new constant.
- Removed unused imports and code in `Overview` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->