### PR TITLE
fix(web): account-for-rta-option-while-brute-forcing

### DIFF
--- a/web/src/pages/Cases/CaseDetails/Voting/Classic/Reveal.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/Classic/Reveal.tsx
@@ -98,7 +98,7 @@ const Reveal: React.FC<IReveal> = ({ arbitrable, voteIDs, setIsOpen, commit, isR
           <StyledButton
             variant="secondary"
             text="Justify & Reveal"
-            disabled={isSending}
+            disabled={isSending || isUndefined(disputeDetails)}
             isLoading={isSending}
             onClick={handleReveal}
           />
@@ -126,6 +126,8 @@ const getSaltAndChoice = async (
       })();
   if (isUndefined(rawSalt)) return;
   const salt = keccak256(rawSalt);
+
+  answers.unshift({ title: "Refuse To Arbitrate", description: "Refuse To Arbitrate" });
   const { choice } = answers.reduce<{ found: boolean; choice: number }>(
     (acc, _, i) => {
       if (acc.found) return acc;


### PR DESCRIPTION
Fixes `Justify&Reveal` vote failing

<img width="409" alt="Screenshot 2024-02-06 at 22 08 00" src="https://github.com/kleros/kleros-v2/assets/51452848/73c3cf6e-ae15-46dc-bd9b-3a20e0129b06">

### Source of error :
When voting, option 0 is for `Refuse to Arbitrate`, so the length of answers is (`i + 1`).
But when brute forcing this was not being taken into account, and the length of answers array was `i` only.
So if someone voted the last option (`i + 1`), the `getSaltAndChoice` function would return `-1 `, thus leading to the error.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated the `disabled` prop of the `Button` component to include an additional condition `isUndefined(disputeDetails)`
- Added a new answer option with the title "Refuse To Arbitrate" and description "Refuse To Arbitrate" to the `answers` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->