### PR TITLE
Core: support for more generic rewards calculations (future-proofing)

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -77,6 +77,8 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
         uint256 round; // The round to execute.
         uint256 coherentCount; // The number of coherent votes in the round.
         uint256 numberOfVotesInRound; // The number of votes in the round.
+        uint256 feePerJurorInRound; // The fee per juror in the round.
+        uint256 pnkAtStakePerJurorInRound; // The amount of PNKs at stake for each juror in the round.
         uint256 pnkPenaltiesInRound; // The amount of PNKs collected from penalties in the round.
         uint256 repartition; // The index of the repartition to execute.
     }
@@ -507,7 +509,7 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
         dispute.lastPeriodChange = block.timestamp;
 
         IDisputeKit disputeKit = disputeKits[disputeKitID];
-        Court storage court = courts[dispute.courtID];
+        Court storage court = courts[courtID];
         Round storage round = dispute.rounds.push();
 
         // Obtain the feeForJuror in the same currency as the _feeAmount
@@ -667,18 +669,26 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
     /// @param _round The appeal round.
     /// @param _iterations The number of iterations to run.
     function execute(uint256 _disputeID, uint256 _round, uint256 _iterations) external {
-        Dispute storage dispute = disputes[_disputeID];
-        if (dispute.period != Period.execution) revert NotExecutionPeriod();
+        Round storage round;
+        {
+            Dispute storage dispute = disputes[_disputeID];
+            if (dispute.period != Period.execution) revert NotExecutionPeriod();
 
-        Round storage round = dispute.rounds[_round];
-        IDisputeKit disputeKit = disputeKits[round.disputeKitID];
+            round = dispute.rounds[_round];
+        } // stack too deep workaround
 
         uint256 start = round.repartitions;
         uint256 end = round.repartitions + _iterations;
 
-        uint256 pnkPenaltiesInRoundCache = round.pnkPenalties; // For saving gas.
+        uint256 pnkPenaltiesInRound = round.pnkPenalties; // Keep in memory to save gas.
         uint256 numberOfVotesInRound = round.drawnJurors.length;
-        uint256 coherentCount = disputeKit.getCoherentCount(_disputeID, _round); // Total number of jurors that are eligible to a reward in this round.
+        uint256 feePerJurorInRound = round.totalFeesForJurors / numberOfVotesInRound;
+        uint256 pnkAtStakePerJurorInRound = round.pnkAtStakePerJuror;
+        uint256 coherentCount;
+        {
+            IDisputeKit disputeKit = disputeKits[round.disputeKitID];
+            coherentCount = disputeKit.getCoherentCount(_disputeID, _round); // Total number of jurors that are eligible to a reward in this round.
+        } // stack too deep workaround
 
         if (coherentCount == 0) {
             // We loop over the votes once as there are no rewards because it is not a tie and no one in this round is coherent with the final outcome.
@@ -691,17 +701,35 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
 
         for (uint256 i = start; i < end; i++) {
             if (i < numberOfVotesInRound) {
-                pnkPenaltiesInRoundCache = _executePenalties(
-                    ExecuteParams(_disputeID, _round, coherentCount, numberOfVotesInRound, pnkPenaltiesInRoundCache, i)
+                pnkPenaltiesInRound = _executePenalties(
+                    ExecuteParams({
+                        disputeID: _disputeID,
+                        round: _round,
+                        coherentCount: coherentCount,
+                        numberOfVotesInRound: numberOfVotesInRound,
+                        feePerJurorInRound: feePerJurorInRound,
+                        pnkAtStakePerJurorInRound: pnkAtStakePerJurorInRound,
+                        pnkPenaltiesInRound: pnkPenaltiesInRound,
+                        repartition: i
+                    })
                 );
             } else {
                 _executeRewards(
-                    ExecuteParams(_disputeID, _round, coherentCount, numberOfVotesInRound, pnkPenaltiesInRoundCache, i)
+                    ExecuteParams({
+                        disputeID: _disputeID,
+                        round: _round,
+                        coherentCount: coherentCount,
+                        numberOfVotesInRound: numberOfVotesInRound,
+                        feePerJurorInRound: feePerJurorInRound,
+                        pnkAtStakePerJurorInRound: pnkAtStakePerJurorInRound,
+                        pnkPenaltiesInRound: pnkPenaltiesInRound,
+                        repartition: i
+                    })
                 );
             }
         }
-        if (round.pnkPenalties != pnkPenaltiesInRoundCache) {
-            round.pnkPenalties = pnkPenaltiesInRoundCache; // Reentrancy risk: breaks Check-Effect-Interact
+        if (round.pnkPenalties != pnkPenaltiesInRound) {
+            round.pnkPenalties = pnkPenaltiesInRound; // Reentrancy risk: breaks Check-Effect-Interact
         }
     }
 
@@ -717,7 +745,9 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
         uint256 degreeOfCoherence = disputeKit.getDegreeOfCoherence(
             _params.disputeID,
             _params.round,
-            _params.repartition
+            _params.repartition,
+            _params.feePerJurorInRound,
+            _params.pnkAtStakePerJurorInRound
         );
         if (degreeOfCoherence > ALPHA_DIVISOR) {
             // Make sure the degree doesn't exceed 1, though it should be ensured by the dispute kit.
@@ -780,7 +810,9 @@ contract KlerosCore is IArbitratorV2, UUPSProxiable, Initializable {
         uint256 degreeOfCoherence = disputeKit.getDegreeOfCoherence(
             _params.disputeID,
             _params.round,
-            _params.repartition % _params.numberOfVotesInRound
+            _params.repartition % _params.numberOfVotesInRound,
+            _params.feePerJurorInRound,
+            _params.pnkAtStakePerJurorInRound
         );
 
         // Make sure the degree doesn't exceed 1, though it should be ensured by the dispute kit.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -489,7 +489,9 @@ contract DisputeKitClassic is IDisputeKit, Initializable, UUPSProxiable {
     function getDegreeOfCoherence(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
-        uint256 _voteID
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
     ) external view override returns (uint256) {
         // In this contract this degree can be either 0 or 1, but in other dispute kits this value can be something in between.
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -507,7 +507,9 @@ contract DisputeKitSybilResistant is IDisputeKit, Initializable, UUPSProxiable {
     function getDegreeOfCoherence(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
-        uint256 _voteID
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
     ) external view override returns (uint256) {
         // In this contract this degree can be either 0 or 1, but in other dispute kits this value can be something in between.
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -70,11 +70,15 @@ interface IDisputeKit {
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
     /// @param _voteID The ID of the vote.
+    /// @param _feePerJuror The fee per juror.
+    /// @param _pnkAtStakePerJuror The PNK at stake per juror.
     /// @return The degree of coherence in basis points.
     function getDegreeOfCoherence(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
-        uint256 _voteID
+        uint256 _voteID,
+        uint256 _feePerJuror,
+        uint256 _pnkAtStakePerJuror
     ) external view returns (uint256);
 
     /// @dev Gets the number of jurors who are eligible to a reward in this round.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the arbitration process by introducing fee and PNK at stake per juror parameters.

### Detailed summary
- Added `_feePerJuror` and `_pnkAtStakePerJuror` parameters in `getDegreeOfCoherence` function.
- Introduced `feePerJurorInRound` and `pnkAtStakePerJurorInRound` variables in `KlerosCore`.
- Updated penalty and reward execution with new parameters.
- Enhanced coherence degree calculation with fee and PNK at stake per juror.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->