### PR TITLE
fix(web): configured ESLint "import/order"

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -97,6 +97,69 @@
         "tsx": "never"
       }
     ],
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "import/order": [
+      "warn",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "{react,styled-components}",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "@kleros/**",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "{svgs/**,assets/**}",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "{hooks/**,utils/**,consts/**,types/**,context/**,connectors/**,}",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "{queries/**,}",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "{src/**,}",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "{styles/**,}",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "{layout/**,pages/**,components/**,}",
+            "group": "internal",
+            "position": "after"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": [
+          "builtin"
+        ],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
**Overview:**
This pull request aims to enhance the ESLint configuration for the project by configuring the `"import/order"` rule. The updated configuration provides better organization and consistency in importing modules across the codebase.

**Changes Made:**

- Modified the ESLint configuration file to include specific grouping and ordering rules for imports.
- Organized imports into groups including `"builtin", "external", "internal", "parent", "sibling", and "index"` for improved readability.
- Ensured consistent usage of newlines between import groups.
- Applied alphabetization for imports within each group in ascending order, case-insensitive.

**Reasoning:**

- **Improved Readability:** By organizing imports into logical groups and enforcing consistent ordering, the codebase becomes easier to navigate and understand.
- **Consistency:** Establishing clear import guidelines ensures consistency across the project, making it easier for developers to maintain and contribute to the codebase.
- **Maintainability:** With a standardized import structure, future modifications and additions to the codebase can be executed more efficiently and with reduced risk of errors.

**Testing:**
- After making the adjustments, the ESLint configuration was retested to validate the expected import order and grouping.

**Additional Notes:**

- Feedback and suggestions for further improvements are welcome and encouraged.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `import/order` rule to the ESLint configuration for better organization and grouping of imports.

### Detailed summary
- Added `import/order` rule to organize imports based on groups and patterns
- Defines specific groups for different types of imports such as `external`, `internal`, etc.
- Specifies the order and position of import groups for better readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->