### PR TITLE
Web: update Perma Curate to Kleros Scout

### DIFF
--- a/web/src/layout/Header/navbar/DappList.tsx
+++ b/web/src/layout/Header/navbar/DappList.tsx
@@ -120,9 +120,9 @@ const ITEMS = [
     url: "https://veascan.io",
   },
   {
-    text: "Perma Curate",
+    text: "Kleros Scout",
     Icon: Curate,
-    url: "https://perma-curate.eth.limo/",
+    url: "https://klerosscout.eth.limo",
   },
   {
     text: "POH V1",


### PR DESCRIPTION
Changed "Perma Curate" in the Dapplist component to "Kleros Scout" and changed link to https://klerosscout.eth.limo

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the text and URL for the "Perma Curate" link in the DappList component to "Kleros Scout" with a new URL.

### Detailed summary
- Updated text from "Perma Curate" to "Kleros Scout"
- Updated URL from "https://perma-curate.eth.limo/" to "https://klerosscout.eth.limo"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->