### PR TITLE
fix: styling of markdown numbered list

### DIFF
--- a/web/src/styles/global-style.ts
+++ b/web/src/styles/global-style.ts
@@ -104,7 +104,7 @@ export const GlobalStyle = createGlobalStyle`
 
   }
 
-  ul {
+  ul, ol {
     li {
       color: ${({ theme }) => theme.primaryText};
     }


### PR DESCRIPTION
This PR solves [issue-47](https://github.com/kleros/ui-components-library/issues/47)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a change to the global styles by adding support for styling `ol` elements in addition to `ul` elements.

### Detailed summary
- Updated global styles to apply text color to both `ul` and `ol` elements
- Added support for styling ordered lists (`ol`) in the global styles

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->