### PR TITLE
refactor(web): Error handling logic

### DIFF
--- a/web/src/components/NumberInputField.tsx
+++ b/web/src/components/NumberInputField.tsx
@@ -35,6 +35,7 @@ interface INumberInputField extends Omit<React.ComponentProps<typeof Field>, "on
   onChange?: (value: string) => void;
   formatter?: (value: string) => string;
   className?: string;
+  min?: number;
 }
 
 export const NumberInputField: React.FC<INumberInputField> = ({
@@ -45,6 +46,7 @@ export const NumberInputField: React.FC<INumberInputField> = ({
   formatter,
   className,
   variant = "info",
+  min,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
 
@@ -61,14 +63,14 @@ export const NumberInputField: React.FC<INumberInputField> = ({
             onChange?.(event.target.value);
           }}
           onBlur={toggleEditing}
-          {...{ value, placeholder, message, variant }}
+          {...{ value, placeholder, message, variant, min }}
         />
       ) : (
         <StyledField
           type="text"
           value={formatter ? formatter(value ?? "0") : value}
           onFocus={toggleEditing}
-          {...{ placeholder, message, variant }}
+          {...{ placeholder, message, variant, min }}
           readOnly
         />
       )}

--- a/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
@@ -89,8 +89,8 @@ const InputDisplay: React.FC<IInputDisplay> = ({
   const isStaking = useMemo(() => action === ActionType.stake, [action]);
 
   useEffect(() => {
-    if (parsedAmount === 0n) {
-      setErrorMsg(undefined);
+    if (parsedAmount === 0n && balance === 0n && isStaking) {
+      setErrorMsg("You need a non-zero PNK balance to stake");
     } else if (isStaking && balance && parsedAmount > balance) {
       setErrorMsg("Insufficient balance to stake this amount");
     } else if (!isStaking && jurorBalance && parsedAmount > jurorBalance[2]) {
@@ -124,6 +124,7 @@ const InputDisplay: React.FC<IInputDisplay> = ({
             message={errorMsg ?? undefined}
             variant={!isUndefined(errorMsg) ? "error" : "info"}
             formatter={(number: string) => commify(roundNumberDown(Number(number)))}
+            min="0"
           />
           <EnsureChainContainer>
             <StakeWithdrawButton

--- a/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
@@ -68,7 +68,6 @@ const InputDisplay: React.FC<IInputDisplay> = ({
   setAmount,
 }) => {
   const [debouncedAmount, setDebouncedAmount] = useState("");
-  const [hasInteracted, setHasInteracted] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | undefined>();
   useDebounce(() => setDebouncedAmount(amount), 500, [amount]);
   const parsedAmount = useParsedAmount(uncommify(debouncedAmount) as `${number}`);
@@ -90,7 +89,7 @@ const InputDisplay: React.FC<IInputDisplay> = ({
   const isStaking = useMemo(() => action === ActionType.stake, [action]);
 
   useEffect(() => {
-    if (!hasInteracted || parsedAmount === 0n) {
+    if (parsedAmount === 0n) {
       setErrorMsg(undefined);
     } else if (isStaking && balance && parsedAmount > balance) {
       setErrorMsg("Insufficient balance to stake this amount");
@@ -99,7 +98,7 @@ const InputDisplay: React.FC<IInputDisplay> = ({
     } else {
       setErrorMsg(undefined);
     }
-  }, [hasInteracted, parsedAmount, isStaking, balance, jurorBalance]);
+  }, [parsedAmount, isStaking, balance, jurorBalance]);
 
   return (
     <>
@@ -109,7 +108,6 @@ const InputDisplay: React.FC<IInputDisplay> = ({
           onClick={() => {
             const amount = isStaking ? parsedBalance : parsedStake;
             setAmount(amount);
-            setHasInteracted(true);
           }}
         >
           {isStaking ? "Stake" : "Withdraw"} all
@@ -121,7 +119,6 @@ const InputDisplay: React.FC<IInputDisplay> = ({
             value={uncommify(amount)}
             onChange={(e) => {
               setAmount(e);
-              setHasInteracted(true);
             }}
             placeholder={isStaking ? "Amount to stake" : "Amount to withdraw"}
             message={errorMsg ?? undefined}
@@ -137,9 +134,6 @@ const InputDisplay: React.FC<IInputDisplay> = ({
                 isSending,
                 setIsSending,
                 setIsPopupOpen,
-                setErrorMsg,
-                hasInteracted,
-                setHasInteracted,
               }}
             />
           </EnsureChainContainer>

--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
@@ -114,13 +114,18 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
     }
   };
 
-  useEffect(() => {
-    if (isAllowance) {
-      setErrorMsg(allowanceError?.shortMessage);
-    } else {
-      setErrorMsg(setStakeError?.shortMessage);
-    }
-  }, [allowanceError, setStakeError, isAllowance, isStaking, setErrorMsg]);
+useEffect(() => {
+  let errorMessage = parsedAmount === 0n
+    ? "Please enter a valid amount to stake or withdraw."
+    : "There was an error processing your request. Please try again later.";
+
+  if (isAllowance && allowanceError?.shortMessage) {
+    setErrorMsg(errorMessage);
+  } else if (!isAllowance && setStakeError?.shortMessage) {
+    setErrorMsg(errorMessage);
+  }
+}, [allowanceError, setStakeError, isAllowance, isStaking, parsedAmount, setErrorMsg]);
+
 
   const buttonProps = {
     [ActionType.allowance]: {

--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
@@ -34,9 +34,6 @@ interface IActionButton {
   setIsSending: (arg0: boolean) => void;
   setAmount: (arg0: string) => void;
   setIsPopupOpen: (arg0: boolean) => void;
-  setErrorMsg: (arg0: string | undefined) => void;
-  hasInteracted: boolean;
-  setHasInteracted: (arg0: boolean) => void;
 }
 
 const StakeWithdrawButton: React.FC<IActionButton> = ({
@@ -45,7 +42,6 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
   isSending,
   setIsSending,
   setIsPopupOpen,
-  setHasInteracted,
 }) => {
   const { id } = useParams();
   const { address } = useAccount();
@@ -149,10 +145,7 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
           (targetStake !== 0n && targetStake < BigInt(courtDetails.court?.minStake)) ||
           (isStaking && !isAllowance && isUndefined(setStakeConfig.request))
         }
-        onClick={() => {
-          setHasInteracted(true);
-          onClick();
-        }}
+        onClick={onClick}
       />
     </EnsureChain>
   );


### PR DESCRIPTION
The changes in hook checks if the isAllowance flag is true. If it is, it sets an error message based on whether parsedAmount is zero or if there’s an allowanceError. If isAllowance is false, it does a similar check but for setStakeError instead.

Breakdown of the conditions:
- If parsedAmount is zero, it sets the error message to “Please enter a valid amount to stake or withdraw.”
- If there’s an allowanceError or setStakeError, it sets the error message to “There was an error processing your request. Please try again later.”

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `min` prop to the `NumberInputField` component and handle error messages in stake operations.

### Detailed summary
- Added `min` prop to `NumberInputField`
- Implemented error message handling in stake operations
- Removed unused `setErrorMsg` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->