### PR TITLE
Refactor(web): refactored svg path

### DIFF
--- a/web/src/components/CasesDisplay/index.tsx
+++ b/web/src/components/CasesDisplay/index.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import { useLocation, useNavigate } from "react-router-dom";
 
-import ArrowIcon from "assets/svgs/icons/arrow.svg";
+import ArrowIcon from "svgs/icons/arrow.svg";
 
 import { responsiveSize } from "styles/responsiveSize";
 

--- a/web/src/components/DisputeView/CardLabels/RewardsAndFundLabel.tsx
+++ b/web/src/components/DisputeView/CardLabels/RewardsAndFundLabel.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled, { useTheme } from "styled-components";
 
-import EthIcon from "assets/svgs/icons/eth.svg";
-import PnkIcon from "assets/svgs/icons/kleros.svg";
+import EthIcon from "svgs/icons/eth.svg";
+import PnkIcon from "svgs/icons/kleros.svg";
 
 import NumberDisplay from "components/NumberDisplay";
 

--- a/web/src/components/HowItWorks.tsx
+++ b/web/src/components/HowItWorks.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import BookOpenIcon from "assets/svgs/icons/book-open.svg";
+import BookOpenIcon from "svgs/icons/book-open.svg";
 
 const Container = styled.div`
   display: flex;

--- a/web/src/components/PlusMinusField.tsx
+++ b/web/src/components/PlusMinusField.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import styled, { css } from "styled-components";
 
-import Ellipse from "assets/svgs/icons/ellipse.svg";
-import Minus from "assets/svgs/icons/minus.svg";
-import Plus from "assets/svgs/icons/plus.svg";
+import Ellipse from "svgs/icons/ellipse.svg";
+import Minus from "svgs/icons/minus.svg";
+import Plus from "svgs/icons/plus.svg";
 
 const Container = styled.div`
   display: flex;

--- a/web/src/components/Popup/MiniGuides/Appeal/CrowdfundAppeal.tsx
+++ b/web/src/components/Popup/MiniGuides/Appeal/CrowdfundAppeal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import CrowdfundAppealSvg from "assets/svgs/mini-guides/appeal/crowdfund-appeal.svg";
+import CrowdfundAppealSvg from "svgs/mini-guides/appeal/crowdfund-appeal.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Appeal/PayoffSimulator.tsx
+++ b/web/src/components/Popup/MiniGuides/Appeal/PayoffSimulator.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import PayoffSimulatorSvg from "assets/svgs/mini-guides/appeal/payoff-simulator.svg";
+import PayoffSimulatorSvg from "svgs/mini-guides/appeal/payoff-simulator.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Appeal/StageOne.tsx
+++ b/web/src/components/Popup/MiniGuides/Appeal/StageOne.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import StageOneSvg from "assets/svgs/mini-guides/appeal/stage-one.svg";
+import StageOneSvg from "svgs/mini-guides/appeal/stage-one.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Appeal/StageTwo.tsx
+++ b/web/src/components/Popup/MiniGuides/Appeal/StageTwo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import StageTwoSvg from "assets/svgs/mini-guides/appeal/stage-two.svg";
+import StageTwoSvg from "svgs/mini-guides/appeal/stage-two.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Appeal/WhoWinsRewards.tsx
+++ b/web/src/components/Popup/MiniGuides/Appeal/WhoWinsRewards.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import WhoWinsRewardsSvg from "assets/svgs/mini-guides/appeal/who-wins-rewards.svg";
+import WhoWinsRewardsSvg from "svgs/mini-guides/appeal/who-wins-rewards.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/BinaryVoting/PrivateVoting.tsx
+++ b/web/src/components/Popup/MiniGuides/BinaryVoting/PrivateVoting.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import PrivateVotingSvg from "assets/svgs/mini-guides/binary-voting/private-voting.svg";
+import PrivateVotingSvg from "svgs/mini-guides/binary-voting/private-voting.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/BinaryVoting/VotingModule.tsx
+++ b/web/src/components/Popup/MiniGuides/BinaryVoting/VotingModule.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import VotingModuleSvg from "assets/svgs/mini-guides/binary-voting/voting-module.svg";
+import VotingModuleSvg from "svgs/mini-guides/binary-voting/voting-module.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/MainStructureTemplate.tsx
+++ b/web/src/components/Popup/MiniGuides/MainStructureTemplate.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, SetStateAction, useRef } from "react";
 import styled, { css } from "styled-components";
 
 import { useClickAway } from "react-use";
-import BookOpenIcon from "assets/svgs/icons/book-open.svg";
+import BookOpenIcon from "svgs/icons/book-open.svg";
 
 import { CompactPagination } from "@kleros/ui-components-library";
 

--- a/web/src/components/Popup/MiniGuides/Onboarding/HowItWorks.tsx
+++ b/web/src/components/Popup/MiniGuides/Onboarding/HowItWorks.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import HowItWorksSvg from "assets/svgs/mini-guides/onboarding/how-it-works.svg";
+import HowItWorksSvg from "svgs/mini-guides/onboarding/how-it-works.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Onboarding/PnkLogoAndTitle.tsx
+++ b/web/src/components/Popup/MiniGuides/Onboarding/PnkLogoAndTitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import PnkIcon from "assets/svgs/styled/pnk.svg";
+import PnkIcon from "svgs/styled/pnk.svg";
 
 import { responsiveSize } from "styles/responsiveSize";
 

--- a/web/src/components/Popup/MiniGuides/Onboarding/WhatDoINeed.tsx
+++ b/web/src/components/Popup/MiniGuides/Onboarding/WhatDoINeed.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import WhatDoINeedSvg from "assets/svgs/mini-guides/onboarding/what-do-i-need.svg";
+import WhatDoINeedSvg from "svgs/mini-guides/onboarding/what-do-i-need.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/RankedVoting/VotingModule.tsx
+++ b/web/src/components/Popup/MiniGuides/RankedVoting/VotingModule.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import VotingModuleSvg from "assets/svgs/mini-guides/ranked-voting/voting-module.svg";
+import VotingModuleSvg from "svgs/mini-guides/ranked-voting/voting-module.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Staking/CourtHeader.tsx
+++ b/web/src/components/Popup/MiniGuides/Staking/CourtHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import CourtHeaderSvg from "assets/svgs/mini-guides/staking/court-header.svg";
+import CourtHeaderSvg from "svgs/mini-guides/staking/court-header.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Staking/JurorRewards.tsx
+++ b/web/src/components/Popup/MiniGuides/Staking/JurorRewards.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import JurorRewardsSvg from "assets/svgs/mini-guides/staking/juror-rewards.svg";
+import JurorRewardsSvg from "svgs/mini-guides/staking/juror-rewards.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Staking/Notifications.tsx
+++ b/web/src/components/Popup/MiniGuides/Staking/Notifications.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import NotificationsSvg from "assets/svgs/mini-guides/staking/notifications.svg";
+import NotificationsSvg from "svgs/mini-guides/staking/notifications.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Popup/MiniGuides/Staking/StakingSection.tsx
+++ b/web/src/components/Popup/MiniGuides/Staking/StakingSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import StakingSectionSvg from "assets/svgs/mini-guides/staking/staking-section.svg";
+import StakingSectionSvg from "svgs/mini-guides/staking/staking-section.svg";
 
 import { StyledImage } from "../PageContentsTemplate";
 

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -5,9 +5,9 @@ import { useParams } from "react-router-dom";
 
 import { _TimelineItem1, CustomTimeline } from "@kleros/ui-components-library";
 
-import CalendarIcon from "assets/svgs/icons/calendar.svg";
-import ClosedCaseIcon from "assets/svgs/icons/check-circle-outline.svg";
-import AppealedCaseIcon from "assets/svgs/icons/close-circle.svg";
+import CalendarIcon from "svgs/icons/calendar.svg";
+import ClosedCaseIcon from "svgs/icons/check-circle-outline.svg";
+import AppealedCaseIcon from "svgs/icons/close-circle.svg";
 
 import { Periods } from "consts/periods";
 import { usePopulatedDisputeData } from "hooks/queries/usePopulatedDisputeData";

--- a/web/src/components/Verdict/FinalDecision.tsx
+++ b/web/src/components/Verdict/FinalDecision.tsx
@@ -5,7 +5,7 @@ import Skeleton from "react-loading-skeleton";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAccount } from "wagmi";
 
-import ArrowIcon from "assets/svgs/icons/arrow.svg";
+import ArrowIcon from "svgs/icons/arrow.svg";
 
 import { REFETCH_INTERVAL } from "consts/index";
 import { Periods } from "consts/periods";

--- a/web/src/components/Verdict/VerdictBanner.tsx
+++ b/web/src/components/Verdict/VerdictBanner.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import ClosedCaseIcon from "assets/svgs/icons/check-circle-outline.svg";
-import HourglassIcon from "assets/svgs/icons/hourglass.svg";
+import ClosedCaseIcon from "svgs/icons/check-circle-outline.svg";
+import HourglassIcon from "svgs/icons/hourglass.svg";
 
 import { responsiveSize } from "styles/responsiveSize";
 

--- a/web/src/pages/Cases/CaseDetails/Tabs.tsx
+++ b/web/src/pages/Cases/CaseDetails/Tabs.tsx
@@ -5,10 +5,10 @@ import { useNavigate, useLocation, useParams } from "react-router-dom";
 
 import { Tabs as TabsComponent } from "@kleros/ui-components-library";
 
-import BullhornIcon from "assets/svgs/icons/bullhorn.svg";
-import DocIcon from "assets/svgs/icons/doc.svg";
-import EyeIcon from "assets/svgs/icons/eye.svg";
-import BalanceIcon from "assets/svgs/icons/law-balance.svg";
+import BullhornIcon from "svgs/icons/bullhorn.svg";
+import DocIcon from "svgs/icons/doc.svg";
+import EyeIcon from "svgs/icons/eye.svg";
+import BalanceIcon from "svgs/icons/law-balance.svg";
 
 import { Periods } from "consts/periods";
 import { useDisputeDetailsQuery } from "hooks/queries/useDisputeDetailsQuery";

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -5,7 +5,7 @@ import Skeleton from "react-loading-skeleton";
 import { useParams } from "react-router-dom";
 import { useAccount } from "wagmi";
 
-import VoteIcon from "assets/svgs/icons/voted.svg";
+import VoteIcon from "svgs/icons/voted.svg";
 
 import { Periods } from "consts/periods";
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";

--- a/web/src/pages/Courts/CourtDetails/StakePanel/index.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
 
-import BalanceIcon from "assets/svgs/icons/balance.svg";
-import ThreePnksIcon from "assets/svgs/styled/three-pnks.svg";
+import BalanceIcon from "svgs/icons/balance.svg";
+import ThreePnksIcon from "svgs/styled/three-pnks.svg";
 
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
 

--- a/web/src/pages/Home/TopJurors/JurorCard/Rewards.tsx
+++ b/web/src/pages/Home/TopJurors/JurorCard/Rewards.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled, { css } from "styled-components";
 
-import EthIcon from "assets/svgs/icons/eth.svg";
-import PnkIcon from "assets/svgs/icons/kleros.svg";
+import EthIcon from "svgs/icons/eth.svg";
+import PnkIcon from "svgs/icons/kleros.svg";
 
 import { useUserQuery } from "hooks/queries/useUser";
 import { getFormattedRewards } from "utils/jurorRewardConfig";

--- a/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
+++ b/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
@@ -6,7 +6,7 @@ import { usePublicClient } from "wagmi";
 
 import { Button } from "@kleros/ui-components-library";
 
-import DisputeIcon from "assets/svgs/icons/dispute.svg";
+import DisputeIcon from "svgs/icons/dispute.svg";
 
 import { IDisputeTemplate, useNewDisputeContext } from "context/NewDisputeContext";
 import {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates import paths for SVG icons in multiple components to the `svgs` directory.

### Detailed summary
- Updated import paths for SVG icons to `svgs` directory in various components.
- Fixed import paths for SVG icons related to book-open, arrow, voting, dispute, and more.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->