### PR TITLE
Fix(web): lifi svgs

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
   plugins: [
     svgr({
       include: ["**/*.svg", "tsx:**/*.svg"],
+      exclude: ["../node_modules/**/*"],
     }),
     tsconfigPaths({
       ignoreConfigErrors: true,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Vite config to exclude SVG files from a specific node_modules directory.

### Detailed summary
- Exclude SVG files from a specific node_modules directory in Vite config
- Add exclusion for `../node_modules/**/*` in `svgr` configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->