### PR TITLE
Fix(web): Evidence render markdown

### DIFF
--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 
 import Identicon from "react-identicons";
+import ReactMarkdown from "react-markdown";
 
 import { Card } from "@kleros/ui-components-library";
 
@@ -119,7 +120,7 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({ evidence, sender, index }) => {
         {data ? (
           <>
             <h3>{data.name}</h3>
-            <p>{data.description}</p>
+            <ReactMarkdown>{data.description}</ReactMarkdown>
           </>
         ) : (
           <p>{evidence}</p>

--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -36,6 +36,12 @@ const Index = styled.p`
   display: inline-block;
 `;
 
+const StyledReactMarkdown = styled(ReactMarkdown)`
+  a {
+    font-size: 16px;
+  }
+`;
+
 const BottomShade = styled.div`
   background-color: ${({ theme }) => theme.lightBlue};
   display: flex;
@@ -120,7 +126,7 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({ evidence, sender, index }) => {
         {data ? (
           <>
             <h3>{data.name}</h3>
-            <ReactMarkdown>{data.description}</ReactMarkdown>
+            <StyledReactMarkdown>{data.description}</StyledReactMarkdown>
           </>
         ) : (
           <p>{evidence}</p>


### PR DESCRIPTION
closes #1589 

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to integrate `ReactMarkdown` in the `EvidenceCard` component for rendering markdown content.

### Detailed summary
- Imported `ReactMarkdown` for rendering markdown content.
- Created a styled component `StyledReactMarkdown` for customizing markdown styles.
- Replaced the plain text rendering of `data.description` with `StyledReactMarkdown` in the `EvidenceCard` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->