### PR TITLE
fix(web): disable siwe when user is not connected

### DIFF
--- a/web/src/components/EnsureAuth.tsx
+++ b/web/src/components/EnsureAuth.tsx
@@ -67,7 +67,13 @@ export const EnsureAuth: React.FC<IEnsureAuth> = ({ children, className }) => {
   return isVerified ? (
     children
   ) : (
-    <Button text="Sign In" onClick={handleSignIn} disabled={isLoading} isLoading={isLoading} {...{ className }} />
+    <Button
+      text="Sign In"
+      onClick={handleSignIn}
+      disabled={isLoading || !address}
+      isLoading={isLoading}
+      {...{ className }}
+    />
   );
 };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `EnsureAuth` component by disabling the "Sign In" button when the `address` is not available.

### Detailed summary
- Updated `EnsureAuth` component to disable the button when `address` is not available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->