### PR TITLE
Refactor: no coupling between dispute kit and sortition (WIP)

### DIFF
--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -222,24 +222,19 @@ contract DisputeKitClassic is IDisputeKit, Initializable, UUPSProxiable {
         emit DisputeCreation(_coreDisputeID, _numberOfChoices, _extraData);
     }
 
-    /// @dev Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
+    /// @dev Draws one juror. The drawn address is picked up by Kleros Core.
     /// Note: Access restricted to Kleros Core only.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core.
     /// @param _nonce Nonce of the drawing iteration.
     /// @return drawnAddress The drawn address.
-    function draw(
+    function drawOne(
         uint256 _coreDisputeID,
         uint256 _nonce
     ) external override onlyByCore notJumped(_coreDisputeID) returns (address drawnAddress) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
 
-        ISortitionModule sortitionModule = core.sortitionModule();
-        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
-        bytes32 key = bytes32(uint256(courtID)); // Get the ID of the tree.
-
-        // TODO: Handle the situation when no one has staked yet.
-        drawnAddress = sortitionModule.draw(key, _coreDisputeID, _nonce);
+        drawnAddress = core.drawOne(_coreDisputeID, _nonce);
 
         if (_postDrawCheck(_coreDisputeID, drawnAddress)) {
             round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));
@@ -604,11 +599,6 @@ contract DisputeKitClassic is IDisputeKit, Initializable, UUPSProxiable {
     /// @param _juror Chosen address.
     /// @return Whether the address can be drawn or not.
     function _postDrawCheck(uint256 _coreDisputeID, address _juror) internal view returns (bool) {
-        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
-        uint256 lockedAmountPerJuror = core
-            .getRoundInfo(_coreDisputeID, core.getNumberOfRounds(_coreDisputeID) - 1)
-            .pnkAtStakePerJuror;
-        (uint256 totalStaked, uint256 totalLocked, , ) = core.sortitionModule().getJurorBalance(_juror, courtID);
-        return totalStaked >= totalLocked + lockedAmountPerJuror;
+        return core.isJurorSolvent(_coreDisputeID, _juror);
     }
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -617,11 +617,7 @@ contract DisputeKitSybilResistant is IDisputeKit, Initializable, UUPSProxiable {
     /// @param _juror Chosen address.
     /// @return Whether the address can be drawn or not.
     function _postDrawCheck(uint256 _coreDisputeID, address _juror) internal view returns (bool) {
-        if (core.isJurorSolvent(_coreDisputeID, _juror)) {
-            return false;
-        } else {
-            return _proofOfHumanity(_juror);
-        }
+        return core.isJurorSolvent(_coreDisputeID, _juror) && _proofOfHumanity(_juror);
     }
 
     /// @dev Checks if an address belongs to the Proof of Humanity registry.

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -48,7 +48,7 @@ interface IDisputeKit {
         uint256 _nbVotes
     ) external;
 
-    /// @dev Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
+    /// @dev Draws one juror. The drawn address is picked up by Kleros Core.
     /// Note: Access restricted to Kleros Core only.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _nonce Nonce.

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -53,7 +53,7 @@ interface IDisputeKit {
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _nonce Nonce.
     /// @return drawnAddress The drawn address.
-    function draw(uint256 _coreDisputeID, uint256 _nonce) external returns (address drawnAddress);
+    function drawOne(uint256 _coreDisputeID, uint256 _nonce) external returns (address drawnAddress);
 
     // ************************************* //
     // *           Public Views            * //


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the arbitration system by renaming the `draw` function to `drawOne` for clarity and adds a new `isJurorSolvent` function for checking juror solvency.

### Detailed summary
- Renamed `draw` function to `drawOne` in `IDisputeKit.sol`, `KlerosCoreBase.sol`, `KlerosCoreUniversity.sol`, `DisputeKitClassic.sol`, and `DisputeKitSybilResistant.sol`
- Added `isJurorSolvent` function in `KlerosCoreBase.sol`, `KlerosCoreUniversity.sol`, `DisputeKitClassic.sol`, and `DisputeKitSybilResistant.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->