### PR TITLE
refactor(web): refactor-date-and-file-viewer-styles

### DIFF
--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -102,7 +102,7 @@ const DesktopText = styled.span`
   )}
 `;
 
-const Timestamp = styled.p`
+const Timestamp = styled.label`
   color: ${({ theme }) => theme.secondaryText};
 `;
 
@@ -164,7 +164,7 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({ evidence, sender, index, timest
           <Identicon size="24" string={sender} />
           <p>{shortenAddress(sender)}</p>
         </AccountContainer>
-        <Timestamp>{formatDate(Number(timestamp))}</Timestamp>
+        <Timestamp>{formatDate(Number(timestamp), true)}</Timestamp>
         {data && typeof data.fileURI !== "undefined" && (
           <StyledLink to={`attachment/?url=${getIpfsUrl(data.fileURI)}`}>
             <AttachmentIcon />

--- a/web/src/components/FileViewer/index.tsx
+++ b/web/src/components/FileViewer/index.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
   background-color: ${({ theme }) => theme.whiteBackground};
   border-radius: 3px;
   box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.06);
-  max-height: 750px;
+  max-height: 1050px;
   overflow: scroll;
 
   ${customScrollbar}

--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -20,8 +20,18 @@ export function getOneYearAgoTimestamp(): number {
   return currentTime - 31536000; // One year in seconds
 }
 
-export function formatDate(unixTimestamp: number): string {
+export function formatDate(unixTimestamp: number, withTime = false): string {
   const date = new Date(unixTimestamp * 1000);
-  const options: Intl.DateTimeFormatOptions = { month: "long", day: "2-digit", year: "numeric" };
+  const options: Intl.DateTimeFormatOptions = withTime
+    ? {
+        month: "long",
+        day: "2-digit",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        timeZone: "GMT",
+        timeZoneName: "short",
+      }
+    : { month: "long", day: "2-digit", year: "numeric" };
   return date.toLocaleDateString("en-US", options);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to increase the maximum height of a component and enhance timestamp display in an Evidence Card.

### Detailed summary
- Increased `max-height` of a component from 750px to 1050px
- Updated timestamp display in `EvidenceCard` component to include time
- Modified `formatDate` function to optionally include time in the formatted date

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->