### PR TITLE
chore: add graph api key to mappings context in real disputes

### DIFF
--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -9,6 +9,7 @@ import { populateTemplate } from "@kleros/kleros-sdk/src/dataMappings/utils/popu
 import { GENESIS_BLOCK_ARBSEPOLIA } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 import { iArbitrableV2Abi } from "hooks/contracts/generated";
+import { useEvidenceGroup } from "queries/useEvidenceGroup";
 import { debounceErrorToast } from "utils/debounceErrorToast";
 import { isUndefined } from "utils/index";
 
@@ -32,6 +33,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
   const { data: crossChainData, isError } = useIsCrossChainDispute(disputeID, arbitrableAddress);
   const isEnabled = !isUndefined(disputeID) && !isUndefined(crossChainData) && !isUndefined(arbitrableAddress);
   const { graphqlBatcher } = useGraphqlBatcher();
+  const externalDisputeID = useEvidenceGroup(disputeID, arbitrableAddress);
 
   return useQuery<DisputeDetails>({
     queryKey: [`DisputeTemplate${disputeID}${arbitrableAddress}`],
@@ -60,6 +62,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
             disputeID: disputeID,
             arbitrable: arbitrableAddress,
             graphApiKey: process.env.GRAPH_API_KEY,
+            externalDisputeID: externalDisputeID,
           };
 
           const data = dataMappings ? await executeActions(JSON.parse(dataMappings), initialContext) : {};

--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -59,6 +59,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
           const initialContext = {
             disputeID: disputeID,
             arbitrable: arbitrableAddress,
+            graphApiKey: process.env.GRAPH_API_KEY,
           };
 
           const data = dataMappings ? await executeActions(JSON.parse(dataMappings), initialContext) : {};

--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -61,7 +61,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
           const initialContext = {
             disputeID: disputeID,
             arbitrable: arbitrableAddress,
-            graphApiKey: import.meta.env.GRAPH_API_KEY,
+            graphApiKey: import.meta.env.REACT_APP_GRAPH_API_KEY,
             externalDisputeID: externalDisputeID,
           };
 

--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -33,7 +33,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
   const { data: crossChainData, isError } = useIsCrossChainDispute(disputeID, arbitrableAddress);
   const isEnabled = !isUndefined(disputeID) && !isUndefined(crossChainData) && !isUndefined(arbitrableAddress);
   const { graphqlBatcher } = useGraphqlBatcher();
-  const externalDisputeID = useEvidenceGroup(disputeID, arbitrableAddress);
+  const { data: externalDisputeID } = useEvidenceGroup(disputeID, arbitrableAddress);
 
   return useQuery<DisputeDetails>({
     queryKey: [`DisputeTemplate${disputeID}${arbitrableAddress}`],
@@ -61,7 +61,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
           const initialContext = {
             disputeID: disputeID,
             arbitrable: arbitrableAddress,
-            graphApiKey: process.env.GRAPH_API_KEY,
+            graphApiKey: import.meta.env.GRAPH_API_KEY,
             externalDisputeID: externalDisputeID,
           };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new hook `useEvidenceGroup` to fetch external dispute data in `usePopulatedDisputeData`.

### Detailed summary
- Added import for `useEvidenceGroup`
- Used `useEvidenceGroup` to fetch external dispute data
- Added `externalDisputeID` to initial context with `graphApiKey`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for fetching external dispute IDs using the `useEvidenceGroup` function in dispute-related data queries.
	- Introduced a new `graphApiKey` property for improved API integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->