### PR TITLE
fix(web): prevent app crash when decimal input is  <1 & fixed integer overflow

### DIFF
--- a/web/src/utils/commify.ts
+++ b/web/src/utils/commify.ts
@@ -1,13 +1,7 @@
 export function commify(value: string | number): string {
   const comps = String(value).split(".");
 
-  if (
-    comps.length > 2 ||
-    !comps[0].match(/^-?[0-9]*$/) ||
-    (comps[1] && !comps[1].match(/^[0-9]*$/)) ||
-    value === "." ||
-    value === "-."
-  ) {
+  if (!String(value).match(/^-?[0-9]*\.?[0-9]*$/)) {
     return "0";
   }
 

--- a/web/src/utils/commify.ts
+++ b/web/src/utils/commify.ts
@@ -8,7 +8,7 @@ export function commify(value: string | number): string {
     value === "." ||
     value === "-."
   ) {
-    return value.toString();
+    return "0";
   }
 
   // Make sure we have at least one whole digit (0 if none)


### PR DESCRIPTION
- Prevent app crashes, when we try to input ".1" (decimal no. less than 1)
- Prevent app crashes, when we try to input "3.333333333333333e+21" (the integer overflow issue)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the `commify` function in `commify.ts` by improving the validation logic for numeric values.

### Detailed summary
- Updated validation logic for numeric values in `commify.ts`
- Returns "0" if the value is not a valid number

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the handling of specific edge cases in the `commify` function. Now returns `"0"` for inputs like ".", "-.", or an empty string, ensuring consistent and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->