### PR TITLE
fix(web): show connect button when user is not connected

### DIFF
--- a/web/src/components/EnsureChain.tsx
+++ b/web/src/components/EnsureChain.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 import { DEFAULT_CHAIN } from "consts/chains";
 
@@ -12,7 +12,7 @@ interface IEnsureChain {
 }
 
 export const EnsureChain: React.FC<IEnsureChain> = ({ children, className }) => {
-  const chainId = useChainId();
+  const { chainId } = useAccount();
 
   return chainId === DEFAULT_CHAIN ? children : <ConnectWallet {...{ className }} />;
 };


### PR DESCRIPTION
<img width="750" alt="Screenshot 2024-06-25 at 15 49 21" src="https://github.com/kleros/kleros-v2/assets/32412967/a80161fc-d1bd-45a8-b2e7-0c317dba2621">

 `<EnsureChain>` in court v2 we are using
```
export const EnsureChain: React.FC<IEnsureChain> = ({ children, className }) => {
  const chainId = useChainId();

  return chainId === DEFAULT_CHAIN ? children : <ConnectWallet {...{ className }} />;
};
```
here, if user is not connected then it will show children..
I made it to show connect wallet button to be consistent with
other v2 apps which show ConnectWallet.
(below code is from Curate v2)
```
export const EnsureChain: React.FC<IEnsureChain> = ({ children, className }) => {
  const { chain } = useNetwork();

  return chain && chain.id === DEFAULT_CHAIN ? children : <ConnectWallet {...{ className }} />;
};
```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to replace the usage of `useChainId` with `useAccount` in the `EnsureChain` component.

### Detailed summary
- Replaced `useChainId` with object destructuring for `chainId` from `useAccount` in `EnsureChain` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of chain ID retrieval by switching to `useAccount` hook. This change enhances the accuracy of the displayed chain ID in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->