### PR TITLE
fix(web): prevent long text overflow

### DIFF
--- a/web/src/components/DisputePreview/Alias.tsx
+++ b/web/src/components/DisputePreview/Alias.tsx
@@ -12,13 +12,18 @@ const AliasContainer = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;
+  max-width: 100%;
 `;
 
 const TextContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  max-width: 100%;
   > label {
     color: ${({ theme }) => theme.primaryText};
     font-size: 14px;
+    word-wrap: break-word;
+    max-width: 100%;
   }
 `;
 

--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -16,11 +16,13 @@ import AliasDisplay from "./Alias";
 
 const StyledH1 = styled.h1`
   margin: 0;
+  word-wrap: break-word;
 `;
 
 const QuestionAndDescription = styled.div`
   display: flex;
   flex-direction: column;
+  word-wrap: break-word;
   div:first-child p:first-of-type {
     font-size: 16px;
     font-weight: 600;
@@ -47,6 +49,9 @@ const Answer = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: ${responsiveSize(2, 8)};
+  > label {
+    max-width: 100%;
+  }
 `;
 
 const AliasesContainer = styled.div`

--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoCard.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoCard.tsx
@@ -52,6 +52,17 @@ const RestOfFieldsContainer = styled.div<{ isOverview?: boolean }>`
     `};
 `;
 
+const StyledFeild = styled(Field)`
+  max-width: 100%;
+  label {
+    &.value {
+      margin-left: 8px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+`;
+
 type IDisputeInfoCard = { fieldItems: FieldItem[] } & IDisputeInfo;
 
 const DisputeInfoCard: React.FC<IDisputeInfoCard> = ({
@@ -75,12 +86,12 @@ const DisputeInfoCard: React.FC<IDisputeInfoCard> = ({
     <Container>
       {court && courtId && isOverview && (
         <CourtBranchFieldContainer>
-          <Field icon={LawBalanceIcon} name="Court Branch" value={courtBranchValue} {...{ isOverview }} />
+          <StyledFeild icon={LawBalanceIcon} name="Court Branch" value={courtBranchValue} {...{ isOverview }} />
         </CourtBranchFieldContainer>
       )}
       <RestOfFieldsContainer {...{ isOverview }}>
         {fieldItems.map((item) =>
-          item.display ? <Field key={item.name} {...(item as IField)} {...{ isOverview }} /> : null
+          item.display ? <StyledFeild key={item.name} {...(item as IField)} {...{ isOverview }} /> : null
         )}
       </RestOfFieldsContainer>
       {showLabels ? <CardLabel disputeId={disputeID} round={round - 1} /> : null}

--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoCard.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoCard.tsx
@@ -52,7 +52,7 @@ const RestOfFieldsContainer = styled.div<{ isOverview?: boolean }>`
     `};
 `;
 
-const StyledFeild = styled(Field)`
+const StyledField = styled(Field)`
   max-width: 100%;
   label {
     &.value {
@@ -86,12 +86,12 @@ const DisputeInfoCard: React.FC<IDisputeInfoCard> = ({
     <Container>
       {court && courtId && isOverview && (
         <CourtBranchFieldContainer>
-          <StyledFeild icon={LawBalanceIcon} name="Court Branch" value={courtBranchValue} {...{ isOverview }} />
+          <StyledField icon={LawBalanceIcon} name="Court Branch" value={courtBranchValue} {...{ isOverview }} />
         </CourtBranchFieldContainer>
       )}
       <RestOfFieldsContainer {...{ isOverview }}>
         {fieldItems.map((item) =>
-          item.display ? <StyledFeild key={item.name} {...(item as IField)} {...{ isOverview }} /> : null
+          item.display ? <StyledField key={item.name} {...(item as IField)} {...{ isOverview }} /> : null
         )}
       </RestOfFieldsContainer>
       {showLabels ? <CardLabel disputeId={disputeID} round={round - 1} /> : null}

--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import styled from "styled-components";
+
 import { responsiveSize } from "styles/responsiveSize";
+
 import Field, { IField } from "components/Field";
+
 import CardLabel from "../CardLabels";
+
 import { FieldItem, IDisputeInfo } from ".";
 
 const Container = styled.div<{ isLabel?: boolean }>`
@@ -29,13 +33,23 @@ const RestOfFieldsContainer = styled.div`
 const StyledField = styled(Field)<{ style?: string }>`
   ${({ style }) => style ?? ""}
 `;
+
+const truncateText = (text, limit) => {
+  if (text.length > limit) {
+    return text.substring(0, limit) + "...";
+  }
+  return text;
+};
+
 type IDisputeInfoList = { fieldItems: FieldItem[] } & IDisputeInfo;
 const DisputeInfoList: React.FC<IDisputeInfoList> = ({ fieldItems, showLabels, disputeID, round }) => {
   return (
     <Container isLabel={showLabels}>
       <RestOfFieldsContainer>
         {fieldItems.map((item) =>
-          item.display ? <StyledField key={item.name} {...(item as IField)} displayAsList /> : null
+          item.display ? (
+            <StyledField key={item.name} {...(item as IField)} value={truncateText(item.value, 20)} displayAsList />
+          ) : null
         )}
       </RestOfFieldsContainer>
       {showLabels ? <CardLabel disputeId={disputeID} round={round - 1} isList /> : null}

--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 
 import { responsiveSize } from "styles/responsiveSize";
@@ -34,8 +34,8 @@ const StyledField = styled(Field)<{ style?: string }>`
   ${({ style }) => style ?? ""}
 `;
 
-const truncateText = (text, limit) => {
-  if (text.length > limit) {
+const truncateText = (text: string, limit: number) => {
+  if (text && text.length > limit) {
     return text.substring(0, limit) + "...";
   }
   return text;
@@ -43,15 +43,19 @@ const truncateText = (text, limit) => {
 
 type IDisputeInfoList = { fieldItems: FieldItem[] } & IDisputeInfo;
 const DisputeInfoList: React.FC<IDisputeInfoList> = ({ fieldItems, showLabels, disputeID, round }) => {
+  const FieldItems = useMemo(
+    () =>
+      fieldItems.map((item) =>
+        item.display ? (
+          <StyledField key={item.name} {...(item as IField)} value={truncateText(item.value, 20)} displayAsList />
+        ) : null
+      ),
+    [fieldItems]
+  );
+
   return (
     <Container isLabel={showLabels}>
-      <RestOfFieldsContainer>
-        {fieldItems.map((item) =>
-          item.display ? (
-            <StyledField key={item.name} {...(item as IField)} value={truncateText(item.value, 20)} displayAsList />
-          ) : null
-        )}
-      </RestOfFieldsContainer>
+      <RestOfFieldsContainer>{FieldItems}</RestOfFieldsContainer>
       {showLabels ? <CardLabel disputeId={disputeID} round={round - 1} isList /> : null}
     </Container>
   );

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -21,6 +21,7 @@ const FieldContainer = styled.div<FieldContainerProps>`
     fill: ${({ theme }) => theme.secondaryPurple};
     margin-right: 8px;
     width: 14px;
+    flex-shrink: 0;
   }
 
   .link {

--- a/web/src/pages/Cases/CaseDetails/Appeal/OptionCard.tsx
+++ b/web/src/pages/Cases/CaseDetails/Appeal/OptionCard.tsx
@@ -38,9 +38,22 @@ const TopContainer = styled.div`
   display: flex;
   justify-content: space-between;
   height: 50%;
-  .block {
-    display: block;
-  }
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: 0;
+`;
+
+const BlockLabel = styled.label`
+  display: block;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
 `;
 
 const LabelContainer = styled.div`
@@ -82,13 +95,13 @@ const OptionCard: React.FC<IOptionCard> = ({
   return (
     <StyledCard ref={ref} hover {...props}>
       <TopContainer>
-        <div>
-          <small className="block">{text}</small>
+        <TextContainer>
+          <BlockLabel>{text}</BlockLabel>
           <WinnerLabel winner={winner ? true : false}>
             <Gavel />
             Jury decision - {winner ? "Winner" : "Loser"}
           </WinnerLabel>
-        </div>
+        </TextContainer>
         {canBeSelected && <StyledRadio label="" checked={selected} />}
       </TopContainer>
       <LabelContainer>

--- a/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
@@ -45,6 +45,11 @@ const StyledTitle = styled.h1`
   margin-bottom: 0;
 `;
 
+const StyledReactMarkDown = styled(ReactMarkdown)`
+  max-width: inherit;
+  word-wrap: break-word;
+`;
+
 const VotingHistory: React.FC<{ arbitrable?: `0x${string}`; isQuestion: boolean }> = ({ arbitrable, isQuestion }) => {
   const { id } = useParams();
   const { data: votingHistory } = useVotingHistory(id);
@@ -79,9 +84,9 @@ const VotingHistory: React.FC<{ arbitrable?: `0x${string}`; isQuestion: boolean 
           {isQuestion && (
             <>
               {disputeDetails.question ? (
-                <ReactMarkdown>{disputeDetails.question}</ReactMarkdown>
+                <StyledReactMarkDown>{disputeDetails.question}</StyledReactMarkDown>
               ) : (
-                <ReactMarkdown>{isError ? RPC_ERROR : INVALID_DISPUTE_DATA_ERROR}</ReactMarkdown>
+                <StyledReactMarkDown>{isError ? RPC_ERROR : INVALID_DISPUTE_DATA_ERROR}</StyledReactMarkDown>
               )}
             </>
           )}


### PR DESCRIPTION
## Before and After

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/7b9afd1c-b37c-45ad-b02c-68a073bd144c) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/7eeeff60-53cd-471d-8ca6-ca5f49bfae12) |

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/9b3702b0-c0f2-421d-a6d4-420245e953c5) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/e7e368cf-5ef2-40c4-b13c-13927f05253f) |

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/e1812436-55e3-4553-bcf8-ccd7dc4c7f7c) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/7d789a6f-7b72-4d0c-96c2-a9b414decd42) |

## Folding Phones (samsung Z fold 5 front)
| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/dcfdd661-6549-43ec-8d0f-0ddee5616593) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/5aa22904-7880-4075-baaf-3bffac5681c3) |

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/e23f1d8d-67ef-40ea-93f4-bdab417ce139) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/e8a25bc5-ec4f-4579-af38-4fc27467d340) |

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/kleros/kleros-v2/assets/32412967/9b050702-acce-4399-b6d4-b1abcd08131b) | ![After Image](https://github.com/kleros/kleros-v2/assets/32412967/855b32ed-1669-4130-aa4b-635b1f4158e3) |

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance text wrapping and styling in various components for better readability and user experience.

### Detailed summary
- Added `flex-shrink: 0` and `max-width: 100%` to improve layout in `Field.tsx` and `DisputePreview/Alias.tsx`
- Updated text wrapping in `DisputeContext.tsx` and `OptionCard.tsx`
- Applied `max-width: 100%` and improved text truncation in `VotingHistory.tsx` and `DisputeInfoCard.tsx`
- Enhanced styling in `DisputeInfoList.tsx` for better text truncation and display as a list

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved text wrapping and layout in various components for better readability.
  - Truncated long text in DisputeInfoList to enhance display clarity.
  - Enhanced styling of voting history section for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->