### PR TITLE
fix: add externaldisputeid to query key in populate hook, remove must…

### DIFF
--- a/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
+++ b/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
@@ -4,7 +4,6 @@ import { validate } from "./DisputeDetailsValidator";
 
 export const populateTemplate = (mustacheTemplate: string, data: any): DisputeDetails => {
   const render = mustache.render(mustacheTemplate, data);
-  console.log("MUSTACHE RENDER: ", render);
   const dispute = JSON.parse(render);
 
   // TODO: the validation below is too strict, it should be fixed, disabled for now, FIXME

--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -31,12 +31,16 @@ const disputeTemplateQuery = graphql(`
 export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: `0x${string}`) => {
   const publicClient = usePublicClient();
   const { data: crossChainData, isError } = useIsCrossChainDispute(disputeID, arbitrableAddress);
-  const isEnabled = !isUndefined(disputeID) && !isUndefined(crossChainData) && !isUndefined(arbitrableAddress);
   const { graphqlBatcher } = useGraphqlBatcher();
   const { data: externalDisputeID } = useEvidenceGroup(disputeID, arbitrableAddress);
+  const isEnabled =
+    !isUndefined(disputeID) &&
+    !isUndefined(crossChainData) &&
+    !isUndefined(arbitrableAddress) &&
+    !isUndefined(externalDisputeID);
 
   return useQuery<DisputeDetails>({
-    queryKey: [`DisputeTemplate${disputeID}${arbitrableAddress}`],
+    queryKey: [`DisputeTemplate${disputeID}${arbitrableAddress}${externalDisputeID}`],
     enabled: isEnabled,
     staleTime: Infinity,
     queryFn: async () => {


### PR DESCRIPTION
…ache log

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `usePopulatedDisputeData` hook to include a new condition `externalDisputeID` for enabling query execution.

### Detailed summary
- Updated `isEnabled` condition to include `externalDisputeID`
- Updated `queryKey` in `useQuery` to include `externalDisputeID`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced dispute data querying logic to include checks for `externalDisputeID`, improving accuracy and robustness.
- **Optimization**
  - Removed unnecessary console logging when rendering templates, resulting in cleaner console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->