### PR TITLE
fix(web): update alchemy url for arbitrum mainnet

### DIFF
--- a/web/src/context/Web3Provider.tsx
+++ b/web/src/context/Web3Provider.tsx
@@ -17,7 +17,7 @@ export const alchemyApiKey = import.meta.env.ALCHEMY_API_KEY ?? "";
 const chains = ALL_CHAINS as [Chain, ...Chain[]];
 
 type AlchemyProtocol = "https" | "wss";
-type AlchemyChain = "arb-sepolia" | "eth-mainnet" | "arb";
+type AlchemyChain = "arb-sepolia" | "eth-mainnet" | "arb-mainnet";
 const alchemyURL = (protocol: AlchemyProtocol, chain: AlchemyChain) =>
   `${protocol}://${chain}.g.alchemy.com/v2/${alchemyApiKey}`;
 const alchemyTransport = (chain: AlchemyChain) =>
@@ -25,7 +25,7 @@ const alchemyTransport = (chain: AlchemyChain) =>
 
 const transports = {
   [isProductionDeployment() ? arbitrum.id : arbitrumSepolia.id]: isProductionDeployment()
-    ? alchemyTransport("arb")
+    ? alchemyTransport("arb-mainnet")
     : alchemyTransport("arb-sepolia"),
   [mainnet.id]: alchemyTransport("eth-mainnet"),
   [gnosisChiado.id]: fallback([webSocket("wss://rpc.chiadochain.net/wss"), http("https://rpc.chiadochain.net")]),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the AlchemyChain type and related functions to include a new chain option "arb-mainnet".

### Detailed summary
- Updated AlchemyChain type to include "arb-mainnet"
- Updated alchemyTransport function to use "arb-mainnet" instead of "arb"
- Updated transports object to use "arb-mainnet" instead of "arb" when in production

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated blockchain network type from "arb" to "arb-mainnet" to ensure proper production deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->