### PR TITLE
fFix(web): add refetch interval to hooks

### DIFF
--- a/web/src/hooks/queries/useClassicAppealQuery.ts
+++ b/web/src/hooks/queries/useClassicAppealQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -38,8 +39,9 @@ export const useClassicAppealQuery = (id?: string | number) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery<ClassicAppealQuery>({
-    queryKey: ["refetchOnBlock", `classicAppealQuery${id}`],
+    queryKey: [`classicAppealQuery${id}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       isEnabled
         ? await graphqlBatcher.fetch({

--- a/web/src/hooks/queries/useCourtDetails.ts
+++ b/web/src/hooks/queries/useCourtDetails.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -29,8 +30,9 @@ export const useCourtDetails = (id?: string) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery<CourtDetailsQuery>({
-    queryKey: ["refetchOnBlock", `courtDetails${id}`],
+    queryKey: [`courtDetails${id}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: courtDetailsQuery, variables: { id } }),
   });

--- a/web/src/hooks/queries/useDisputeDetailsQuery.ts
+++ b/web/src/hooks/queries/useDisputeDetailsQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -37,8 +38,9 @@ export const useDisputeDetailsQuery = (id?: string | number) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery<DisputeDetailsQuery>({
-    queryKey: ["refetchOnBlock", `disputeDetailsQuery${id}`],
+    queryKey: [`disputeDetailsQuery${id}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),

--- a/web/src/hooks/queries/useEvidences.ts
+++ b/web/src/hooks/queries/useEvidences.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -24,8 +25,9 @@ export const useEvidences = (evidenceGroup?: string) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery({
-    queryKey: ["refetchOnBlock", `evidencesQuery${evidenceGroup}`],
+    queryKey: [`evidencesQuery${evidenceGroup}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),

--- a/web/src/hooks/queries/useJurorStakeDetailsQuery.ts
+++ b/web/src/hooks/queries/useJurorStakeDetailsQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -24,8 +25,9 @@ export const useJurorStakeDetailsQuery = (userId?: string) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery<JurorStakeDetailsQuery>({
-    queryKey: ["refetchOnBlock", `jurorStakeDetails${userId}`],
+    queryKey: [`jurorStakeDetails${userId}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: jurorStakeDetailsQuery, variables: { userId } }),
   });

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -49,8 +50,9 @@ export const useVotingHistory = (disputeID?: string) => {
   const { graphqlBatcher } = useGraphqlBatcher();
 
   return useQuery<VotingHistoryQuery>({
-    queryKey: ["refetchOnBlock", `VotingHistory${disputeID}`],
+    queryKey: [`VotingHistory${disputeID}`],
     enabled: isEnabled,
+    refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
       await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: votingHistoryQuery, variables: { disputeID } }),
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `refetchInterval` to various queries in hooks to enable periodic data updates.

### Detailed summary
- Added `refetchInterval` to `useEvidences`, `useClassicAppealQuery`, `useDisputeDetailsQuery`, `useCourtDetails`, `useVotingHistory`, and `useJurorStakeDetailsQuery` hooks
- Imported `REFETCH_INTERVAL` from "consts/index"
- Used `REFETCH_INTERVAL` for the `refetchInterval` property

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented periodic refetching for data queries, ensuring more up-to-date information across various app sections.

- **Enhancements**
  - Improved data consistency by setting a standardized refetch interval for queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->