### PR TITLE
Fix(web): conditionally choose gnosis or chiado

### DIFF
--- a/web/src/consts/chains.ts
+++ b/web/src/consts/chains.ts
@@ -12,7 +12,6 @@ export const SUPPORTED_CHAINS: Record<number, Chain> = {
 
 // Read Only
 export const QUERY_CHAINS: Record<number, Chain> = {
-  [gnosisChiado.id]: gnosisChiado,
   [isProductionDeployment() ? gnosis.id : gnosisChiado.id]: isProductionDeployment() ? gnosis : gnosisChiado,
   [mainnet.id]: mainnet,
 };

--- a/web/src/consts/chains.ts
+++ b/web/src/consts/chains.ts
@@ -13,7 +13,7 @@ export const SUPPORTED_CHAINS: Record<number, Chain> = {
 // Read Only
 export const QUERY_CHAINS: Record<number, Chain> = {
   [gnosisChiado.id]: gnosisChiado,
-  [gnosis.id]: gnosis,
+  [isProductionDeployment() ? gnosis.id : gnosisChiado.id]: isProductionDeployment() ? gnosis : gnosisChiado,
   [mainnet.id]: mainnet,
 };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `QUERY_CHAINS` constant in `chains.ts` to dynamically select the chain based on the production deployment status.

### Detailed summary
- Dynamically selects the chain based on production deployment status in `QUERY_CHAINS` constant in `chains.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved chain selection functionality to dynamically choose between `gnosis` and `gnosisChiado` based on the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->