### PR TITLE
Fix: signature regex for multisig accounts

### DIFF
--- a/web/src/consts/processEnvConsts.ts
+++ b/web/src/consts/processEnvConsts.ts
@@ -17,7 +17,7 @@ export const HERMES_TELEGRAM_BOT_URL =
 export const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
 export const TELEGRAM_REGEX = /^@\w{5,32}$/;
 export const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
-export const ETH_SIGNATURE_REGEX = /^0x[a-fA-F0-9]{130}$/;
+export const ETH_SIGNATURE_REGEX = /^0x([a-fA-F0-9]{130})+$|^0x$/;
 
 export const isProductionDeployment = () => process.env.REACT_APP_DEPLOYMENT === "mainnet";
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `ETH_SIGNATURE_REGEX` regular expression to allow for multiple occurrences of a 130-character hex string or an empty string.

### Detailed summary
- Updated `ETH_SIGNATURE_REGEX` to allow for multiple occurrences of a 130-character hex string or an empty string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Ethereum signature validation to allow for optional or uninitialized signatures, enhancing flexibility in handling various cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->