### PR TITLE
feat(web): ruling-and-rewards-indicators

### DIFF
--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -12,8 +12,10 @@ const votingHistoryQuery = graphql(`
     dispute(id: $disputeID) {
       id
       createdAt
+      ruled
       rounds {
         nbVotes
+        jurorRewardsDispersed
         court {
           id
           name

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -27,6 +27,7 @@ const votingHistoryQuery = graphql(`
           }
           vote {
             ... on ClassicVote {
+              commited
               justification {
                 choice
                 reference

--- a/web/src/pages/Cases/CaseDetails/Voting/RulingAndRewardsIndicators.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/RulingAndRewardsIndicators.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+
+import CheckCircle from "svgs/icons/check-circle-outline.svg";
+import Coins from "svgs/icons/pile-coins.svg";
+
+import Label from "components/DisputeView/CardLabels/Label";
+
+const Container = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+interface IRulingAndRewardsIndicators {
+  jurorRewardsDispersed: boolean;
+  ruled: boolean;
+}
+
+const RulingAndRewardsIndicators: React.FC<IRulingAndRewardsIndicators> = ({ jurorRewardsDispersed, ruled }) => (
+  <Container>
+    {ruled ? <Label icon={CheckCircle} text="Ruling executed" color="green" /> : null}
+    {jurorRewardsDispersed ? <Label icon={Coins} text="Juror rewards distributed" color="green" /> : null}
+  </Container>
+);
+
+export default RulingAndRewardsIndicators;

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/AccordionTitle.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/AccordionTitle.tsx
@@ -42,10 +42,22 @@ const VoteStatus: React.FC<{
   choice?: string;
   period: string;
   answers: Answer[];
+  commited: boolean;
   isActiveRound: boolean;
-}> = ({ choice, period, answers, isActiveRound }) => {
+  hiddenVotes: boolean;
+}> = ({ choice, period, answers, isActiveRound, commited, hiddenVotes }) => {
+  if (hiddenVotes) {
+    if (!commited && (isActiveRound ? ["vote", "appeal", "execution"].includes(period) : true))
+      return <StyledLabel>Did not commit vote </StyledLabel>;
+
+    if (["evidence", "commit"].includes(period))
+      return <StyledLabel>{commited ? "Vote committed" : "Pending vote commitment"}</StyledLabel>;
+  }
+
+  // not voted
   if (isUndefined(choice) && (isActiveRound ? ["appeal", "execution"].includes(period) : true))
     return <StyledLabel>Did not vote</StyledLabel>;
+
   return (
     <StyledLabel>
       {isUndefined(choice) ? "Pending Vote" : <StyledSmall>{getVoteChoice(parseInt(choice), answers)}</StyledSmall>}
@@ -60,14 +72,16 @@ const AccordionTitle: React.FC<{
   period: string;
   answers: Answer[];
   isActiveRound: boolean;
-}> = ({ juror, choice, voteCount, period, answers, isActiveRound }) => {
+  commited: boolean;
+  hiddenVotes: boolean;
+}> = ({ juror, choice, voteCount, period, answers, isActiveRound, commited, hiddenVotes }) => {
   return (
     <TitleContainer>
       <AddressContainer>
         <Identicon size="20" string={juror} />
         <StyledLabel variant="secondaryText">{shortenAddress(juror)}</StyledLabel>
       </AddressContainer>
-      <VoteStatus {...{ choice, period, answers, isActiveRound }} />
+      <VoteStatus {...{ choice, period, answers, isActiveRound, commited, hiddenVotes }} />
       <StyledLabel variant="secondaryPurple">
         {voteCount} vote{voteCount > 1 && "s"}
       </StyledLabel>

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -95,9 +95,10 @@ interface IVotesAccordion {
   period: string;
   answers: Answer[];
   isActiveRound: boolean;
+  hiddenVotes: boolean;
 }
 
-const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answers, isActiveRound }) => {
+const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answers, isActiveRound, hiddenVotes }) => {
   const accordionItems = useMemo(() => {
     return drawnJurors
       .map((drawnJuror) =>
@@ -111,6 +112,8 @@ const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answer
                   period={period}
                   answers={answers}
                   isActiveRound={isActiveRound}
+                  commited={Boolean(drawnJuror.vote.commited)}
+                  hiddenVotes={hiddenVotes}
                 />
               ),
               body: (
@@ -124,7 +127,7 @@ const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answer
           : null
       )
       .filter((item) => item !== null);
-  }, [drawnJurors, period, answers, isActiveRound]);
+  }, [drawnJurors, period, answers, isActiveRound, hiddenVotes]);
 
   return (
     <>
@@ -146,6 +149,8 @@ const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answer
                   period={period}
                   answers={answers}
                   isActiveRound={isActiveRound}
+                  hiddenVotes={hiddenVotes}
+                  commited={Boolean(drawnJuror.vote?.commited)}
                 />
               </StyledCard>
             )

--- a/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
@@ -116,6 +116,7 @@ const VotingHistory: React.FC<{ arbitrable?: `0x${string}`; isQuestion: boolean 
             period={disputeData?.dispute?.period}
             answers={answers}
             isActiveRound={localRounds?.length - 1 === currentTab}
+            hiddenVotes={Boolean(disputeData?.dispute?.court.hiddenVotes)}
           />
         </>
       ) : (

--- a/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotingHistory.tsx
@@ -22,6 +22,7 @@ import HowItWorks from "components/HowItWorks";
 import BinaryVoting from "components/Popup/MiniGuides/BinaryVoting";
 
 import PendingVotesBox from "./PendingVotesBox";
+import RulingAndRewardsIndicators from "./RulingAndRewardsIndicators";
 import VotesAccordion from "./VotesDetails";
 
 const Container = styled.div``;
@@ -29,6 +30,7 @@ const Container = styled.div``;
 const StyledTabs = styled(Tabs)`
   width: 100%;
   margin-bottom: 16px;
+  margin-top: 48px;
 `;
 
 const Header = styled.div`
@@ -69,6 +71,8 @@ const VotingHistory: React.FC<{ arbitrable?: `0x${string}`; isQuestion: boolean 
     [votingHistory, currentTab]
   );
 
+  const jurorRewardsDispersed = useMemo(() => Boolean(rounds?.every((round) => round.jurorRewardsDispersed)), [rounds]);
+
   return (
     <Container>
       <Header>
@@ -90,6 +94,10 @@ const VotingHistory: React.FC<{ arbitrable?: `0x${string}`; isQuestion: boolean 
               )}
             </>
           )}
+          <RulingAndRewardsIndicators
+            ruled={Boolean(disputeData?.dispute?.ruled)}
+            jurorRewardsDispersed={jurorRewardsDispersed}
+          />
           <StyledTabs
             currentValue={currentTab}
             items={rounds.map((_, i) => ({


### PR DESCRIPTION
- Adds indicators for `Ruling executed` and `Juror rewards dispersed` in Voting Tab.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add new indicators in the voting history UI and improve vote details visibility.

### Detailed summary
- Added `ruled` and `jurorRewardsDispersed` fields in voting history UI.
- Created `RulingAndRewardsIndicators` component.
- Updated `VotesAccordion` and related components to handle new fields.
- Improved vote details visibility with `hiddenVotes` and `commited` indicators.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced voting history with additional fields for rulings and juror rewards.
	- Introduced a new component to display indicators for rulings and rewards in the user interface.
	- Integrated new voting status indicators into the Voting History component for improved context on disputes.
	- Added support for conditional rendering of vote commitment status in voting-related components.

- **Bug Fixes**
	- Improved layout spacing in the Voting History component for better visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->