### PR TITLE
feat(web): direct-address-to-explorer-in-account-display

### DIFF
--- a/web/src/layout/Header/navbar/Menu/Settings/General.tsx
+++ b/web/src/layout/Header/navbar/Menu/Settings/General.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 
 import { useAccount, useDisconnect } from "wagmi";
@@ -67,13 +67,30 @@ const UserContainer = styled.div`
   gap: 12px;
 `;
 
+const StyledA = styled.a`
+  text-decoration: none;
+  label {
+    cursor: pointer;
+    color: ${({ theme }) => theme.primaryBlue};
+  }
+
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
 export const DisconnectWalletButton: React.FC = () => {
   const { disconnect } = useDisconnect();
   return <Button text={`Disconnect`} onClick={() => disconnect()} />;
 };
 
 const General: React.FC = () => {
-  const { address } = useAccount();
+  const { address, chain } = useAccount();
+
+  const addressExplorerLink = useMemo(() => {
+    return `${chain?.blockExplorers?.default.url}/address/${address}`;
+  }, [address, chain]);
+
   return (
     <EnsureChainContainer>
       <EnsureChain>
@@ -84,7 +101,9 @@ const General: React.FC = () => {
                 <IdenticonOrAvatar size="48" />
               </StyledAvatarContainer>
               <StyledAddressContainer>
-                <AddressOrName />
+                <StyledA href={addressExplorerLink} rel="noreferrer" target="_blank">
+                  <AddressOrName />
+                </StyledA>
               </StyledAddressContainer>
               <StyledChainContainer>
                 <ChainDisplay />


### PR DESCRIPTION
Initial idea was to make address copiable and display user balance below it, but leading it to an explorer makes more sense and address can be copied there along with other features of the explorer.

This is needed in case we ever implement WalletAsService, so users can easily click on the address and see it's balance and other stuff.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a styled link in the General settings for the user's wallet address to view on the blockchain explorer.

### Detailed summary
- Added styled link for the user's wallet address in General settings
- Created `StyledA` component with hover effect
- Added `chain` to `useAccount` and generated address explorer link
- Updated `General` component to display address with link

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Settings module with blockchain address exploration capabilities.
	- Introduced a clickable link for users to access their blockchain address on the explorer page.
  
- **User Interface Improvements**
	- Updated styles for the address link to improve interactivity and visual appeal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->