### PR TITLE
fix(web): execute-rewards-maintenance-button-logic

### DIFF
--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DistributeRewards.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DistributeRewards.tsx
@@ -52,7 +52,10 @@ const DistributeRewards: React.FC<IDistributeRewards> = ({ id, roundIndex, setIs
     const argsArr: TransactionBatcherConfig = [];
 
     for (const round of rounds) {
-      argsArr.push({ ...baseArgs, args: [BigInt(id), BigInt(round.id.split("-")[1]), BigInt(round.nbVotes)] });
+      argsArr.push({
+        ...baseArgs,
+        args: [BigInt(id), BigInt(round.id.split("-")[1]), BigInt(round.nbVotes) * BigInt(2)],
+      });
     }
 
     setContractConfigs(argsArr);


### PR DESCRIPTION
- fixes the number of iterations passed to the execute function , now we are multiplying by 2 always.
- There is no need to optimize (to not multiply by 2) since in contract the maximum value of `end` is `2*nbVotes` or `nbVotes` if coherent, so even if we pass `2*nbVotes` in case of coherent it will cap it itself to `nbVotes`. Correct me if i am wrong 🤔 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the calculation of vote rewards in the `DistributeRewards.tsx` file by multiplying the number of votes by `2` before pushing the arguments to `argsArr`.

### Detailed summary
- Updated the `argsArr.push` method to multiply `BigInt(round.nbVotes)` by `BigInt(2)`.
- Adjusted the formatting of the `argsArr.push` for improved readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the reward distribution logic to double the number of votes for each round in the rewards processing.

- **Bug Fixes**
	- Improved accuracy in the data sent for contract configurations related to reward distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->