### PR TITLE
chore(web): abstract-sortition-module-hooks-and-hide-in-university

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -22,6 +22,7 @@ dist
 .env.development.local
 .env.test.local
 .env.production.local
+.env.devnet-university
 
 # generated code
 src/hooks/contracts/generated.ts

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "build-local": "scripts/runEnv.sh local 'yarn generate && vite build'",
     "build-devnet": "scripts/runEnv.sh devnet 'yarn generate && vite build'",
     "build-devnet-neo": "scripts/runEnv.sh devnet-neo 'yarn generate && vite build'",
+    "build-devnet-university": "scripts/runEnv.sh devnet-university 'yarn generate && vite build'",
     "build-testnet": "scripts/runEnv.sh testnet 'yarn generate && vite build'",
     "build-mainnet-neo": "scripts/runEnv.sh mainnet-neo 'yarn generate && vite build'",
     "build-netlify": "scripts/generateBuildInfo.sh && yarn generate && vite build",

--- a/web/src/components/Phase.tsx
+++ b/web/src/components/Phase.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { useSortitionModulePhase } from "hooks/useSortitionModulePhase";
+import { useSortitionModulePhase } from "hooks/useSortitionModule";
 
 import { isUndefined } from "src/utils";
 

--- a/web/src/hooks/useSortitionModule.ts
+++ b/web/src/hooks/useSortitionModule.ts
@@ -1,0 +1,54 @@
+import { REFETCH_INTERVAL } from "consts/index";
+
+import { useReadSortitionModule } from "hooks/contracts/generated";
+
+export const useSortitionModulePhase = () => {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return useReadSortitionModule({ functionName: "phase", query: { refetchInterval: REFETCH_INTERVAL } });
+};
+
+export const useReadSortitionModuleDelayedStakeReadIndex = () => {
+  return useReadSortitionModule({
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "delayedStakeReadIndex",
+    query: { refetchInterval: REFETCH_INTERVAL },
+  });
+};
+
+export const useReadSortitionModuleDelayedStakeWriteIndex = () => {
+  return useReadSortitionModule({
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "delayedStakeWriteIndex",
+    query: { refetchInterval: REFETCH_INTERVAL },
+  });
+};
+
+export const useReadSortitionModuleLastPhaseChange = () => {
+  return useReadSortitionModule({
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "lastPhaseChange",
+    query: { refetchInterval: REFETCH_INTERVAL },
+  });
+};
+
+export const useReadSortitionModuleMaxDrawingTime = () => {
+  return useReadSortitionModule({
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "maxDrawingTime",
+    query: { refetchInterval: REFETCH_INTERVAL },
+  });
+};
+
+export const useReadSortitionModuleMinStakingTime = () => {
+  return useReadSortitionModule({
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "minStakingTime",
+    query: { refetchInterval: REFETCH_INTERVAL },
+  });
+};

--- a/web/src/hooks/useSortitionModulePhase.ts
+++ b/web/src/hooks/useSortitionModulePhase.ts
@@ -1,9 +1,0 @@
-import { REFETCH_INTERVAL } from "consts/index";
-
-import { useReadSortitionModule } from "hooks/contracts/generated";
-
-export const useSortitionModulePhase = () => {
-  // eslint-disable-next-line
-  // @ts-ignore
-  return useReadSortitionModule({ functionName: "phase", query: { refetchInterval: REFETCH_INTERVAL } });
-};

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DrawButton.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DrawButton.tsx
@@ -6,7 +6,7 @@ import { usePublicClient } from "wagmi";
 import { Button } from "@kleros/ui-components-library";
 
 import { useSimulateKlerosCoreDraw, useWriteKlerosCoreDraw } from "hooks/contracts/generated";
-import { useSortitionModulePhase } from "hooks/useSortitionModulePhase";
+import { useSortitionModulePhase } from "hooks/useSortitionModule";
 import { wrapWithToast } from "utils/wrapWithToast";
 
 import useDisputeMaintenanceQuery from "queries/useDisputeMaintenanceQuery";

--- a/web/src/pages/Courts/StakeMaintenanceButton/ExecuteDelayedStakeButton.tsx
+++ b/web/src/pages/Courts/StakeMaintenanceButton/ExecuteDelayedStakeButton.tsx
@@ -5,13 +5,12 @@ import { usePublicClient } from "wagmi";
 
 import { Button } from "@kleros/ui-components-library";
 
+import { useSimulateSortitionModule, useWriteSortitionModule } from "hooks/contracts/generated";
 import {
   useReadSortitionModuleDelayedStakeReadIndex,
   useReadSortitionModuleDelayedStakeWriteIndex,
-  useSimulateSortitionModuleExecuteDelayedStakes,
-  useWriteSortitionModuleExecuteDelayedStakes,
-} from "hooks/contracts/generated";
-import { useSortitionModulePhase } from "hooks/useSortitionModulePhase";
+  useSortitionModulePhase,
+} from "hooks/useSortitionModule";
 import { wrapWithToast } from "utils/wrapWithToast";
 
 import { isUndefined } from "src/utils";
@@ -42,14 +41,19 @@ const ExecuteDelayedStakeButton: React.FC<IExecuteStakeDelayedButton> = ({ setIs
     data: executeDelayedStakeConfig,
     isLoading: isLoadingConfig,
     isError,
-  } = useSimulateSortitionModuleExecuteDelayedStakes({
+  } = useSimulateSortitionModule({
     query: {
       enabled: canExecute,
     },
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "executeDelayedStakes",
+    // eslint-disable-next-line
+    // @ts-ignore
     args: [1n + (delayedStakeWriteIndex ?? 0n) - (delayedStakeReadIndex ?? 0n)],
   });
 
-  const { writeContractAsync: executeDelayedStake } = useWriteSortitionModuleExecuteDelayedStakes();
+  const { writeContractAsync: executeDelayedStake } = useWriteSortitionModule();
 
   const isLoading = useMemo(() => isLoadingConfig || isSending, [isLoadingConfig, isSending]);
   const isDisabled = useMemo(() => isError || isLoading || !canExecute, [isError, isLoading, canExecute]);

--- a/web/src/pages/Courts/StakeMaintenanceButton/PassPhaseButton.tsx
+++ b/web/src/pages/Courts/StakeMaintenanceButton/PassPhaseButton.tsx
@@ -7,13 +7,15 @@ import { Button } from "@kleros/ui-components-library";
 
 import {
   useReadSortitionModuleDisputesWithoutJurors,
+  useSimulateSortitionModule,
+  useWriteSortitionModule,
+} from "hooks/contracts/generated";
+import {
   useReadSortitionModuleLastPhaseChange,
   useReadSortitionModuleMaxDrawingTime,
   useReadSortitionModuleMinStakingTime,
-  useSimulateSortitionModulePassPhase,
-  useWriteSortitionModulePassPhase,
-} from "hooks/contracts/generated";
-import { useSortitionModulePhase } from "hooks/useSortitionModulePhase";
+  useSortitionModulePhase,
+} from "hooks/useSortitionModule";
 import { wrapWithToast } from "utils/wrapWithToast";
 
 import { isUndefined } from "src/utils";
@@ -62,13 +64,16 @@ const PassPhaseButton: React.FC<IPassPhaseButton> = ({ setIsOpen }) => {
     data: passPhaseConfig,
     isLoading: isLoadingConfig,
     isError,
-  } = useSimulateSortitionModulePassPhase({
+  } = useSimulateSortitionModule({
     query: {
       enabled: canChangePhase,
     },
+    // eslint-disable-next-line
+    // @ts-ignore
+    functionName: "passPhase",
   });
 
-  const { writeContractAsync: passPhase } = useWriteSortitionModulePassPhase();
+  const { writeContractAsync: passPhase } = useWriteSortitionModule();
 
   const isLoading = useMemo(() => isLoadingConfig || isSending, [isLoadingConfig, isSending]);
   const isDisabled = useMemo(() => isError || isLoading || !canChangePhase, [isError, isLoading, canChangePhase]);

--- a/web/src/pages/Courts/TopSearch.tsx
+++ b/web/src/pages/Courts/TopSearch.tsx
@@ -14,6 +14,7 @@ import { responsiveSize } from "styles/responsiveSize";
 import { StyledSkeleton } from "components/StyledSkeleton";
 
 import StakeMaintenanceButtons from "./StakeMaintenanceButton";
+import { isKlerosUniversity } from "src/consts";
 
 const Container = styled.div`
   width: 100%;
@@ -33,6 +34,7 @@ const TopSearch: React.FC = () => {
   const { data } = useCourtTree();
   const navigate = useNavigate();
   const items = useMemo(() => !isUndefined(data) && [rootCourtToItems(data.court)], [data]);
+  const isUniversity = isKlerosUniversity();
   return (
     <Container>
       {items ? (
@@ -44,7 +46,7 @@ const TopSearch: React.FC = () => {
       ) : (
         <StyledSkeleton width={240} height={42} />
       )}
-      <StakeMaintenanceButtons />
+      {isUniversity ? null : <StakeMaintenanceButtons />}
     </Container>
   );
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the usage of the `useSortitionModulePhase` hook, updating environment configurations, and enhancing the functionality of various components to accommodate the new `devnet-university` build. It also introduces new hooks for reading from the `SortitionModule`.

### Detailed summary
- Deleted `web/src/hooks/useSortitionModulePhase.ts`.
- Renamed `useSortitionModulePhase` hook to use the new `useSortitionModule`.
- Added new environment configuration for `devnet-university`.
- Updated various components to conditionally render based on `isKlerosUniversity`.
- Introduced new hooks for reading multiple parameters from `SortitionModule`.
- Modified button components to handle new functionality and state management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new build script for the "devnet-university" environment, enhancing build process options.
	- Conditional rendering of the `StakeMaintenanceButtons` component based on university status.

- **Bug Fixes**
	- Updated hooks in various components to improve functionality related to delayed stakes and phase management.

- **Refactor**
	- Consolidated and generalized hooks for sortition module interactions, streamlining code and enhancing maintainability.

- **Chores**
	- Updated `.gitignore` to exclude a specific development environment configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->