### PR TITLE
fix(web): error-handling-in-submit-evidence-modal

### DIFF
--- a/web/src/pages/Cases/CaseDetails/Evidence/SubmitEvidenceModal.tsx
+++ b/web/src/pages/Cases/CaseDetails/Evidence/SubmitEvidenceModal.tsx
@@ -83,8 +83,10 @@ const SubmitEvidenceModal: React.FC<{
           close();
         })
         .finally(() => setIsSending(false));
-    } catch {
+    } catch (error) {
       setIsSending(false);
+      toast.error("Failed to submit evidence.", toastOptions);
+      console.error("Error in submitEvidence:", error);
     }
   }, [publicClient, wagmiConfig, walletClient, close, evidenceGroup, file, message, setIsSending, uploadFile]);
 


### PR DESCRIPTION
closes #1718 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling in the `submitEvidence` function within the `SubmitEvidenceModal.tsx` file by providing more informative feedback when an error occurs during evidence submission.

### Detailed summary
- Changed the `catch` block to accept an `error` parameter.
- Added a `toast.error` message to notify users of the failure to submit evidence.
- Logged the error to the console for debugging purposes with `console.error`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for evidence submission, providing clearer user notifications.
	- Toast notifications now inform users of submission failures.

- **Bug Fixes**
	- Improved error reporting with descriptive messages logged to the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->