### PR TITLE
chore: change neo tag to beta

### DIFF
--- a/web/src/layout/Header/Logo.tsx
+++ b/web/src/layout/Header/Logo.tsx
@@ -35,7 +35,7 @@ const CourtBadge: React.FC = () => {
   const { text, color } = useMemo<{ text?: string; color?: keyof Theme }>(() => {
     switch (getArbitratorType()) {
       case ArbitratorTypes.neo:
-        return { text: "Neo", color: "paleCyan" };
+        return { text: "Beta", color: "paleCyan" };
       case ArbitratorTypes.university:
         return { text: "Uni", color: "limeGreen" };
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the return value for the `ArbitratorTypes.neo` case in the `getArbitratorType` function within the `Logo.tsx` file, changing the text from "Neo" to "Beta".

### Detailed summary
- Modified the return value for `ArbitratorTypes.neo` in the `getArbitratorType` function.
- Updated the returned object to have `text: "Beta"` instead of `text: "Neo"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label for the "Neo" arbitrator type to "Beta" in the CourtBadge component.
  
- **Bug Fixes**
	- Ensured consistent handling of undefined color values in the CourtBadge component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->