### PR TITLE
chore(kleros-sdk): move-viem-to-peer-dependencies

### DIFF
--- a/kleros-sdk/package.json
+++ b/kleros-sdk/package.json
@@ -39,13 +39,16 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
+    "viem": "^2.21.53",
     "vitest": "^1.6.0"
   },
   "dependencies": {
     "@reality.eth/reality-eth-lib": "^3.2.44",
     "@urql/core": "^5.0.8",
     "mustache": "^4.2.0",
-    "viem": "^2.21.48",
     "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "viem": "^2.21.53"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -117,7 +117,7 @@
     "react-toastify": "^9.1.3",
     "react-use": "^17.5.1",
     "styled-components": "^5.3.3",
-    "viem": "^2.21.48",
+    "viem": "^2.21.53",
     "wagmi": "^2.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,9 +5018,11 @@ __metadata:
     rimraf: "npm:^6.0.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.6.3"
-    viem: "npm:^2.21.48"
+    viem: "npm:^2.21.53"
     vitest: "npm:^1.6.0"
     zod: "npm:^3.23.8"
+  peerDependencies:
+    viem: ^2.21.53
   languageName: unknown
   linkType: soft
 
@@ -5260,7 +5262,7 @@ __metadata:
     react-use: "npm:^17.5.1"
     styled-components: "npm:^5.3.3"
     typescript: "npm:^5.6.3"
-    viem: "npm:^2.21.48"
+    viem: "npm:^2.21.53"
     vite: "npm:^5.4.11"
     vite-plugin-node-polyfills: "npm:^0.21.0"
     vite-plugin-svgr: "npm:^4.3.0"
@@ -34854,6 +34856,28 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/6525c7dfa679d48759d50a31751b1d608f055e4396506c4f48550b81655b75b53978bd2dbe39099ac200f549c7429261d3478810dbd63b36df6a0afd77f69931
+  languageName: node
+  linkType: hard
+
+"viem@npm:^2.21.53":
+  version: 2.21.53
+  resolution: "viem@npm:2.21.53"
+  dependencies:
+    "@noble/curves": "npm:1.6.0"
+    "@noble/hashes": "npm:1.5.0"
+    "@scure/bip32": "npm:1.5.0"
+    "@scure/bip39": "npm:1.4.0"
+    abitype: "npm:1.0.6"
+    isows: "npm:1.0.6"
+    ox: "npm:0.1.2"
+    webauthn-p256: "npm:0.0.10"
+    ws: "npm:8.18.0"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/fe41684a63b4d493b7cfb7f30451d5275c51dda196047c949710f05cf920bb22d5f3ff16375d1854797b0f0c8f5c31c0dd8720826f135e2b3040e2067d18b88f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `viem` package across multiple files, ensuring consistency in dependency management.

### Detailed summary
- Updated `viem` version from `^2.21.48` to `^2.21.53` in:
  - `web/package.json`
  - `kleros-sdk/package.json`
  - `yarn.lock`
- Added `viem` as a `peerDependency` in `kleros-sdk/package.json`.
- Updated `yarn.lock` to reflect the new version of `viem`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@kleros/kleros-sdk` package to version `2.1.8`.
	- Updated the `@kleros/kleros-v2-web` project to version `0.2.0`.

- **Bug Fixes**
	- Updated the `viem` package version to `^2.21.53` in both `kleros-sdk` and `kleros-v2-web` projects to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->