### PR TITLE
chore(kleros-sdk): remove-console-logs

### DIFF
--- a/kleros-sdk/src/dataMappings/retrieveRealityData.ts
+++ b/kleros-sdk/src/dataMappings/retrieveRealityData.ts
@@ -50,7 +50,6 @@ export const retrieveRealityData = async (realityQuestionID: string, arbitrable?
   };
 
   const questionData = await executeAction(questionMapping);
-  console.log("questionData", questionData);
 
   const templateMapping: AbiEventMapping = {
     type: "abi/event",
@@ -66,7 +65,6 @@ export const retrieveRealityData = async (realityQuestionID: string, arbitrable?
   };
 
   const templateData = await executeAction(templateMapping);
-  console.log("templateData", templateData);
 
   if (!templateData) {
     throw new NotFoundError("Template Data", "Failed to retrieve template data");
@@ -81,8 +79,6 @@ export const retrieveRealityData = async (realityQuestionID: string, arbitrable?
     templateData.questionText,
     questionData.realityQuestion
   );
-
-  console.log("populatedTemplate", populatedTemplate);
 
   let answers: RealityAnswer[] = [];
   if (populatedTemplate.type === "bool") {

--- a/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
+++ b/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
@@ -12,7 +12,6 @@ export const populateTemplate = (mustacheTemplate: string, data: any): DisputeDe
     console.error("Validation errors:", validation.error.errors, "\n\nDispute details:", `${JSON.stringify(dispute)}`);
     throw new InvalidFormatError("Invalid dispute details format");
   }
-  console.log(dispute);
 
   return dispute;
 };

--- a/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
+++ b/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
@@ -9,8 +9,7 @@ export const populateTemplate = (mustacheTemplate: string, data: any): DisputeDe
 
   const validation = DisputeDetailsSchema.safeParse(dispute);
   if (!validation.success) {
-    console.error("Validation errors:", validation.error.errors, "\n\nDispute details:", `${JSON.stringify(dispute)}`);
-    throw new InvalidFormatError("Invalid dispute details format");
+    throw validation.error;
   }
 
   return dispute;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `populateTemplate.ts` and `retrieveRealityData.ts` files by replacing console error logs with appropriate error throwing mechanisms.

### Detailed summary
- In `populateTemplate.ts`, the error thrown for validation failures is changed from a custom `InvalidFormatError` to the validation error itself.
- Removed console log statements for `dispute` and `templateData` in `retrieveRealityData.ts`.
- Removed console log for `questionData` in `retrieveRealityData.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed unnecessary console logs from the data retrieval process, improving performance and reducing clutter.
- **Refactor**
	- Streamlined the `retrieveRealityData` function while maintaining core functionality and error handling.
	- Enhanced error handling in the `populateTemplate` function by providing more specific validation error messages and removing debug output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->