### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
@@ -160,7 +160,7 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
         totalCostMultiplier = _totalCostMultiplier;
     }
 
-    /// @dev Change the the time window within which evidence submissions and removals can be contested.
+    /// @dev Change the time window within which evidence submissions and removals can be contested.
     /// Ongoing moderations will start using the latest bondTimeout available after calling moderate() again.
     /// @param _bondTimeout Multiplier of arbitration fees that must be paid as fee stake. In basis points.
     function changeBondTimeout(uint256 _bondTimeout) external onlyGovernor {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `changeBondTimeout` function in the `ModeratedEvidenceModule.sol` contract to clarify the behavior regarding the time window for contesting evidence submissions and removals.

### Detailed summary
- Updated the documentation comment for the `changeBondTimeout` function.
- Clarified that ongoing moderations will use the latest `bondTimeout` after calling `moderate()` again.
- Described the `_bondTimeout` parameter as a multiplier of arbitration fees in basis points.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved clarity of the comment for the `changeBondTimeout` function, accurately describing the time window for contesting evidence submissions and removals.

No changes were made to functionality or logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->