### PR TITLE
fix(web): fix-overlay-scroll-lock

### DIFF
--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
@@ -16,6 +16,7 @@ import {
   useWritePnkIncreaseAllowance,
 } from "hooks/contracts/generated";
 import { useCourtDetails } from "hooks/queries/useCourtDetails";
+import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
 import { usePnkData } from "hooks/usePNKData";
 import { formatETH } from "utils/format";
 import { isUndefined } from "utils/index";
@@ -55,6 +56,7 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({ amount, parsedAmount, ac
   const [isSuccess, setIsSuccess] = useState(false);
   const [popupStepsState, setPopupStepsState] = useState<Steps>();
   const controllerRef = useRef<AbortController | null>(null);
+  useLockOverlayScroll(isPopupOpen);
 
   const { data: courtDetails } = useCourtDetails(id);
   const { balance, jurorBalance, allowance, refetchAllowance } = usePnkData({ courtId: id });

--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/index.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/index.tsx
@@ -5,7 +5,6 @@ import { _TimelineItem1, CustomTimeline } from "@kleros/ui-components-library";
 
 import Close from "svgs/icons/close.svg";
 
-import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
 import { useSortitionModulePhase } from "hooks/useSortitionModule";
 
 import { landscapeStyle } from "styles/landscapeStyle";
@@ -112,7 +111,6 @@ interface IStakeWithdrawPopup {
 }
 
 const StakeWithdrawPopup: React.FC<IStakeWithdrawPopup> = ({ amount, closePopup, steps, isSuccess, action }) => {
-  useLockOverlayScroll(true);
   const { data: phase } = useSortitionModulePhase();
 
   return (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on the integration of the `useLockOverlayScroll` hook into the `StakeWithdrawButton` component while removing it from the `StakeWithdrawPopup` component. This change likely aims to manage scroll behavior more effectively during the withdrawal process.

### Detailed summary
- Removed `useLockOverlayScroll(true)` from the `StakeWithdrawPopup` component in `index.tsx`.
- Added `useLockOverlayScroll(isPopupOpen)` to the `StakeWithdrawButton` component in `StakeWithdrawButton.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added scroll locking functionality to the Stake Withdraw button, enhancing user experience by preventing background scrolling when the popup is open.
  
- **Bug Fixes**
	- Adjusted scroll behavior of the Stake Withdraw popup, allowing underlying content to scroll while the popup is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->