### PR TITLE
chore: nitpick space in v2 beta disputes

### DIFF
--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -65,16 +65,21 @@ export const DisputeContext: React.FC<IDisputeContext> = ({ disputeDetails, isRp
   return (
     <>
       <StyledH1>{isUndefined(disputeDetails) ? <StyledSkeleton /> : (disputeDetails?.title ?? errMsg)}</StyledH1>
-      {!isUndefined(disputeDetails) && (
+      {!isUndefined(disputeDetails) ? (
         <>
-          <ReactMarkdownWrapper>
-            <ReactMarkdown>{disputeDetails?.question}</ReactMarkdown>
-          </ReactMarkdownWrapper>
-          <ReactMarkdownWrapper>
-            <ReactMarkdown>{disputeDetails?.description}</ReactMarkdown>
-          </ReactMarkdownWrapper>
+          {disputeDetails?.question?.trim() ? (
+            <ReactMarkdownWrapper>
+              <ReactMarkdown>{disputeDetails.question}</ReactMarkdown>
+            </ReactMarkdownWrapper>
+          ) : null}
+          {disputeDetails?.description?.trim() ? (
+            <ReactMarkdownWrapper>
+              <ReactMarkdown>{disputeDetails.description}</ReactMarkdown>
+            </ReactMarkdownWrapper>
+          ) : null}
         </>
-      )}
+      ) : null}
+
       {isUndefined(disputeDetails?.frontendUrl) ? null : (
         <ExternalLink href={disputeDetails?.frontendUrl} target="_blank" rel="noreferrer">
           Go to arbitrable


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the rendering logic of `disputeDetails` in the `DisputeContext` component by ensuring that the `question` and `description` are only displayed if they contain trimmed content.

### Detailed summary
- Changed the conditional rendering of `disputeDetails`.
- Updated to check if `disputeDetails.question` and `disputeDetails.description` are trimmed before rendering.
- Removed unnecessary wrappers for `ReactMarkdown` when content is not present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved conditional rendering for `disputeDetails`, ensuring that question and description are only displayed when they contain non-empty content.

- **Bug Fixes**
	- Enhanced robustness of rendering logic to prevent displaying empty fragments when `disputeDetails` is undefined or contains empty fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->