### PR TITLE
fix(web): min-stake-check

### DIFF
--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
@@ -266,9 +266,10 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
     if (
       parsedAmount == 0n ||
       (action === ActionType.stake &&
-        targetStake !== 0n &&
         courtDetails &&
-        targetStake < BigInt(courtDetails?.court?.minStake))
+        jurorBalance &&
+        parsedAmount !== 0n &&
+        jurorBalance[2] + parsedAmount < BigInt(courtDetails?.court?.minStake))
     )
       return true;
     if (isAllowance) {
@@ -284,9 +285,9 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
     setStakeError,
     allowanceError,
     isAllowance,
-    targetStake,
     action,
     courtDetails,
+    jurorBalance,
   ]);
 
   const closePopup = () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the logic in the `StakeWithdrawButton` component to include checks for `jurorBalance` and modifies the conditions under which the button can be activated based on the `parsedAmount` and `courtDetails`.

### Detailed summary
- Added a check for `jurorBalance` in the condition.
- Updated the condition to ensure `parsedAmount` is not zero and that the sum of `jurorBalance[2]` and `parsedAmount` is less than the minimum stake from `courtDetails`.
- Modified the destructuring of props to include `jurorBalance`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for enabling/disabling the Stake Withdraw button based on user balance and court requirements.
- **Bug Fixes**
	- Improved error handling for the Stake Withdraw button to clarify conditions for error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->