### PR TITLE
Feat/dispute dates and hashes link

### DIFF
--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -8,9 +8,9 @@ dataSources:
     name: KlerosCore
     network: arbitrum-one
     source:
-      address: "0xCd415C03dfa85B02646C7e2977F22a480c4354F1"
+      address: "0x991d2df165670b9cac3B022f4B68D65b664222ea"
       abi: KlerosCore
-      startBlock: 190274596
+      startBlock: 272063254
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -64,9 +64,9 @@ dataSources:
     name: PolicyRegistry
     network: arbitrum-one
     source:
-      address: "0x26c1980120F1C82cF611D666CE81D2b54d018547"
+      address: "0x553dcbF6aB3aE06a1064b5200Df1B5A9fB403d3c"
       abi: PolicyRegistry
-      startBlock: 190274403
+      startBlock: 272063037
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -84,9 +84,9 @@ dataSources:
     name: DisputeKitClassic
     network: arbitrum-one
     source:
-      address: "0xb7c292cD9Fd3d20De84a71AE1caF054eEB6374A9"
+      address: "0x70B464be85A547144C72485eBa2577E5D3A45421"
       abi: DisputeKitClassic
-      startBlock: 190274518
+      startBlock: 272063168
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -119,9 +119,9 @@ dataSources:
     name: EvidenceModule
     network: arbitrum-one
     source:
-      address: "0xe62B776498F48061ef9425fCEf30F3d1370DB005"
+      address: "0x48e052B4A6dC4F30e90930F1CeaAFd83b3981EB3"
       abi: EvidenceModule
-      startBlock: 190274441
+      startBlock: 272063086
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -140,9 +140,9 @@ dataSources:
     name: SortitionModule
     network: arbitrum-one
     source:
-      address: "0x614498118850184c62f82d08261109334bFB050f"
+      address: "0x21A9402aDb818744B296e1d1BE58C804118DC03D"
       abi: SortitionModule
-      startBlock: 190274557
+      startBlock: 272063201
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -160,6 +160,7 @@ type Dispute @entity {
   disputeID: BigInt!
   court: Court!
   createdAt: BigInt
+  transactionHash: String!
   arbitrated: Arbitrable!
   period: Period!
   ruled: Boolean!
@@ -180,6 +181,8 @@ type Dispute @entity {
   arbitrableChainId:BigInt
   externalDisputeId:BigInt
   templateId:BigInt
+  rulingTimestamp:BigInt
+  rulingTransactionHash:String
 }
 
 type PeriodIndexCounter @entity {
@@ -303,6 +306,8 @@ type ClassicJustification @entity {
   choice: BigInt!
   votes: [ClassicVote!]! @derivedFrom(field: "justification")
   reference: String!
+  transactionHash: String!
+  timestamp: BigInt!
 }
 
 type ClassicEvidenceGroup implements EvidenceGroup @entity {

--- a/subgraph/core/src/DisputeKitClassic.ts
+++ b/subgraph/core/src/DisputeKitClassic.ts
@@ -66,6 +66,8 @@ export function handleVoteCast(event: VoteCast): void {
   justification.localRound = currentLocalRoundID;
   justification.choice = choice;
   justification.reference = event.params._justification;
+  justification.transactionHash = event.transaction.hash.toHexString();
+  justification.timestamp = event.block.timestamp;
   justification.save();
   const currentRulingInfo = updateCountsAndGetCurrentRuling(
     currentLocalRoundID,

--- a/subgraph/core/src/KlerosCore.ts
+++ b/subgraph/core/src/KlerosCore.ts
@@ -184,6 +184,8 @@ export function handleRuling(event: Ruling): void {
   const dispute = Dispute.load(disputeID.toString());
   if (!dispute) return;
   dispute.ruled = true;
+  dispute.rulingTransactionHash = event.transaction.hash.toHexString();
+  dispute.rulingTimestamp = event.block.timestamp;
   dispute.save();
   const court = Court.load(dispute.court);
   if (!court) return;

--- a/subgraph/core/src/entities/Dispute.ts
+++ b/subgraph/core/src/entities/Dispute.ts
@@ -21,6 +21,7 @@ export function createDisputeFromEvent(event: DisputeCreation): void {
   dispute.lastPeriodChange = event.block.timestamp;
   dispute.lastPeriodChangeBlockNumber = event.block.number;
   dispute.periodNotificationIndex = getAndIncrementPeriodCounter(dispute.period);
+  dispute.transactionHash = event.transaction.hash.toHexString();
   const court = Court.load(courtID);
   if (!court) return;
   dispute.periodDeadline = event.block.timestamp.plus(court.timesPerPeriod[0]);

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "license": "MIT",
   "scripts": {
     "update:core:arbitrum-sepolia-devnet": "./scripts/update.sh arbitrumSepoliaDevnet arbitrum-sepolia core/subgraph.yaml",

--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo } from "react";
 import styled, { css } from "styled-components";
 
-import { landscapeStyle } from "styles/landscapeStyle";
-import { responsiveSize } from "styles/responsiveSize";
-import { hoverShortTransitionTiming } from "styles/commonStyles";
-
 import Identicon from "react-identicons";
 import ReactMarkdown from "react-markdown";
 
@@ -18,6 +14,11 @@ import { getIpfsUrl } from "utils/getIpfsUrl";
 import { shortenAddress } from "utils/shortenAddress";
 
 import { type Evidence } from "src/graphql/graphql";
+import { getTxnExplorerLink } from "src/utils";
+
+import { hoverShortTransitionTiming } from "styles/commonStyles";
+import { landscapeStyle } from "styles/landscapeStyle";
+import { responsiveSize } from "styles/responsiveSize";
 
 import { ExternalLink } from "./ExternalLink";
 import { InternalLink } from "./InternalLink";
@@ -224,7 +225,7 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({
   }, [sender]);
 
   const transactionExplorerLink = useMemo(() => {
-    return `${getChain(DEFAULT_CHAIN)?.blockExplorers?.default.url}/tx/${transactionHash}`;
+    return getTxnExplorerLink(transactionHash ?? "");
   }, [transactionHash]);
 
   return (

--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -20,10 +20,6 @@ import { hoverShortTransitionTiming } from "styles/commonStyles";
 import { landscapeStyle } from "styles/landscapeStyle";
 import { responsiveSize } from "styles/responsiveSize";
 
-import { hoverShortTransitionTiming } from "styles/commonStyles";
-import { landscapeStyle } from "styles/landscapeStyle";
-import { responsiveSize } from "styles/responsiveSize";
-
 import { ExternalLink } from "./ExternalLink";
 import { InternalLink } from "./InternalLink";
 

--- a/web/src/components/TxnHash.tsx
+++ b/web/src/components/TxnHash.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import NewTabIcon from "svgs/icons/new-tab.svg";
 
-import { DEFAULT_CHAIN, getChain } from "consts/chains";
+import { getTxnExplorerLink } from "src/utils";
 
 import { ExternalLink } from "./ExternalLink";
 
@@ -23,7 +23,7 @@ interface ITxnHash {
 }
 const TxnHash: React.FC<ITxnHash> = ({ hash, variant }) => {
   const transactionExplorerLink = useMemo(() => {
-    return `${getChain(DEFAULT_CHAIN)?.blockExplorers?.default.url}/tx/${hash}`;
+    return getTxnExplorerLink(hash);
   }, [hash]);
 
   return (

--- a/web/src/components/Verdict/DisputeTimeline.tsx
+++ b/web/src/components/Verdict/DisputeTimeline.tsx
@@ -8,12 +8,12 @@ import { _TimelineItem1, CustomTimeline } from "@kleros/ui-components-library";
 
 import CalendarIcon from "svgs/icons/calendar.svg";
 import ClosedCaseIcon from "svgs/icons/check-circle-outline.svg";
+import NewTabIcon from "svgs/icons/new-tab.svg";
 
 import { Periods } from "consts/periods";
 import { usePopulatedDisputeData } from "hooks/queries/usePopulatedDisputeData";
 import { getLocalRounds } from "utils/getLocalRounds";
 import { getVoteChoice } from "utils/getVoteChoice";
-import { shortenTxnHash } from "utils/shortenAddress";
 
 import { DisputeDetailsQuery, useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
 import { useVotingHistory } from "queries/useVotingHistory";
@@ -55,13 +55,15 @@ const StyledCalendarIcon = styled(CalendarIcon)`
   height: 14px;
 `;
 
-const LinkContainer = styled.div`
-  display: flex;
-  gap: 4px;
-  align-items: center;
-  span {
-    font-size: 14px;
-    color: ${({ theme }) => theme.primaryText};
+const StyledNewTabIcon = styled(NewTabIcon)`
+  margin-bottom: 2px;
+  path {
+    fill: ${({ theme }) => theme.primaryBlue};
+  }
+  :hover {
+    path {
+      fill: ${({ theme }) => theme.secondaryBlue};
+    }
   }
 `;
 
@@ -138,16 +140,9 @@ const useItems = (disputeDetails?: DisputeDetailsQuery, arbitrable?: `0x${string
           {
             title: "Dispute created",
             party: (
-              <LinkContainer>
-                <span>at</span>
-                <ExternalLink to={txnExplorerLink} rel="noopener noreferrer" target="_blank">
-                  {votingHistory?.dispute?.transactionHash ? (
-                    shortenTxnHash(votingHistory?.dispute?.transactionHash)
-                  ) : (
-                    <Skeleton height={16} width={56} />
-                  )}
-                </ExternalLink>
-              </LinkContainer>
+              <ExternalLink to={txnExplorerLink} rel="noopener noreferrer" target="_blank">
+                <StyledNewTabIcon />
+              </ExternalLink>
             ),
             subtitle: formatDate(votingHistory?.dispute?.createdAt),
             rightSided: true,

--- a/web/src/hooks/queries/useDisputeDetailsQuery.ts
+++ b/web/src/hooks/queries/useDisputeDetailsQuery.ts
@@ -34,6 +34,8 @@ const disputeDetailsQuery = graphql(`
       arbitrableChainId
       externalDisputeId
       templateId
+      rulingTimestamp
+      rulingTransactionHash
     }
   }
 `);

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -12,6 +12,7 @@ const votingHistoryQuery = graphql(`
     dispute(id: $disputeID) {
       id
       createdAt
+      transactionHash
       ruled
       rounds {
         nbVotes
@@ -29,6 +30,8 @@ const votingHistoryQuery = graphql(`
             ... on ClassicVote {
               commited
               justification {
+                transactionHash
+                timestamp
                 choice
                 reference
               }

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -95,6 +95,10 @@ const SecondaryTextLabel = styled.label`
   font-size: 16px;
 `;
 
+const StyledInfoCard = styled(InfoCard)`
+  margin-top: 18.5px;
+`;
+
 const AccordionContent: React.FC<{
   choice?: string;
   answers: Answer[];
@@ -172,12 +176,7 @@ const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answer
 
   return (
     <>
-      {drawnJurors.length === 0 ? (
-        <>
-          <br />
-          <InfoCard msg="Jurors have not been drawn yet." />
-        </>
-      ) : null}
+      {drawnJurors.length === 0 ? <StyledInfoCard msg="Jurors have not been drawn yet." /> : null}
       <Container>
         {accordionItems.length > 0 ? <StyledAccordion items={accordionItems} /> : null}
         {drawnJurors.map(

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -95,10 +95,6 @@ const SecondaryTextLabel = styled.label`
   font-size: 16px;
 `;
 
-const StyledExternalLink = styled(ExternalLink)`
-  font-size: 16px;
-`;
-
 const AccordionContent: React.FC<{
   choice?: string;
   answers: Answer[];
@@ -118,18 +114,16 @@ const AccordionContent: React.FC<{
           <SecondaryTextLabel>{getVoteChoice(parseInt(choice), answers)}</SecondaryTextLabel>
         </div>
       )}
-      {!isUndefined(timestamp) && (
-        <div>
-          <StyledLabel>Date:&nbsp;</StyledLabel>
-          <StyledExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
-            {formatDate(Number(timestamp), true)}
-          </StyledExternalLink>
-        </div>
-      )}
+
       {justification ? (
         <JustificationText>{justification}</JustificationText>
       ) : (
         <SecondaryTextLabel>No justification provided</SecondaryTextLabel>
+      )}
+      {!isUndefined(timestamp) && (
+        <ExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
+          {formatDate(Number(timestamp), true)}
+        </ExternalLink>
       )}
     </AccordionContentContainer>
   );

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -4,13 +4,15 @@ import styled, { css } from "styled-components";
 import { Card, CustomAccordion } from "@kleros/ui-components-library";
 
 import { Answer } from "context/NewDisputeContext";
+import { formatDate } from "utils/date";
 import { DrawnJuror } from "utils/getDrawnJurorsWithCount";
 import { getVoteChoice } from "utils/getVoteChoice";
-import { isUndefined } from "utils/index";
+import { getTxnExplorerLink, isUndefined } from "utils/index";
 
 import { hoverShortTransitionTiming } from "styles/commonStyles";
 import { landscapeStyle } from "styles/landscapeStyle";
 
+import { ExternalLink } from "components/ExternalLink";
 import InfoCard from "components/InfoCard";
 
 import AccordionTitle from "./AccordionTitle";
@@ -76,7 +78,7 @@ const AccordionContentContainer = styled.div`
 const JustificationText = styled.div`
   color: ${({ theme }) => theme.secondaryText};
   font-size: 16px;
-  line-height: 1.2;
+  line-height: 1.25;
   &:before {
     content: "Justification: ";
     color: ${({ theme }) => theme.primaryText};
@@ -97,21 +99,37 @@ const AccordionContent: React.FC<{
   choice?: string;
   answers: Answer[];
   justification: string;
-}> = ({ justification, choice, answers }) => (
-  <AccordionContentContainer>
-    {!isUndefined(choice) && (
-      <div>
-        <StyledLabel>Voted:&nbsp;</StyledLabel>
-        <SecondaryTextLabel>{getVoteChoice(parseInt(choice), answers)}</SecondaryTextLabel>
-      </div>
-    )}
-    {justification ? (
-      <JustificationText>{justification}</JustificationText>
-    ) : (
-      <SecondaryTextLabel>No justification provided</SecondaryTextLabel>
-    )}
-  </AccordionContentContainer>
-);
+  timestamp?: string;
+  transactionHash?: string;
+}> = ({ justification, choice, answers, timestamp, transactionHash }) => {
+  const transactionExplorerLink = useMemo(() => {
+    return getTxnExplorerLink(transactionHash ?? "");
+  }, [transactionHash]);
+
+  return (
+    <AccordionContentContainer>
+      {!isUndefined(choice) && (
+        <div>
+          <StyledLabel>Voted:&nbsp;</StyledLabel>
+          <SecondaryTextLabel>{getVoteChoice(parseInt(choice), answers)}</SecondaryTextLabel>
+        </div>
+      )}
+      {!isUndefined(timestamp) && (
+        <div>
+          <StyledLabel>Date:&nbsp;</StyledLabel>
+          <ExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
+            {formatDate(Number(timestamp), true)}
+          </ExternalLink>
+        </div>
+      )}
+      {justification ? (
+        <JustificationText>{justification}</JustificationText>
+      ) : (
+        <SecondaryTextLabel>No justification provided</SecondaryTextLabel>
+      )}
+    </AccordionContentContainer>
+  );
+};
 
 interface IVotesAccordion {
   drawnJurors: DrawnJuror[];
@@ -144,6 +162,8 @@ const VotesAccordion: React.FC<IVotesAccordion> = ({ drawnJurors, period, answer
                   justification={drawnJuror?.vote?.justification.reference ?? ""}
                   choice={drawnJuror.vote?.justification?.choice}
                   answers={answers}
+                  transactionHash={drawnJuror.transactionHash}
+                  timestamp={drawnJuror.timestamp}
                 />
               ),
             }

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -75,21 +75,20 @@ const AccordionContentContainer = styled.div`
   gap: 12px;
 `;
 
-const LabelWrapper = styled.div`
-  display: flex;
-  gap: 4px;
-`;
-
-const JustificationText = styled.label`
+const VotedText = styled.label`
   color: ${({ theme }) => theme.secondaryText};
   font-size: 16px;
-  line-height: 1.25;
-  flex: 1;
+  ::before {
+    content: "Voted: ";
+    color: ${({ theme }) => theme.primaryText};
+  }
 `;
 
-const StyledLabel = styled.label`
-  color: ${({ theme }) => theme.primaryText};
-  font-size: 16px;
+const JustificationText = styled(VotedText)`
+  line-height: 1.25;
+  ::before {
+    content: "Justification: ";
+  }
 `;
 
 const SecondaryTextLabel = styled.label`
@@ -115,18 +114,10 @@ const AccordionContent: React.FC<{
 
   return (
     <AccordionContentContainer>
-      {!isUndefined(choice) && (
-        <LabelWrapper>
-          <StyledLabel>Voted:&nbsp;</StyledLabel>
-          <SecondaryTextLabel dir="auto">{getVoteChoice(parseInt(choice), answers)}</SecondaryTextLabel>
-        </LabelWrapper>
-      )}
+      {!isUndefined(choice) && <VotedText dir="auto">{getVoteChoice(parseInt(choice), answers)}</VotedText>}
 
       {justification ? (
-        <LabelWrapper>
-          <StyledLabel>Justification:&nbsp;</StyledLabel>
-          <JustificationText dir="auto">{justification}</JustificationText>
-        </LabelWrapper>
+        <JustificationText dir="auto">{justification}</JustificationText>
       ) : (
         <SecondaryTextLabel>No justification provided</SecondaryTextLabel>
       )}

--- a/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/VotesDetails/index.tsx
@@ -95,6 +95,10 @@ const SecondaryTextLabel = styled.label`
   font-size: 16px;
 `;
 
+const StyledExternalLink = styled(ExternalLink)`
+  font-size: 16px;
+`;
+
 const AccordionContent: React.FC<{
   choice?: string;
   answers: Answer[];
@@ -117,9 +121,9 @@ const AccordionContent: React.FC<{
       {!isUndefined(timestamp) && (
         <div>
           <StyledLabel>Date:&nbsp;</StyledLabel>
-          <ExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
+          <StyledExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
             {formatDate(Number(timestamp), true)}
-          </ExternalLink>
+          </StyledExternalLink>
         </div>
       )}
       {justification ? (

--- a/web/src/utils/getDrawnJurorsWithCount.ts
+++ b/web/src/utils/getDrawnJurorsWithCount.ts
@@ -1,19 +1,26 @@
 import { VotingHistoryQuery } from "src/graphql/graphql";
 
 type IVotingHistoryRounds = NonNullable<NonNullable<VotingHistoryQuery["dispute"]>["rounds"][number]["drawnJurors"]>;
-export type DrawnJuror = IVotingHistoryRounds[number] & { voteCount: number };
+export type DrawnJuror = IVotingHistoryRounds[number] & {
+  voteCount: number;
+  transactionHash?: string;
+  timestamp?: string;
+};
 
 export const getDrawnJurorsWithCount = (drawnJurors: IVotingHistoryRounds) =>
   drawnJurors?.reduce<DrawnJuror[]>((acc, current) => {
     const jurorId = current.juror.id;
 
     const existingJuror = acc.find((item) => item.juror.id === jurorId);
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     existingJuror
       ? existingJuror.voteCount++
       : acc.push({
           juror: { id: jurorId },
           voteCount: 1,
           vote: current.vote,
+          transactionHash: current.vote?.justification?.transactionHash,
+          timestamp: current.vote?.justification?.timestamp,
         });
     return acc;
   }, []);

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CHAIN, getChain } from "consts/chains";
+
 export const isUndefined = (maybeObject: any): maybeObject is undefined | null =>
   typeof maybeObject === "undefined" || maybeObject === null;
 
@@ -5,3 +7,6 @@ export const isUndefined = (maybeObject: any): maybeObject is undefined | null =
  * Checks if a string is empty or contains only whitespace.
  */
 export const isEmpty = (str: string): boolean => str.trim() === "";
+
+export const getTxnExplorerLink = (hash: string) =>
+  `${getChain(DEFAULT_CHAIN)?.blockExplorers?.default.url}/tx/${hash}`;

--- a/web/src/utils/shortenAddress.ts
+++ b/web/src/utils/shortenAddress.ts
@@ -8,11 +8,3 @@ export function shortenAddress(address: string): string {
     throw new TypeError("Invalid input, address can't be parsed");
   }
 }
-
-export function shortenTxnHash(hash: string): string {
-  try {
-    return hash.substring(0, 6) + "..." + hash.substring(hash.length - 4);
-  } catch {
-    throw new TypeError("Invalid input, address can't be parsed");
-  }
-}

--- a/web/src/utils/shortenAddress.ts
+++ b/web/src/utils/shortenAddress.ts
@@ -8,3 +8,11 @@ export function shortenAddress(address: string): string {
     throw new TypeError("Invalid input, address can't be parsed");
   }
 }
+
+export function shortenTxnHash(hash: string): string {
+  try {
+    return hash.substring(0, 6) + "..." + hash.substring(hash.length - 4);
+  } catch {
+    throw new TypeError("Invalid input, address can't be parsed");
+  }
+}


### PR DESCRIPTION
- Adds txn link for dispute creation
- Adds timestamp and txn link for Vote / justification
- Adds txn link for dispute Ruling transaction

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the dispute and voting history functionalities by adding transaction-related fields and improving the user interface for displaying transaction information.

### Detailed summary
- Added `rulingTimestamp` and `rulingTransactionHash` to `Dispute` and `ClassicJustification`.
- Introduced `transactionHash` and `timestamp` to voting history and justification.
- Updated the `getTxnExplorerLink` utility for transaction links.
- Modified components to display transaction details and links.
- Updated subgraph version in `package.json` to `0.10.1`.
- Adjusted various components to utilize new transaction data and improve UI interactions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced dispute and justification tracking with new fields for transaction hashes and timestamps.
	- Improved transaction explorer link generation across various components.

- **Bug Fixes**
	- Updated Ethereum addresses and start blocks for several modules to ensure accurate data sourcing.

- **Documentation**
	- Updated GraphQL queries to return additional fields for disputes and voting history.

- **Chores**
	- Updated package version for `@kleros/kleros-v2-subgraph`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->