### PR TITLE
fix: fix chainid bug in refetch

### DIFF
--- a/web-devtools/src/hooks/queries/useDisputeTemplateFromId.ts
+++ b/web-devtools/src/hooks/queries/useDisputeTemplateFromId.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/isUndefined";
 
 import { graphql } from "src/graphql-generated";
@@ -29,6 +30,7 @@ export const useDisputeTemplateFromId = (templateId?: string) => {
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: disputeTemplateQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { id: templateId?.toString() },
         isDisputeTemplate: true,
       }),

--- a/web/src/components/ErrorFallback.tsx
+++ b/web/src/components/ErrorFallback.tsx
@@ -28,6 +28,7 @@ const ErrorContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
   ${landscapeStyle(
     () => css`
       flex-direction: row;
@@ -42,6 +43,7 @@ const InfoWrapper = styled.div`
   gap: 32px;
   align-items: center;
   flex: 1;
+
   ${landscapeStyle(
     () => css`
       align-items: start;

--- a/web/src/hooks/queries/useAllCasesQuery.ts
+++ b/web/src/hooks/queries/useAllCasesQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { AllCasesQuery } from "src/graphql/graphql";
@@ -21,6 +22,11 @@ export const useAllCasesQuery = () => {
   return useQuery({
     queryKey: [`allCasesQuery`],
     queryFn: async () =>
-      await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: allCasesQuery, variables: {} }),
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: allCasesQuery,
+        chainId: DEFAULT_CHAIN,
+        variables: {},
+      }),
   });
 };

--- a/web/src/hooks/queries/useCasesQuery.ts
+++ b/web/src/hooks/queries/useCasesQuery.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Address } from "viem";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 
 import { graphql } from "src/graphql";
@@ -77,6 +78,7 @@ export const useCasesQuery = (skip = 0, first = 3, where?: Dispute_Filter, sortO
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: isUndefined(where) ? casesQuery : casesQueryWhere,
+        chainId: DEFAULT_CHAIN,
         variables: {
           first,
           skip,
@@ -98,6 +100,7 @@ export const useMyCasesQuery = (user?: Address, skip = 0, where?: Dispute_Filter
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: isUndefined(where) ? myCasesQuery : myCasesQueryWhere,
+        chainId: DEFAULT_CHAIN,
         variables: {
           skip,
           id: user?.toLowerCase(),

--- a/web/src/hooks/queries/useClassicAppealQuery.ts
+++ b/web/src/hooks/queries/useClassicAppealQuery.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { ClassicAppealQuery } from "src/graphql/graphql";
@@ -49,6 +50,7 @@ export const useClassicAppealQuery = (id?: string | number) => {
         ? await graphqlBatcher.fetch({
             id: crypto.randomUUID(),
             document: classicAppealQuery,
+            chainId: DEFAULT_CHAIN,
             variables: {
               disputeID: id?.toString(),
               orderBy: "timestamp",

--- a/web/src/hooks/queries/useCounter.ts
+++ b/web/src/hooks/queries/useCounter.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { CounterQuery } from "src/graphql/graphql";
@@ -28,6 +29,12 @@ export const useCounterQuery = () => {
 
   return useQuery<CounterQuery>({
     queryKey: [`useCounterQuery`],
-    queryFn: async () => await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: counterQuery, variables: {} }),
+    queryFn: async () =>
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: counterQuery,
+        chainId: DEFAULT_CHAIN,
+        variables: {},
+      }),
   });
 };

--- a/web/src/hooks/queries/useCourtDetails.ts
+++ b/web/src/hooks/queries/useCourtDetails.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -37,6 +38,11 @@ export const useCourtDetails = (id?: string) => {
     enabled: isEnabled,
     refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
-      await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: courtDetailsQuery, variables: { id } }),
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: courtDetailsQuery,
+        chainId: DEFAULT_CHAIN,
+        variables: { id },
+      }),
   });
 };

--- a/web/src/hooks/queries/useCourtPolicyURI.ts
+++ b/web/src/hooks/queries/useCourtPolicyURI.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 
 import { graphql } from "src/graphql";
@@ -29,6 +30,7 @@ export const useCourtPolicyURI = (id?: string | number) => {
         ? await graphqlBatcher.fetch({
             id: crypto.randomUUID(),
             document: courtPolicyURIQuery,
+            chainId: DEFAULT_CHAIN,
             variables: { courtID: id.toString() },
           })
         : undefined,

--- a/web/src/hooks/queries/useCourtTree.ts
+++ b/web/src/hooks/queries/useCourtTree.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { CourtTreeQuery } from "src/graphql/graphql";
@@ -40,7 +41,12 @@ export const useCourtTree = () => {
   return useQuery<CourtTreeQuery>({
     queryKey: ["courtTreeQuery"],
     queryFn: async () =>
-      await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: courtTreeQuery, variables: {} }),
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: courtTreeQuery,
+        chainId: DEFAULT_CHAIN,
+        variables: {},
+      }),
   });
 };
 

--- a/web/src/hooks/queries/useDisputeDetailsQuery.ts
+++ b/web/src/hooks/queries/useDisputeDetailsQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -50,6 +51,7 @@ export const useDisputeDetailsQuery = (id?: string | number) => {
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: disputeDetailsQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { disputeID: id?.toString() },
       }),
   });

--- a/web/src/hooks/queries/useDisputeMaintenanceQuery.ts
+++ b/web/src/hooks/queries/useDisputeMaintenanceQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { DisputeMaintenanceQuery } from "src/graphql/graphql";
@@ -44,6 +45,7 @@ const useDisputeMaintenanceQuery = (id?: string) => {
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: disputeMaintenance,
+        chainId: DEFAULT_CHAIN,
         variables: { disputeId: id?.toString(), disputeIdAsString: id?.toString() },
       }),
   });

--- a/web/src/hooks/queries/useDisputeTemplateFromId.ts
+++ b/web/src/hooks/queries/useDisputeTemplateFromId.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 
 import { graphql } from "src/graphql";
@@ -29,6 +30,7 @@ export const useDisputeTemplateFromId = (templateId?: string) => {
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: disputeTemplateQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { id: templateId?.toString() },
         isDisputeTemplate: true,
       }),

--- a/web/src/hooks/queries/useDrawQuery.ts
+++ b/web/src/hooks/queries/useDrawQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 
 import { graphql } from "src/graphql";
 import { DrawQuery } from "src/graphql/graphql";
@@ -31,6 +32,7 @@ export const useDrawQuery = (address?: string | null, disputeID?: string, roundI
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: drawQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { address, disputeID, roundID },
       }),
   });

--- a/web/src/hooks/queries/useEvidences.ts
+++ b/web/src/hooks/queries/useEvidences.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 import { transformSearch } from "utils/transformSearch";
 
@@ -56,6 +57,7 @@ export const useEvidences = (evidenceGroup?: string, keywords?: string) => {
       const result = await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: document,
+        chainId: DEFAULT_CHAIN,
         variables: { evidenceGroupID: evidenceGroup?.toString(), keywords: transformedKeywords },
       });
 

--- a/web/src/hooks/queries/useHomePageBlockQuery.ts
+++ b/web/src/hooks/queries/useHomePageBlockQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 
 import { graphql } from "src/graphql";
@@ -72,6 +73,7 @@ export const useHomePageBlockQuery = (blockNumber: number | undefined, allTime: 
       const data = await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: homePageBlockQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { blockNumber: targetBlock },
       });
 

--- a/web/src/hooks/queries/useHomePageQuery.ts
+++ b/web/src/hooks/queries/useHomePageQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -40,6 +41,7 @@ export const useHomePageQuery = (timeframe: number) => {
       const data = await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: homePageQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { timeframe: timeframe.toString() },
       });
       return data;

--- a/web/src/hooks/queries/useJurorStakeDetailsQuery.ts
+++ b/web/src/hooks/queries/useJurorStakeDetailsQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -30,6 +31,11 @@ export const useJurorStakeDetailsQuery = (userId?: string) => {
     enabled: isEnabled,
     refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
-      await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: jurorStakeDetailsQuery, variables: { userId } }),
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: jurorStakeDetailsQuery,
+        chainId: DEFAULT_CHAIN,
+        variables: { userId },
+      }),
   });
 };

--- a/web/src/hooks/queries/useLabelInfoQuery.ts
+++ b/web/src/hooks/queries/useLabelInfoQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -49,6 +50,7 @@ export const useLabelInfoQuery = (address?: string | null, disputeID?: string) =
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: labelQuery,
+        chainId: DEFAULT_CHAIN,
         variables: { address, disputeID },
       }),
   });

--- a/web/src/hooks/queries/useTopUsersByCoherenceScore.ts
+++ b/web/src/hooks/queries/useTopUsersByCoherenceScore.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 
 import { graphql } from "src/graphql";
@@ -32,6 +33,7 @@ export const useTopUsersByCoherenceScore = (first = 5) => {
         ? await graphqlBatcher.fetch({
             id: crypto.randomUUID(),
             document: topUsersByCoherenceScoreQuery,
+            chainId: DEFAULT_CHAIN,
             variables: {
               first: first,
               orderBy: "coherenceScore",

--- a/web/src/hooks/queries/useUser.ts
+++ b/web/src/hooks/queries/useUser.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Address } from "viem";
 
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -62,6 +63,7 @@ export const useUserQuery = (address?: Address, where?: Dispute_Filter) => {
       await graphqlBatcher.fetch({
         id: crypto.randomUUID(),
         document: query,
+        chainId: DEFAULT_CHAIN,
         variables: { address: address?.toLowerCase(), where },
       }),
   });

--- a/web/src/hooks/queries/useVotingHistory.ts
+++ b/web/src/hooks/queries/useVotingHistory.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { REFETCH_INTERVAL } from "consts/index";
+import { DEFAULT_CHAIN } from "consts/chains";
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
 
 import { graphql } from "src/graphql";
@@ -57,6 +58,11 @@ export const useVotingHistory = (disputeID?: string) => {
     enabled: isEnabled,
     refetchInterval: REFETCH_INTERVAL,
     queryFn: async () =>
-      await graphqlBatcher.fetch({ id: crypto.randomUUID(), document: votingHistoryQuery, variables: { disputeID } }),
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        chainId: DEFAULT_CHAIN,
+        document: votingHistoryQuery,
+        variables: { disputeID },
+      }),
   });
 };

--- a/web/src/layout/Header/navbar/Menu/Settings/index.tsx
+++ b/web/src/layout/Header/navbar/Menu/Settings/index.tsx
@@ -53,6 +53,7 @@ const StyledTabs = styled(Tabs)`
   width: 86vw;
   max-width: 660px;
   align-self: center;
+
   ${landscapeStyle(
     () => css`
       width: ${responsiveSize(300, 424, 300)};

--- a/web/src/pages/GetPnk/Widget.tsx
+++ b/web/src/pages/GetPnk/Widget.tsx
@@ -16,6 +16,7 @@ const WidgetContainer = styled.div`
     }
   }
 `;
+
 const getWidgetConfig = (theme: Theme): WidgetConfig => ({
   fromChain: 1,
   toChain: 42161,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on incorporating the `DEFAULT_CHAIN` constant into various GraphQL query hooks to ensure that the correct chain ID is used when fetching data.

### Detailed summary
- Added `DEFAULT_CHAIN` import in multiple query hooks.
- Updated GraphQL fetch calls to include `chainId: DEFAULT_CHAIN` in:
  - `useLabelInfoQuery`
  - `useHomePageQuery`
  - `useUserQuery`
  - `useCourtPolicyURI`
  - `useDrawQuery`
  - `useDisputeDetailsQuery`
  - `useTopUsersByCoherenceScore`
  - `useHomePageBlockQuery`
  - `useDisputeTemplateFromId`
  - `useDisputeMaintenanceQuery`
  - `useClassicAppealQuery`
  - `useEvidences`
  - `useAllCasesQuery`
  - `useCourtTree`
  - `useCounter`
  - `useCourtDetails`
  - `useVotingHistory`
  - `useJurorStakeDetailsQuery`
  - `useCasesQuery`
  - `useMyCasesQuery`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default chain identifier in various query functions to enhance data fetching capabilities.
	- Added a new configuration function for the `LiFiWidget`, improving customization options for the widget's appearance and behavior.

- **Bug Fixes**
	- Enhanced the responsiveness of the `ErrorFallback` component for better display across different screen orientations.

- **Chores**
	- Updated multiple query hooks to include a default chain ID for improved query execution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->