### PR TITLE
chore: appeal tab improve loading

### DIFF
--- a/web/src/components/Popup/MiniGuides/PageContentsTemplate.tsx
+++ b/web/src/components/Popup/MiniGuides/PageContentsTemplate.tsx
@@ -24,6 +24,7 @@ export const LeftContentContainer = styled.div`
 
 export const StyledImage = styled.div`
   width: ${responsiveSize(260, 460)};
+
   ${landscapeStyle(
     () => css`
       width: 389px;

--- a/web/src/pages/Cases/CaseDetails/Appeal/AppealHistory.tsx
+++ b/web/src/pages/Cases/CaseDetails/Appeal/AppealHistory.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import styled from "styled-components";
 
+import Skeleton from "react-loading-skeleton";
+
 import { useOptionsContext, useFundingContext } from "hooks/useClassicAppealContext";
 
 import HowItWorks from "components/HowItWorks";
 import Appeal from "components/Popup/MiniGuides/Appeal";
 
 import OptionCard from "./OptionCard";
-
-import { AppealHeader, StyledTitle } from ".";
+import { AppealHeader, StyledTitle } from "./index";
 
 const OptionsContainer = styled.div`
   display: grid;
@@ -26,7 +27,7 @@ const AppealHistory: React.FC<IAppealHistory> = ({ isAppealMiniGuideOpen, toggle
   const options = useOptionsContext();
   const { winningChoice, paidFees, fundedChoices } = useFundingContext();
 
-  return (
+  return options && options.length > 2 ? (
     <div>
       <AppealHeader>
         <StyledTitle>Appeal Results - Last Round</StyledTitle>
@@ -37,24 +38,20 @@ const AppealHistory: React.FC<IAppealHistory> = ({ isAppealMiniGuideOpen, toggle
         />
       </AppealHeader>
       <OptionsContainer>
-        {options ? (
-          options.map((option, index) => {
-            return (
-              <OptionCard
-                key={option + index}
-                text={option}
-                winner={index.toString() === winningChoice}
-                funding={BigInt(paidFees?.[index] ?? "0")}
-                required={fundedChoices?.includes(index.toString()) ? BigInt(paidFees?.[index] ?? "0") : undefined}
-                canBeSelected={false}
-              />
-            );
-          })
-        ) : (
-          <h2>Not in appeal period</h2>
-        )}
+        {options.map((option, index) => (
+          <OptionCard
+            key={option + index}
+            text={option}
+            winner={index.toString() === winningChoice}
+            funding={BigInt(paidFees?.[index] ?? "0")}
+            required={fundedChoices?.includes(index.toString()) ? BigInt(paidFees?.[index] ?? "0") : undefined}
+            canBeSelected={false}
+          />
+        ))}
       </OptionsContainer>
     </div>
+  ) : (
+    <Skeleton />
   );
 };
 export default AppealHistory;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `AppealHistory` component by introducing a loading state with `Skeleton` and refining the rendering logic for options based on the available data.

### Detailed summary
- Added `Skeleton` from `react-loading-skeleton` for loading state.
- Changed the return statement to render `Skeleton` if `options` is not available or has 2 or fewer items.
- Simplified the mapping of `options` to `OptionCard` components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsive image styling with landscape orientation support
	- Improved loading state handling in Appeal History component using Skeleton loading placeholders

- **Bug Fixes**
	- Simplified rendering logic for Appeal History options display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->