### PR TITLE
SortitionModule upgrade to add changeGovernor()

### DIFF
--- a/contracts/deploy/upgrade-sortition-module-v0.9.0.ts
+++ b/contracts/deploy/upgrade-sortition-module-v0.9.0.ts
@@ -15,7 +15,7 @@ const deployUpgradeSortitionModule: DeployFunction = async (hre: HardhatRuntimeE
     console.log("upgrading SortitionModuleNeo...");
     await deployUpgradable(deployments, "SortitionModuleNeo", {
       newImplementation: "SortitionModuleNeo",
-      initializer: "initialize",
+      initializer: "initialize3",
       from: deployer,
       // Warning: do not reinitialize everything, only the new variables
       args: [],

--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -44,6 +44,10 @@ contract SortitionModule is SortitionModuleBase {
         __SortitionModuleBase_initialize(_governor, _core, _minStakingTime, _maxDrawingTime, _rng, _rngLookahead);
     }
 
+    function initialize3() external reinitializer(3) {
+        // NOP
+    }
+
     // ************************************* //
     // *             Governance            * //
     // ************************************* //

--- a/contracts/src/arbitration/SortitionModuleBase.sol
+++ b/contracts/src/arbitration/SortitionModuleBase.sol
@@ -152,6 +152,12 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     // *             Governance            * //
     // ************************************* //
 
+    /// @dev Changes the governor of the contract.
+    /// @param _governor The new governor.
+    function changeGovernor(address _governor) external onlyByGovernor {
+        governor = _governor;
+    }
+
     /// @dev Changes the `minStakingTime` storage variable.
     /// @param _minStakingTime The new value for the `minStakingTime` storage variable.
     function changeMinStakingTime(uint256 _minStakingTime) external onlyByGovernor {

--- a/contracts/src/arbitration/SortitionModuleNeo.sol
+++ b/contracts/src/arbitration/SortitionModuleNeo.sol
@@ -58,6 +58,10 @@ contract SortitionModuleNeo is SortitionModuleBase {
         maxTotalStaked = _maxTotalStaked;
     }
 
+    function initialize3() external reinitializer(3) {
+        // NOP
+    }
+
     // ************************************* //
     // *             Governance            * //
     // ************************************* //


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on introducing a new initialization function and updating the governor management in the `SortitionModuleBase` contract, while also changing the initializer used during deployment for the `SortitionModuleNeo`.

### Detailed summary
- Added `initialize3()` function in `SortitionModule.sol` and `SortitionModuleNeo.sol`.
- Introduced `changeGovernor(address _governor)` function in `SortitionModuleBase.sol` to change the contract's governor.
- Updated the initializer in `upgrade-sortition-module.ts` from `initialize` to `initialize3`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v0.9.0

- **New Features**
  - Added ability to change contract governor.
  - Introduced new contract initialization method (`initialize3`) for SortitionModule and SortitionModuleNeo.

- **Improvements**
  - Enhanced governance capabilities for SortitionModule contracts.

These updates provide improved contract management and flexibility for the arbitration module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->