### PR TITLE
chore(web-devtools): initialize the SDK

### DIFF
--- a/web-devtools/.gitignore
+++ b/web-devtools/.gitignore
@@ -45,3 +45,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault

--- a/web-devtools/src/context/Web3Provider.tsx
+++ b/web-devtools/src/context/Web3Provider.tsx
@@ -6,6 +6,8 @@ import { createConfig, fallback, http, WagmiProvider, webSocket } from "wagmi";
 import { mainnet, arbitrumSepolia, arbitrum, gnosisChiado, sepolia, gnosis } from "wagmi/chains";
 import { walletConnect } from "wagmi/connectors";
 
+import { configureSDK } from "@kleros/kleros-sdk/src/sdk";
+
 import { ALL_CHAINS, DEFAULT_CHAIN } from "consts/chains";
 import { isProductionDeployment } from "consts/index";
 
@@ -76,6 +78,13 @@ export const wagmiConfig = createConfig({
   chains,
   transports,
   connectors: [walletConnect({ projectId })],
+});
+
+configureSDK({
+  client: {
+    chain: isProduction ? arbitrum : arbitrumSepolia,
+    transport: transports[isProduction ? arbitrum.id : arbitrumSepolia.id],
+  },
 });
 
 createWeb3Modal({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `.gitignore` file to include environment configuration files and modifying the `Web3Provider.tsx` to integrate the `configureSDK` function from the `@kleros/kleros-sdk`, enhancing the SDK configuration based on the deployment environment.

### Detailed summary
- Updated `.gitignore` to include:
  - `*.tsbuildinfo`
  - `.env*`
  - `.flaskenv*`
  - Exclude `.env.project` and `.env.vault`
- Imported `configureSDK` from `@kleros/kleros-sdk/src/sdk`
- Configured the SDK client based on the production environment in `Web3Provider.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Updated `.gitignore` to handle environment variable files more precisely.

- **New Features**
	- Enhanced SDK integration for blockchain interactions, improving the Web3 provider setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->