### PR TITLE
refactor(web): jurors-page-scroll

### DIFF
--- a/web/src/hooks/useScrollTop.ts
+++ b/web/src/hooks/useScrollTop.ts
@@ -4,8 +4,11 @@ import { OverlayScrollContext } from "context/OverlayScrollContext";
 export const useScrollTop = () => {
   const osInstanceRef = useContext(OverlayScrollContext);
 
-  const scrollTop = () => {
-    osInstanceRef?.current?.osInstance().elements().viewport.scroll({ top: 0 });
+  const scrollTop = (smooth = false) => {
+    osInstanceRef?.current
+      ?.osInstance()
+      .elements()
+      .viewport.scroll({ top: 0, behavior: smooth ? "smooth" : "auto" });
   };
 
   return scrollTop;

--- a/web/src/pages/Jurors/DisplayJurors.tsx
+++ b/web/src/pages/Jurors/DisplayJurors.tsx
@@ -15,6 +15,7 @@ import JurorCard from "../Home/TopJurors/JurorCard";
 import { ListContainer, StyledLabel } from "../Home/TopJurors";
 import Header from "../Home/TopJurors/Header";
 import { decodeURIFilter } from "utils/uri";
+import { useScrollTop } from "hooks/useScrollTop";
 
 interface IDisplayJurors {
   totalLeaderboardJurors: number;
@@ -28,6 +29,7 @@ const StyledPagination = styled(StandardPagination)`
 
 const DisplayJurors: React.FC<IDisplayJurors> = ({ totalLeaderboardJurors }) => {
   const { page, order, filter } = useParams();
+  const scrollTop = useScrollTop();
   const { id: searchValue } = decodeURIFilter(filter ?? "all");
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
@@ -62,6 +64,7 @@ const DisplayJurors: React.FC<IDisplayJurors> = ({ totalLeaderboardJurors }) => 
   );
 
   const handlePageChange = (newPage: number) => {
+    scrollTop(true);
     navigate(`/jurors/${newPage}/${order}/${filter}`);
   };
 

--- a/web/src/pages/Jurors/DisplayJurors.tsx
+++ b/web/src/pages/Jurors/DisplayJurors.tsx
@@ -6,7 +6,6 @@ import { isUndefined } from "utils/index";
 import { StandardPagination } from "@kleros/ui-components-library";
 
 import { useJurorsByCoherenceScore } from "queries/useJurorsByCoherenceScore";
-import useIsDesktop from "hooks/useIsDesktop";
 
 import { OrderDirection } from "src/graphql/graphql";
 
@@ -32,8 +31,7 @@ const DisplayJurors: React.FC<IDisplayJurors> = ({ totalLeaderboardJurors }) => 
   const scrollTop = useScrollTop();
   const { id: searchValue } = decodeURIFilter(filter ?? "all");
   const navigate = useNavigate();
-  const isDesktop = useIsDesktop();
-  const jurorsPerPage = isDesktop ? 20 : 10;
+  const jurorsPerPage = 10;
   const currentPage = parseInt(page ?? "1");
   const jurorSkip = jurorsPerPage * (currentPage - 1);
   const { data: queryJurors } = useJurorsByCoherenceScore(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `scrollTop` functionality in the `useScrollTop` hook to support smooth scrolling and integrating this feature into the `DisplayJurors` component for improved user experience during page navigation.

### Detailed summary
- Modified `scrollTop` function in `useScrollTop` to accept a `smooth` parameter for smooth scrolling.
- Integrated `useScrollTop` into `DisplayJurors` component.
- Updated `handlePageChange` to call `scrollTop(true)` for smooth scrolling when changing pages.
- Removed unused `useIsDesktop` import and variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an option for smooth scrolling when returning to the top, offering a more fluid user experience.
	- Enhanced navigation by automatically resetting the view to the top during page transitions.
	- Simplified pagination logic in the Display Jurors component to a fixed value of 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->