### PR TITLE
fix(web): arbitraion-cost-decimals

### DIFF
--- a/web/src/pages/Resolver/Parameters/Jurors.tsx
+++ b/web/src/pages/Resolver/Parameters/Jurors.tsx
@@ -62,7 +62,7 @@ const Jurors: React.FC = () => {
     chainId: DEFAULT_CHAIN,
   });
 
-  const arbitrationFee = formatETH(data ?? BigInt(0), 5);
+  const arbitrationFee = formatETH(data ?? BigInt(0), 18);
 
   useEffect(() => setDisputeData({ ...disputeData, arbitrationCost: data?.toString() }), [data]);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `arbitrationFee` calculation in the `Jurors.tsx` file to use a precision of 18 decimal places instead of 5, ensuring more accurate representation of Ethereum values.

### Detailed summary
- Changed the precision of `arbitrationFee` from 5 to 18 decimal places in the `formatETH` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the arbitration fee display to use extended decimal precision, ensuring users view a more accurate fee value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->