### PR TITLE
fix: external link href typo

### DIFF
--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -95,7 +95,7 @@ export const DisputeContext: React.FC<IDisputeContext> = ({ disputeDetails, isRp
       ) : null}
 
       {isUndefined(disputeDetails?.frontendUrl) ? null : (
-        <ExternalLink href={disputeDetails?.frontendUrl} target="_blank" rel="noreferrer">
+        <ExternalLink to={disputeDetails?.frontendUrl} target="_blank" rel="noreferrer">
           Go to arbitrable
         </ExternalLink>
       )}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `DisputePreview` component to change the prop used for the `ExternalLink` component from `href` to `to`, which may indicate a shift in how links are handled within the application.

### Detailed summary
- Changed the `ExternalLink` prop from `href={disputeDetails?.frontendUrl}` to `to={disputeDetails?.frontendUrl}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of external links in dispute previews to ensure smooth navigation. Users clicking on dispute-related external links will now be redirected correctly to the intended resources, enhancing the overall user experience without any disruption for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->