### PR TITLE
fix(KC): remove null dk

### DIFF
--- a/contracts/scripts/simulations/tasks.ts
+++ b/contracts/scripts/simulations/tasks.ts
@@ -85,7 +85,7 @@ task("simulate:create-court", "callable by Governor only. Create a new Court")
     const hiddenVotes = false as boolean;
     const timesPerPeriod = [300, 300, 300, 300] as [BigNumberish, BigNumberish, BigNumberish, BigNumberish];
     const sortitionSumTreeK = ethers.toBeHex(3);
-    const supportedDisputeKits = [1] as BigNumberish[]; // IDs of supported dispute kits
+    const supportedDisputeKits = [0] as BigNumberish[]; // IDs of supported dispute kits
     let courtID;
     try {
       const tx = await (

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -1142,7 +1142,6 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
     error DisputeKitOnly();
     error SortitionModuleOnly();
     error UnsuccessfulCall();
-    error InvalidDisputKitParent();
     error MinStakeLowerThanParentCourt();
     error UnsupportedDisputeKit();
     error InvalidForkingCourtAsParent();

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -207,9 +207,6 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         jurorProsecutionModule = _jurorProsecutionModule;
         sortitionModule = _sortitionModuleAddress;
 
-        // NULL_DISPUTE_KIT: an empty element at index 0 to indicate when a dispute kit is not supported.
-        disputeKits.push();
-
         // DISPUTE_KIT_CLASSIC
         disputeKits.push(_disputeKit);
 
@@ -346,7 +343,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         Court storage court = courts.push();
 
         for (uint256 i = 0; i < _supportedDisputeKits.length; i++) {
-            if (_supportedDisputeKits[i] == 0 || _supportedDisputeKits[i] >= disputeKits.length) {
+            if (_supportedDisputeKits[i] >= disputeKits.length) {
                 revert WrongDisputeKitIndex();
             }
             _enableDisputeKit(uint96(courtID), _supportedDisputeKits[i], true);
@@ -422,7 +419,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
     function enableDisputeKits(uint96 _courtID, uint256[] memory _disputeKitIDs, bool _enable) external onlyByGovernor {
         for (uint256 i = 0; i < _disputeKitIDs.length; i++) {
             if (_enable) {
-                if (_disputeKitIDs[i] == 0 || _disputeKitIDs[i] >= disputeKits.length) {
+                if (_disputeKitIDs[i] >= disputeKits.length) {
                     revert WrongDisputeKitIndex();
                 }
                 _enableDisputeKit(_courtID, _disputeKitIDs[i], true);
@@ -1126,8 +1123,8 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
             if (minJurors == 0) {
                 minJurors = DEFAULT_NB_OF_JURORS;
             }
-            if (disputeKitID == NULL_DISPUTE_KIT || disputeKitID >= disputeKits.length) {
-                disputeKitID = DISPUTE_KIT_CLASSIC; // 0 index is not used.
+            if (disputeKitID >= disputeKits.length) {
+                disputeKitID = DISPUTE_KIT_CLASSIC;
             }
         } else {
             courtID = GENERAL_COURT;

--- a/contracts/src/arbitration/SortitionModuleBase.sol
+++ b/contracts/src/arbitration/SortitionModuleBase.sol
@@ -507,7 +507,7 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     /// @return The stake of the juror in the court.
     function stakeOf(bytes32 _key, bytes32 _ID) public view returns (uint256) {
         SortitionSumTree storage tree = sortitionSumTrees[_key];
-        uint treeIndex = tree.IDsToNodeIndexes[_ID];
+        uint256 treeIndex = tree.IDsToNodeIndexes[_ID];
         if (treeIndex == 0) {
             return 0;
         }

--- a/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
+++ b/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
@@ -657,9 +657,6 @@ contract KlerosCoreRuler is IArbitratorV2, UUPSProxiable, Initializable {
             if (minJurors == 0) {
                 minJurors = DEFAULT_NB_OF_JURORS;
             }
-            if (disputeKitID == NULL_DISPUTE_KIT) {
-                disputeKitID = DISPUTE_KIT_CLASSIC; // 0 index is not used.
-            }
         } else {
             courtID = GENERAL_COURT;
             minJurors = DEFAULT_NB_OF_JURORS;

--- a/contracts/src/arbitration/university/KlerosCoreUniversity.sol
+++ b/contracts/src/arbitration/university/KlerosCoreUniversity.sol
@@ -214,9 +214,6 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
         jurorProsecutionModule = _jurorProsecutionModule;
         sortitionModule = _sortitionModuleAddress;
 
-        // NULL_DISPUTE_KIT: an empty element at index 0 to indicate when a dispute kit is not supported.
-        disputeKits.push();
-
         // DISPUTE_KIT_CLASSIC
         disputeKits.push(_disputeKit);
 
@@ -341,7 +338,7 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
         Court storage court = courts.push();
 
         for (uint256 i = 0; i < _supportedDisputeKits.length; i++) {
-            if (_supportedDisputeKits[i] == 0 || _supportedDisputeKits[i] >= disputeKits.length) {
+            if (_supportedDisputeKits[i] >= disputeKits.length) {
                 revert WrongDisputeKitIndex();
             }
             court.supportedDisputeKits[_supportedDisputeKits[i]] = true;
@@ -415,7 +412,7 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
     function enableDisputeKits(uint96 _courtID, uint256[] memory _disputeKitIDs, bool _enable) external onlyByGovernor {
         for (uint256 i = 0; i < _disputeKitIDs.length; i++) {
             if (_enable) {
-                if (_disputeKitIDs[i] == 0 || _disputeKitIDs[i] >= disputeKits.length) {
+                if (_disputeKitIDs[i] >= disputeKits.length) {
                     revert WrongDisputeKitIndex();
                 }
                 _enableDisputeKit(_courtID, _disputeKitIDs[i], true);
@@ -1118,8 +1115,8 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
             if (minJurors == 0) {
                 minJurors = DEFAULT_NB_OF_JURORS;
             }
-            if (disputeKitID == NULL_DISPUTE_KIT || disputeKitID >= disputeKits.length) {
-                disputeKitID = DISPUTE_KIT_CLASSIC; // 0 index is not used.
+            if (disputeKitID >= disputeKits.length) {
+                disputeKitID = DISPUTE_KIT_CLASSIC;
             }
         } else {
             courtID = GENERAL_COURT;

--- a/contracts/src/libraries/Constants.sol
+++ b/contracts/src/libraries/Constants.sol
@@ -9,8 +9,7 @@ uint96 constant FORKING_COURT = 0; // Index of the forking court.
 uint96 constant GENERAL_COURT = 1; // Index of the default (general) court.
 
 // Dispute Kits
-uint256 constant NULL_DISPUTE_KIT = 0; // Null pattern to indicate a top-level DK which has no parent. DEPRECATED, as its main purpose was to accommodate forest structure which is not used now.
-uint256 constant DISPUTE_KIT_CLASSIC = 1; // Index of the default DK. 0 index is skipped.
+uint256 constant DISPUTE_KIT_CLASSIC = 0; // Index of the default DK.
 
 // Sortition Module
 uint256 constant MAX_STAKE_PATHS = 4; // The maximum number of stake paths a juror can have.

--- a/contracts/test/arbitration/draw.ts
+++ b/contracts/test/arbitration/draw.ts
@@ -97,7 +97,7 @@ describe("Draw Benchmark", async () => {
         256,
         [0, 0, 0, 10], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
         ethers.toBeHex(5), // Extra data for sortition module will return the default value of K)
-        [1]
+        [0]
       )
       .then((tx) => tx.wait());
   });

--- a/contracts/test/arbitration/index.ts
+++ b/contracts/test/arbitration/index.ts
@@ -16,7 +16,7 @@ describe("DisputeKitClassic", async () => {
   it("Kleros Core initialization", async () => {
     const events = await core.queryFilter(core.filters.DisputeKitCreated());
     expect(events.length).to.equal(1);
-    expect(events[0].args._disputeKitID).to.equal(1);
+    expect(events[0].args._disputeKitID).to.equal(0);
     expect(events[0].args._disputeKitAddress).to.equal(disputeKit.target);
 
     // Reminder: the Forking court will be added which will break these expectations.
@@ -30,12 +30,12 @@ describe("DisputeKitClassic", async () => {
     expect(events2[0].args._feeForJuror).to.equal(ethers.parseUnits("0.1", 18));
     expect(events2[0].args._jurorsForCourtJump).to.equal(256);
     expect(events2[0].args._timesPerPeriod).to.deep.equal([0, 0, 0, 10]);
-    expect(events2[0].args._supportedDisputeKits).to.deep.equal([1]);
+    expect(events2[0].args._supportedDisputeKits).to.deep.equal([0]);
 
     const events3 = await core.queryFilter(core.filters.DisputeKitEnabled());
     expect(events3.length).to.equal(1);
     expect(events3[0].args._courtID).to.equal(1);
-    expect(events3[0].args._disputeKitID).to.equal(1);
+    expect(events3[0].args._disputeKitID).to.equal(0);
     expect(events3[0].args._enable).to.equal(true);
   });
 

--- a/contracts/test/arbitration/staking-neo.ts
+++ b/contracts/test/arbitration/staking-neo.ts
@@ -399,7 +399,7 @@ describe("Staking", async () => {
   describe("When outside the Staking phase", async () => {
     const createSubcourtStakeAndCreateDispute = async () => {
       expect(await sortition.phase()).to.be.equal(0); // Staking
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [0]); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));
@@ -734,7 +734,7 @@ describe("Staking", async () => {
     });
 
     it("Should unstake from all courts", async () => {
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [0]); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));

--- a/contracts/test/arbitration/staking.ts
+++ b/contracts/test/arbitration/staking.ts
@@ -40,7 +40,7 @@ describe("Staking", async () => {
     const reachDrawingPhase = async () => {
       expect(await sortition.phase()).to.be.equal(0); // Staking
       const arbitrationCost = ETH(0.1) * 3n;
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [0]); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));
@@ -386,7 +386,7 @@ describe("Staking", async () => {
 
     it("Should unstake from all courts", async () => {
       const arbitrationCost = ETH(0.1) * 3n;
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [0]); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the handling of dispute kits in the Kleros arbitration system, particularly changing default values and references from `1` to `0`, indicating a shift in the index of the classic dispute kit and related functionality.

### Detailed summary
- Changed `disputeKitID` default from `1` to `0` in multiple contracts.
- Updated `supportedDisputeKits` in tests from `[1]` to `[0]`.
- Adjusted assertions in tests to reflect the new dispute kit index.
- Modified the handling of `NULL_DISPUTE_KIT` to remove its usage.
- Updated comments to reflect changes in dispute kit indexing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined dispute kit management and court initialization logic by removing redundant validations.
- **Chore**
  - Standardized dispute kit indexing by updating default constants.
- **Tests**
  - Aligned test configurations and event expectations with the revised dispute kit defaults to ensure consistent behavior.

These improvements enhance the consistency and reliability of the arbitration and court creation features without impacting the overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->