### PR TITLE
fix: toastify styling tweak to allow for clicking on navbar while act…

### DIFF
--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -67,6 +67,7 @@ const LinkContainer = styled.div`
 const StyledInternalLink = styled(InternalLink)`
   text-wrap: auto;
   justify-content: end;
+  line-height: 1.25;
 `;
 
 type FieldContainerProps = {

--- a/web/src/styles/global-style.ts
+++ b/web/src/styles/global-style.ts
@@ -127,6 +127,6 @@ export const GlobalStyle = createGlobalStyle`
 
   [class*="Toastify__toast-container"] {
     top: unset;
-    padding-top: 20px;
+    padding-top: 20px !important;
   }
 `;

--- a/web/src/styles/global-style.ts
+++ b/web/src/styles/global-style.ts
@@ -124,4 +124,9 @@ export const GlobalStyle = createGlobalStyle`
   .hiddenCanvasElement{
     display: none;
   }
+
+  [class*="Toastify__toast-container"] {
+    top: unset;
+    padding-top: 20px;
+  }
 `;


### PR DESCRIPTION
…ive notif

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the styling of the `Field` component and adding new styles for `Toastify` notifications.

### Detailed summary
- Added `line-height: 1.25;` to the `FieldContainerProps`.
- Set `display: none;` in `global-style.ts`.
- Introduced styles for `Toastify` toast containers:
  - Set `top: unset;`
  - Added `padding-top: 20px !important;`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Adjusted the appearance of toast notifications by updating their vertical positioning and adding extra padding for improved visual consistency.
	- Modified the internal link component's text rendering by adding a line-height property for enhanced readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->