### PR TITLE
feat(subgraph): add StakeSet entity and handler tweak

### DIFF
--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -149,6 +149,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
+        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrum/SortitionModuleNeo.json

--- a/subgraph/core-university/src/SortitionModule.ts
+++ b/subgraph/core-university/src/SortitionModule.ts
@@ -1,26 +1,25 @@
 import { SortitionModule, StakeLocked, StakeSet as StakeSetEvent } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity, User } from "../generated/schema";
+import { StakeSet as StakeSetEntity } from "../generated/schema";
 
-import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
+import { ensureJurorTokensPerCourt, updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
 export function handleStakeSet(event: StakeSetEvent): void {
   const jurorAddress = event.params._address.toHexString();
-  ensureUser(jurorAddress);
+  const juror = ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
 
-  const juror = User.load(jurorAddress);
-  if (!juror) return;
   const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  stakeSet.address = jurorAddress;
+  const jurorTokensPerCourt = ensureJurorTokensPerCourt(jurorAddress, "1");
+  stakeSet.juror = juror.id;
   stakeSet.courtID = event.params._courtID;
   stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
+  stakeSet.newTotalStake = jurorTokensPerCourt.effectiveStake;
   stakeSet.blocknumber = event.block.number;
   stakeSet.timestamp = event.block.timestamp;
   stakeSet.logIndex = event.logIndex;

--- a/subgraph/core-university/src/SortitionModule.ts
+++ b/subgraph/core-university/src/SortitionModule.ts
@@ -1,13 +1,12 @@
 import { SortitionModule, StakeLocked, StakeSet as StakeSetEvent } from "../generated/SortitionModule/SortitionModule";
 import { StakeSet as StakeSetEntity } from "../generated/schema";
 
-import { ensureJurorTokensPerCourt, updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
+import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
 export function handleStakeSet(event: StakeSetEvent): void {
   const jurorAddress = event.params._address.toHexString();
-  const juror = ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
@@ -15,11 +14,11 @@ export function handleStakeSet(event: StakeSetEvent): void {
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
 
   const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const jurorTokensPerCourt = ensureJurorTokensPerCourt(jurorAddress, "1");
+  const juror = ensureUser(jurorAddress);
   stakeSet.juror = juror.id;
   stakeSet.courtID = event.params._courtID;
   stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = jurorTokensPerCourt.effectiveStake;
+  stakeSet.newTotalStake = juror.totalStake;
   stakeSet.blocknumber = event.block.number;
   stakeSet.timestamp = event.block.timestamp;
   stakeSet.logIndex = event.logIndex;

--- a/subgraph/core-university/subgraph.yaml
+++ b/subgraph/core-university/subgraph.yaml
@@ -149,6 +149,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
+        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModuleUniversity.json

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -354,6 +354,17 @@ type ClassicContribution implements Contribution @entity {
   rewardWithdrawn: Boolean!
 }
 
+type StakeSet @entity {
+  id: ID! # event.transaction.hash.toHex() + - + event.logIndex.toString()
+  address: Bytes!
+  courtID: BigInt!
+  stake: BigInt!
+  newTotalStake: BigInt!
+  blocknumber: BigInt!
+  timestamp: BigInt!
+  logIndex: BigInt!
+}
+
 type _Schema_
   @fulltext(
     name: "evidenceSearch"

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -356,7 +356,7 @@ type ClassicContribution implements Contribution @entity {
 
 type StakeSet @entity {
   id: ID! # event.transaction.hash.toHex() + - + event.logIndex.toString()
-  address: Bytes!
+  address: String!
   courtID: BigInt!
   stake: BigInt!
   newTotalStake: BigInt!

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -354,9 +354,9 @@ type ClassicContribution implements Contribution @entity {
   rewardWithdrawn: Boolean!
 }
 
-type StakeSet @entity {
+type StakeSet @entity(immutable: true) {
   id: ID! # event.transaction.hash.toHex() + - + event.logIndex.toString()
-  address: String!
+  juror: User!
   courtID: BigInt!
   stake: BigInt!
   newTotalStake: BigInt!

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -4,8 +4,9 @@ import {
   StakeDelayedAlreadyTransferredWithdrawn,
   StakeDelayedNotTransferred,
   StakeLocked,
-  StakeSet,
+  StakeSet as StakeSetEvent,
 } from "../generated/SortitionModule/SortitionModule";
+import { Court, StakeSet as StakeSetEntity } from "../generated/schema";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
@@ -23,7 +24,7 @@ export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferr
   updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 
-export function handleStakeSet(event: StakeSet): void {
+export function handleStakeSet(event: StakeSetEvent): void {
   const jurorAddress = event.params._address.toHexString();
   ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
@@ -31,5 +32,18 @@ export function handleStakeSet(event: StakeSet): void {
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
+
+  const generalCourt = Court.load("1");
+  if (!generalCourt) return;
+  const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
+  stakeSet.address = event.params._address;
+  stakeSet.courtID = event.params._courtID;
+  stakeSet.stake = event.params._amount;
+  stakeSet.newTotalStake = generalCourt.effectiveStake;
+  stakeSet.blocknumber = event.block.number;
+  stakeSet.timestamp = event.block.timestamp;
+  stakeSet.logIndex = event.logIndex;
+  stakeSet.save();
 }
+
 export function handleStakeLocked(event: StakeLocked): void {}

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -6,7 +6,7 @@ import {
   StakeLocked,
   StakeSet as StakeSetEvent,
 } from "../generated/SortitionModule/SortitionModule";
-import { Court, StakeSet as StakeSetEntity } from "../generated/schema";
+import { StakeSet as StakeSetEntity, User } from "../generated/schema";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
@@ -33,13 +33,13 @@ export function handleStakeSet(event: StakeSetEvent): void {
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
 
-  const generalCourt = Court.load("1");
-  if (!generalCourt) return;
+  const juror = User.load(jurorAddress);
+  if (!juror) return;
   const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  stakeSet.address = event.params._address;
+  stakeSet.address = jurorAddress;
   stakeSet.courtID = event.params._courtID;
   stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = generalCourt.effectiveStake;
+  stakeSet.newTotalStake = juror.totalStake;
   stakeSet.blocknumber = event.block.number;
   stakeSet.timestamp = event.block.timestamp;
   stakeSet.logIndex = event.logIndex;

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -8,7 +8,7 @@ import {
 } from "../generated/SortitionModule/SortitionModule";
 import { StakeSet as StakeSetEntity } from "../generated/schema";
 
-import { ensureJurorTokensPerCourt, updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
+import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
@@ -26,7 +26,6 @@ export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferr
 
 export function handleStakeSet(event: StakeSetEvent): void {
   const jurorAddress = event.params._address.toHexString();
-  const juror = ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
@@ -34,11 +33,11 @@ export function handleStakeSet(event: StakeSetEvent): void {
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
 
   const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const jurorTokensPerCourt = ensureJurorTokensPerCourt(jurorAddress, "1");
+  const juror = ensureUser(jurorAddress);
   stakeSet.juror = juror.id;
   stakeSet.courtID = event.params._courtID;
   stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = jurorTokensPerCourt.effectiveStake;
+  stakeSet.newTotalStake = juror.totalStake;
   stakeSet.blocknumber = event.block.number;
   stakeSet.timestamp = event.block.timestamp;
   stakeSet.logIndex = event.logIndex;

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -6,9 +6,9 @@ import {
   StakeLocked,
   StakeSet as StakeSetEvent,
 } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity, User } from "../generated/schema";
+import { StakeSet as StakeSetEntity } from "../generated/schema";
 
-import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
+import { ensureJurorTokensPerCourt, updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
@@ -26,20 +26,19 @@ export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferr
 
 export function handleStakeSet(event: StakeSetEvent): void {
   const jurorAddress = event.params._address.toHexString();
-  ensureUser(jurorAddress);
+  const juror = ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
 
-  const juror = User.load(jurorAddress);
-  if (!juror) return;
   const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  stakeSet.address = jurorAddress;
+  const jurorTokensPerCourt = ensureJurorTokensPerCourt(jurorAddress, "1");
+  stakeSet.juror = juror.id;
   stakeSet.courtID = event.params._courtID;
   stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
+  stakeSet.newTotalStake = jurorTokensPerCourt.effectiveStake;
   stakeSet.blocknumber = event.block.number;
   stakeSet.timestamp = event.block.timestamp;
   stakeSet.logIndex = event.logIndex;

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -149,6 +149,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
+        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "drtVersion": "0.11.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
this is needed for the Staking Rewards script (for pnk-merkle-drop) in V2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the subgraph's schema and functionality to accommodate a new `StakeSet` entity, reflecting changes in staking events and enhancing data management for jurors.

### Detailed summary
- Updated `version` in `subgraph/package.json` to `0.12.0`.
- Added `StakeSet` entity in multiple `subgraph.yaml` files.
- Defined `StakeSet` type in `subgraph/core/schema.graphql`.
- Modified `handleStakeSet` function to create and save `StakeSetEntity`.
- Updated imports to include `StakeSetEntity` in relevant TypeScript files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new entity, `StakeSet`, to enhance staking tracking with detailed information (e.g., stake amounts, updated totals, timestamps) for stake events, offering more granular insights for data monitoring.

- **Refactor**
	- Improved event handling logic for stake updates to streamline processing and ensure reliable performance without affecting existing functionality.

- **Chores**
	- Updated package version from "0.11.0" to "0.12.0".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->