### PR TITLE
Chore/clear local dispute data on mount

### DIFF
--- a/web/src/components/Popup/index.tsx
+++ b/web/src/components/Popup/index.tsx
@@ -239,6 +239,9 @@ const Popup: React.FC<PopupProps & IPopup> = ({
   const closePopup = () => {
     setIsOpen(false);
     resetValue();
+    // dispute data is cleared, so if popup is closed the preview will show empty,
+    // instead redirect to start point.
+    if (popupType === PopupType.DISPUTE_CREATED) navigate("/resolver");
   };
 
   return (

--- a/web/src/context/NewDisputeContext.tsx
+++ b/web/src/context/NewDisputeContext.tsx
@@ -60,7 +60,7 @@ interface INewDisputeContext {
   setIsPolicyUploading: (isPolicyUploading: boolean) => void;
 }
 
-const initialDisputeData: IDisputeData = {
+const getInitialDisputeData = (): IDisputeData => ({
   numberOfJurors: 3,
   title: "",
   description: "",
@@ -72,7 +72,9 @@ const initialDisputeData: IDisputeData = {
   ],
   aliasesArray: [{ name: "", address: "", id: "1" }],
   version: "1.0",
-};
+});
+
+const initialDisputeData = getInitialDisputeData();
 
 const NewDisputeContext = createContext<INewDisputeContext | undefined>(undefined);
 
@@ -92,7 +94,8 @@ export const NewDisputeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   const disputeTemplate = useMemo(() => constructDisputeTemplate(disputeData), [disputeData]);
 
   const resetDisputeData = useCallback(() => {
-    setDisputeData(initialDisputeData);
+    const freshData = getInitialDisputeData();
+    setDisputeData(freshData);
   }, [setDisputeData]);
 
   const contextValues = useMemo(

--- a/web/src/pages/Resolver/index.tsx
+++ b/web/src/pages/Resolver/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useToggle } from "react-use";
 import { useAccount } from "wagmi";
+
+import { useNewDisputeContext } from "context/NewDisputeContext";
 
 import { MAX_WIDTH_LANDSCAPE, landscapeStyle } from "styles/landscapeStyle";
 import { responsiveSize } from "styles/responsiveSize";
@@ -79,7 +81,9 @@ const DisputeResolver: React.FC = () => {
   const [isDisputeResolverMiniGuideOpen, toggleDisputeResolverMiniGuide] = useToggle(false);
   const { isConnected } = useAccount();
   const isPreviewPage = location.pathname.includes("/preview");
+  const { resetDisputeData } = useNewDisputeContext();
 
+  useEffect(() => resetDisputeData(), []);
   return (
     <Wrapper>
       <HeroImage />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on enhancing the handling of dispute data in the application, particularly when navigating away from the dispute creation popup. It ensures that the data is reset appropriately and adds necessary logic to manage the user experience.

### Detailed summary
- In `Popup/index.tsx`, added logic to navigate to `/resolver` when the popup type is `DISPUTE_CREATED`.
- In `Resolver/index.tsx`, introduced `resetDisputeData` from `NewDisputeContext` and called it within a `useEffect`.
- In `NewDisputeContext.tsx`, refactored initial dispute data setup by creating `getInitialDisputeData` function.
- Updated `resetDisputeData` to use fresh data from `getInitialDisputeData`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Dispute popups now redirect users to a dedicated resolution page when closed.
	- The dispute resolution page automatically resets dispute information, ensuring you always start with a fresh state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->