### PR TITLE
Adding the juror's total stake for all courts in the StakeSet event back in

### DIFF
--- a/contracts/src/arbitration/SortitionModuleBase.sol
+++ b/contracts/src/arbitration/SortitionModuleBase.sol
@@ -81,10 +81,35 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     // *              Events               * //
     // ************************************* //
 
-    event StakeSet(address indexed _address, uint256 _courtID, uint256 _amount);
+    /// @notice Emitted when a juror stakes in a court.
+    /// @param _address The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @param _amount The amount of tokens staked in the court.
+    /// @param _amountAllCourts The amount of tokens staked in all courts.
+    event StakeSet(address indexed _address, uint256 _courtID, uint256 _amount, uint256 _amountAllCourts);
+
+    /// @notice Emitted when a juror's stake is delayed and tokens are not transferred yet.
+    /// @param _address The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @param _amount The amount of tokens staked in the court.
     event StakeDelayedNotTransferred(address indexed _address, uint256 _courtID, uint256 _amount);
+
+    /// @notice Emitted when a juror's stake is delayed and tokens are already transferred.
+    /// @param _address The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @param _amount The amount of tokens staked in the court.
     event StakeDelayedAlreadyTransferred(address indexed _address, uint256 _courtID, uint256 _amount);
+
+    /// @notice Emitted when a juror's stake is delayed and tokens are already transferred.
+    /// @param _address The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @param _amount The amount of tokens staked in the court.
     event StakeDelayedAlreadyTransferredWithdrawn(address indexed _address, uint96 indexed _courtID, uint256 _amount);
+
+    /// @notice Emitted when a juror's stake is locked.
+    /// @param _address The address of the juror.
+    /// @param _relativeAmount The amount of tokens locked.
+    /// @param _unlock Whether the stake is locked or unlocked.
     event StakeLocked(address indexed _address, uint256 _relativeAmount, bool _unlock);
 
     // ************************************* //
@@ -318,7 +343,7 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
                 (currenCourtID, , , , , , ) = core.courts(currenCourtID); // Get the parent court.
             }
         }
-        emit StakeSet(_account, _courtID, _newStake);
+        emit StakeSet(_account, _courtID, _newStake, juror.stakedPnk);
         return (pnkDeposit, pnkWithdrawal, StakingResult.Successful);
     }
 

--- a/contracts/src/arbitration/SortitionModuleBase.sol
+++ b/contracts/src/arbitration/SortitionModuleBase.sol
@@ -94,16 +94,16 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     /// @param _amount The amount of tokens staked in the court.
     event StakeDelayedNotTransferred(address indexed _address, uint256 _courtID, uint256 _amount);
 
-    /// @notice Emitted when a juror's stake is delayed and tokens are already transferred.
+    /// @notice Emitted when a juror's stake is delayed and tokens are already deposited.
     /// @param _address The address of the juror.
     /// @param _courtID The ID of the court.
     /// @param _amount The amount of tokens staked in the court.
-    event StakeDelayedAlreadyTransferred(address indexed _address, uint256 _courtID, uint256 _amount);
+    event StakeDelayedAlreadyTransferredDeposited(address indexed _address, uint256 _courtID, uint256 _amount);
 
-    /// @notice Emitted when a juror's stake is delayed and tokens are already transferred.
+    /// @notice Emitted when a juror's stake is delayed and tokens are already withdrawn.
     /// @param _address The address of the juror.
     /// @param _courtID The ID of the court.
-    /// @param _amount The amount of tokens staked in the court.
+    /// @param _amount The amount of tokens withdrawn.
     event StakeDelayedAlreadyTransferredWithdrawn(address indexed _address, uint96 indexed _courtID, uint256 _amount);
 
     /// @notice Emitted when a juror's stake is locked.
@@ -313,7 +313,7 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
                 // PNK deposit: tokens are transferred now.
                 delayedStake.alreadyTransferred = true;
                 pnkDeposit = _increaseStake(juror, _courtID, _newStake, currentStake);
-                emit StakeDelayedAlreadyTransferred(_account, _courtID, _newStake);
+                emit StakeDelayedAlreadyTransferredDeposited(_account, _courtID, _newStake);
             } else {
                 // PNK withdrawal: tokens are not transferred yet.
                 emit StakeDelayedNotTransferred(_account, _courtID, _newStake);

--- a/contracts/src/arbitration/university/SortitionModuleUniversity.sol
+++ b/contracts/src/arbitration/university/SortitionModuleUniversity.sol
@@ -47,7 +47,17 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
     // *              Events               * //
     // ************************************* //
 
-    event StakeSet(address indexed _address, uint256 _courtID, uint256 _amount);
+    /// @notice Emitted when a juror stakes in a court.
+    /// @param _address The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @param _amount The amount of tokens staked in the court.
+    /// @param _amountAllCourts The amount of tokens staked in all courts.
+    event StakeSet(address indexed _address, uint256 _courtID, uint256 _amount, uint256 _amountAllCourts);
+
+    /// @notice Emitted when a juror's stake is locked.
+    /// @param _address The address of the juror.
+    /// @param _relativeAmount The amount of tokens locked.
+    /// @param _unlock Whether the stake is locked or unlocked.
     event StakeLocked(address indexed _address, uint256 _relativeAmount, bool _unlock);
 
     // ************************************* //
@@ -163,7 +173,7 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
                 (currentCourtID, , , , , , ) = core.courts(currentCourtID);
             }
         }
-        emit StakeSet(_account, _courtID, _newStake);
+        emit StakeSet(_account, _courtID, _newStake, juror.stakedPnk);
         return (pnkDeposit, pnkWithdrawal, StakingResult.Successful);
     }
 

--- a/contracts/test/arbitration/staking-neo.ts
+++ b/contracts/test/arbitration/staking-neo.ts
@@ -272,7 +272,7 @@ describe("Staking", async () => {
           await core.connect(juror).setStake(1, PNK(1000));
           await createDisputeAndReachGeneratingPhaseFromStaking();
           expect(await core.connect(juror).setStake(1, PNK(2000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(juror.address, 1, PNK(2000))
             .to.not.emit(sortition, "StakeSet");
           expect(await sortition.totalStaked()).to.be.equal(PNK(1000));
@@ -334,7 +334,7 @@ describe("Staking", async () => {
         it("Should be able to stake exactly maxTotalStaked", async () => {
           await pnk.connect(juror).approve(core.target, PNK(1000));
           await expect(await core.connect(juror).setStake(1, PNK(1000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(juror.address, 1, PNK(1000));
           expect(await sortition.totalStaked()).to.be.equal(PNK(2000)); // Not updated until the delayed stake is executed
           await drawAndReachStakingPhaseFromGenerating();
@@ -430,7 +430,7 @@ describe("Staking", async () => {
           await pnk.approve(core.target, PNK(1000));
           expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0);
           await expect(core.setStake(2, PNK(3000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(deployer, 2, PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([PNK(5000), 0, PNK(2000), 2]); // stake does not change
         });
@@ -458,7 +458,7 @@ describe("Staking", async () => {
             .to.emit(sortition, "StakeSet")
             .withArgs(deployer, 2, PNK(3000), PNK(5000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
-            .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.not.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(5000),
@@ -653,7 +653,7 @@ describe("Staking", async () => {
           await pnk.approve(core.target, PNK(1000));
           expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0);
           await expect(core.setStake(2, PNK(3000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(deployer, 2, PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([PNK(5000), 0, PNK(2000), 2]); // stake does not change
         });
@@ -706,7 +706,7 @@ describe("Staking", async () => {
             .to.emit(await sortition, "StakeSet")
             .withArgs(deployer, 2, PNK(2000), PNK(4000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
-            .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.not.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(4000),

--- a/contracts/test/arbitration/staking-neo.ts
+++ b/contracts/test/arbitration/staking-neo.ts
@@ -183,7 +183,7 @@ describe("Staking", async () => {
       await pnk.connect(juror).approve(core.target, PNK(1000));
       await expect(await core.connect(juror).setStake(1, PNK(1000)))
         .to.emit(sortition, "StakeSet")
-        .withArgs(juror.address, 1, PNK(1000));
+        .withArgs(juror.address, 1, PNK(1000), PNK(1000));
       expect(await sortition.totalStaked()).to.be.equal(PNK(1000));
     });
   });
@@ -201,17 +201,17 @@ describe("Staking", async () => {
       it("Should be able to unstake", async () => {
         expect(await core.connect(juror).setStake(1, PNK(500)))
           .to.emit(sortition, "StakeSet")
-          .withArgs(juror.address, 1, PNK(500));
+          .withArgs(juror.address, 1, PNK(500), PNK(500));
         expect(await sortition.totalStaked()).to.be.equal(PNK(500));
 
         expect(await core.connect(juror).setStake(1, PNK(1001)))
           .to.emit(sortition, "StakeSet")
-          .withArgs(juror.address, 1, PNK(1001));
+          .withArgs(juror.address, 1, PNK(1001), PNK(1001));
         expect(await sortition.totalStaked()).to.be.equal(PNK(1001));
 
         expect(await core.connect(juror).setStake(1, PNK(0)))
           .to.emit(sortition, "StakeSet")
-          .withArgs(juror.address, 1, PNK(0));
+          .withArgs(juror.address, 1, PNK(0), PNK(0));
         expect(await sortition.totalStaked()).to.be.equal(PNK(0));
       });
     });
@@ -230,7 +230,7 @@ describe("Staking", async () => {
         await drawAndReachStakingPhaseFromGenerating();
         expect(await sortition.executeDelayedStakes(10))
           .to.emit(sortition, "StakeSet")
-          .withArgs(juror.address, 1, PNK(0));
+          .withArgs(juror.address, 1, PNK(0), PNK(0));
       });
     });
   });
@@ -279,7 +279,7 @@ describe("Staking", async () => {
           await drawAndReachStakingPhaseFromGenerating();
           expect(await sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(juror.address, 1, PNK(2000));
+            .withArgs(juror.address, 1, PNK(2000), PNK(2000));
           expect(await sortition.totalStaked()).to.be.equal(PNK(2000));
         });
       });
@@ -309,7 +309,7 @@ describe("Staking", async () => {
           await pnk.connect(juror).approve(core.target, PNK(1000));
           await expect(await core.connect(juror).setStake(1, PNK(1000)))
             .to.emit(sortition, "StakeSet")
-            .withArgs(juror.address, 1, PNK(1000));
+            .withArgs(juror.address, 1, PNK(1000), PNK(1000));
           expect(await sortition.totalStaked()).to.be.equal(PNK(3000));
         });
       });
@@ -340,7 +340,7 @@ describe("Staking", async () => {
           await drawAndReachStakingPhaseFromGenerating();
           await expect(await sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(juror.address, 1, PNK(1000));
+            .withArgs(juror.address, 1, PNK(1000), PNK(1000));
           expect(await sortition.totalStaked()).to.be.equal(PNK(3000));
         });
       });
@@ -456,7 +456,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes", async () => {
           await expect(await sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(3000))
+            .withArgs(deployer, 2, PNK(3000), PNK(5000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
@@ -524,7 +524,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes by withdrawing PNK and reducing the stakes", async () => {
           await expect(await sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(1000));
+            .withArgs(deployer, 2, PNK(1000), PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(3000),
             PNK(300), // we're the only juror so we are drawn 3 times
@@ -613,7 +613,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes but the stakes should remain the same", async () => {
           await expect(await sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(2000));
+            .withArgs(deployer, 2, PNK(2000), PNK(4000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(4000),
             PNK(300), // we're the only juror so we are drawn 3 times
@@ -704,7 +704,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes but the stakes should remain the same", async () => {
           await expect(sortition.executeDelayedStakes(10))
             .to.emit(await sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(2000))
+            .withArgs(deployer, 2, PNK(2000), PNK(4000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");

--- a/contracts/test/arbitration/staking.ts
+++ b/contracts/test/arbitration/staking.ts
@@ -87,7 +87,7 @@ describe("Staking", async () => {
           await pnk.approve(core.target, PNK(1000));
           expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0);
           await expect(core.setStake(2, PNK(3000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(deployer, 2, PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([PNK(5000), 0, PNK(2000), 2]); // stake does not change
         });
@@ -115,7 +115,7 @@ describe("Staking", async () => {
             .to.emit(sortition, "StakeSet")
             .withArgs(deployer, 2, PNK(3000), PNK(5000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
-            .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.not.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(5000),
@@ -304,7 +304,7 @@ describe("Staking", async () => {
           await pnk.approve(core.target, PNK(1000));
           expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0);
           await expect(core.setStake(2, PNK(3000)))
-            .to.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .withArgs(deployer, 2, PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([PNK(5000), 0, PNK(2000), 2]); // stake does not change
         });
@@ -357,7 +357,7 @@ describe("Staking", async () => {
             .to.emit(sortition, "StakeSet")
             .withArgs(deployer, 2, PNK(2000), PNK(4000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
-            .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
+            .to.not.emit(sortition, "StakeDelayedAlreadyTransferredDeposited")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(4000),

--- a/contracts/test/arbitration/staking.ts
+++ b/contracts/test/arbitration/staking.ts
@@ -113,7 +113,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes", async () => {
           await expect(sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(3000))
+            .withArgs(deployer, 2, PNK(3000), PNK(5000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");
@@ -179,7 +179,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes by withdrawing PNK and reducing the stakes", async () => {
           await expect(sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(1000));
+            .withArgs(deployer, 2, PNK(1000), PNK(3000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(3000),
             PNK(300), // we're the only juror so we are drawn 3 times
@@ -266,7 +266,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes but the stakes should remain the same", async () => {
           await expect(sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(2000));
+            .withArgs(deployer, 2, PNK(2000), PNK(4000));
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([
             PNK(4000),
             PNK(300), // we're the only juror so we are drawn 3 times
@@ -355,7 +355,7 @@ describe("Staking", async () => {
         it("Should execute the delayed stakes but the stakes should remain the same", async () => {
           await expect(sortition.executeDelayedStakes(10))
             .to.emit(sortition, "StakeSet")
-            .withArgs(deployer, 2, PNK(2000))
+            .withArgs(deployer, 2, PNK(2000), PNK(4000))
             .to.not.emit(sortition, "StakeDelayedNotTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferred")
             .to.not.emit(sortition, "StakeDelayedAlreadyTransferredWithdrawn");

--- a/contracts/test/foundry/KlerosCore.t.sol
+++ b/contracts/test/foundry/KlerosCore.t.sol
@@ -17,7 +17,7 @@ import {TestERC20} from "../../src/token/TestERC20.sol";
 import {ArbitrableExample, IArbitrableV2} from "../../src/arbitration/arbitrables/ArbitrableExample.sol";
 import {DisputeTemplateRegistry} from "../../src/arbitration/DisputeTemplateRegistry.sol";
 import "../../src/libraries/Constants.sol";
-import {IKlerosCore, KlerosCoreSnapshotProxy} from "../../src/snapshot-proxy/KlerosCoreSnapshotProxy.sol";
+import {IKlerosCore, KlerosCoreSnapshotProxy} from "../../src/arbitration/view/KlerosCoreSnapshotProxy.sol";
 
 contract KlerosCoreTest is Test {
     event Initialized(uint64 version);
@@ -861,7 +861,7 @@ contract KlerosCoreTest is Test {
 
         vm.prank(staker1);
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 1001);
+        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 1001, 1001);
         core.setStake(GENERAL_COURT, 1001);
 
         (uint256 totalStaked, uint256 totalLocked, uint256 stakedInCourt, uint256 nbCourts) = sortitionModule
@@ -887,7 +887,7 @@ contract KlerosCoreTest is Test {
         // Increase stake one more time to verify the correct behavior
         vm.prank(staker1);
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 2000);
+        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 2000, 2000);
         core.setStake(GENERAL_COURT, 2000);
 
         (totalStaked, totalLocked, stakedInCourt, nbCourts) = sortitionModule.getJurorBalance(staker1, GENERAL_COURT);
@@ -1197,7 +1197,7 @@ contract KlerosCoreTest is Test {
         assertEq(pinakion.balanceOf(address(core)), 1800, "Wrong token balance of the core");
 
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 1800);
+        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 1800, 1800);
         sortitionModule.executeDelayedStakes(20); // Deliberately ask for more iterations than needed
 
         assertEq(sortitionModule.delayedStakeWriteIndex(), 3, "Wrong delayedStakeWriteIndex");
@@ -2402,9 +2402,9 @@ contract KlerosCoreTest is Test {
         uint256 governorTokenBalance = pinakion.balanceOf(governor);
 
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeSet(staker1, newCourtID, 0);
+        emit SortitionModuleBase.StakeSet(staker1, newCourtID, 0, 19000);
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 0);
+        emit SortitionModuleBase.StakeSet(staker1, GENERAL_COURT, 0, 0);
         core.execute(disputeID, 0, 3);
 
         assertEq(pinakion.balanceOf(address(core)), 0, "Wrong token balance of the core");

--- a/contracts/test/foundry/KlerosCore.t.sol
+++ b/contracts/test/foundry/KlerosCore.t.sol
@@ -1010,7 +1010,7 @@ contract KlerosCoreTest is Test {
 
         vm.prank(staker1);
         vm.expectEmit(true, true, true, true);
-        emit SortitionModuleBase.StakeDelayedAlreadyTransferred(staker1, GENERAL_COURT, 1500);
+        emit SortitionModuleBase.StakeDelayedAlreadyTransferredDeposited(staker1, GENERAL_COURT, 1500);
         core.setStake(GENERAL_COURT, 1500);
 
         uint256 delayedStakeId = sortitionModule.delayedStakeWriteIndex();

--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -149,7 +149,6 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrum/SortitionModuleNeo.json
@@ -162,6 +161,6 @@ dataSources:
           handler: handleStakeDelayedNotTransferred
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -154,8 +154,8 @@ dataSources:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrum/SortitionModuleNeo.json
       eventHandlers:
-        - event: StakeDelayedAlreadyTransferred(indexed address,uint256,uint256)
-          handler: handleStakeDelayedAlreadyTransferred
+        - event: StakeDelayedAlreadyTransferredDeposited(indexed address,uint256,uint256)
+          handler: handleStakeDelayedAlreadyTransferredDeposited
         - event: StakeDelayedAlreadyTransferredWithdrawn(indexed address,indexed uint96,uint256)
           handler: handleStakeDelayedAlreadyTransferredWithdrawn
         - event: StakeDelayedNotTransferred(indexed address,uint256,uint256)

--- a/subgraph/core-university/src/SortitionModule.ts
+++ b/subgraph/core-university/src/SortitionModule.ts
@@ -1,28 +1,17 @@
-import { SortitionModule, StakeLocked, StakeSet as StakeSetEvent } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity } from "../generated/schema";
+import { SortitionModule, StakeLocked, StakeSet } from "../generated/SortitionModule/SortitionModule";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
-export function handleStakeSet(event: StakeSetEvent): void {
+export function handleStakeSet(event: StakeSet): void {
   const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
-
-  const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const juror = ensureUser(jurorAddress);
-  stakeSet.juror = juror.id;
-  stakeSet.courtID = event.params._courtID;
-  stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
-  stakeSet.blocknumber = event.block.number;
-  stakeSet.timestamp = event.block.timestamp;
-  stakeSet.logIndex = event.logIndex;
-  stakeSet.save();
 }
 
 export function handleStakeLocked(event: StakeLocked): void {

--- a/subgraph/core-university/subgraph.yaml
+++ b/subgraph/core-university/subgraph.yaml
@@ -149,13 +149,12 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModuleUniversity.json
       eventHandlers:
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -354,17 +354,6 @@ type ClassicContribution implements Contribution @entity {
   rewardWithdrawn: Boolean!
 }
 
-type StakeSet @entity(immutable: true) {
-  id: ID! # event.transaction.hash.toHex() + - + event.logIndex.toString()
-  juror: User!
-  courtID: BigInt!
-  stake: BigInt!
-  newTotalStake: BigInt!
-  blocknumber: BigInt!
-  timestamp: BigInt!
-  logIndex: BigInt!
-}
-
 type _Schema_
   @fulltext(
     name: "evidenceSearch"

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -4,9 +4,8 @@ import {
   StakeDelayedAlreadyTransferredWithdrawn,
   StakeDelayedNotTransferred,
   StakeLocked,
-  StakeSet as StakeSetEvent,
+  StakeSet,
 } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity } from "../generated/schema";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
@@ -24,24 +23,14 @@ export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferr
   updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 
-export function handleStakeSet(event: StakeSetEvent): void {
+export function handleStakeSet(event: StakeSet): void {
   const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
-
-  const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const juror = ensureUser(jurorAddress);
-  stakeSet.juror = juror.id;
-  stakeSet.courtID = event.params._courtID;
-  stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
-  stakeSet.blocknumber = event.block.number;
-  stakeSet.timestamp = event.block.timestamp;
-  stakeSet.logIndex = event.logIndex;
-  stakeSet.save();
 }
 
 export function handleStakeLocked(event: StakeLocked): void {}

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -1,6 +1,6 @@
 import {
   SortitionModule,
-  StakeDelayedAlreadyTransferred,
+  StakeDelayedAlreadyTransferredDeposited,
   StakeDelayedAlreadyTransferredWithdrawn,
   StakeDelayedNotTransferred,
   StakeLocked,
@@ -12,7 +12,7 @@ import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorToken
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
-export function handleStakeDelayedAlreadyTransferred(event: StakeDelayedAlreadyTransferred): void {
+export function handleStakeDelayedAlreadyTransferredDeposited(event: StakeDelayedAlreadyTransferredDeposited): void {
   updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -154,8 +154,8 @@ dataSources:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json
       eventHandlers:
-        - event: StakeDelayedAlreadyTransferred(indexed address,uint256,uint256)
-          handler: handleStakeDelayedAlreadyTransferred
+        - event: StakeDelayedAlreadyTransferredDeposited(indexed address,uint256,uint256)
+          handler: handleStakeDelayedAlreadyTransferredDeposited
         - event: StakeDelayedAlreadyTransferredWithdrawn(indexed address,indexed uint96,uint256)
           handler: handleStakeDelayedAlreadyTransferredWithdrawn
         - event: StakeDelayedNotTransferred(indexed address,uint256,uint256)

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -149,7 +149,6 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json
@@ -162,6 +161,6 @@ dataSources:
           handler: handleStakeDelayedNotTransferred
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core/tests/sortition-module-utils.ts
+++ b/subgraph/core/tests/sortition-module-utils.ts
@@ -1,33 +1,33 @@
 import { newMockEvent } from "matchstick-as";
 import { ethereum, BigInt, Address } from "@graphprotocol/graph-ts";
 import {
-  StakeDelayedAlreadyTransferred,
+  StakeDelayedAlreadyTransferredDeposited,
   StakeDelayedAlreadyTransferredWithdrawn,
   StakeDelayedNotTransferred,
   StakeLocked,
   StakeSet,
 } from "../generated/SortitionModule/SortitionModule";
 
-export function createStakeDelayedAlreadyTransferredEvent(
+export function createStakeDelayedAlreadyTransferredDepositedEvent(
   _address: Address,
   _courtID: BigInt,
   _amount: BigInt
-): StakeDelayedAlreadyTransferred {
-  let stakeDelayedAlreadyTransferredEvent: StakeDelayedAlreadyTransferred = newMockEvent();
+): StakeDelayedAlreadyTransferredDeposited {
+  let stakeDelayedAlreadyTransferredDepositedEvent: StakeDelayedAlreadyTransferredDeposited = newMockEvent();
 
-  stakeDelayedAlreadyTransferredEvent.parameters = new Array();
+  stakeDelayedAlreadyTransferredDepositedEvent.parameters = new Array();
 
-  stakeDelayedAlreadyTransferredEvent.parameters.push(
+  stakeDelayedAlreadyTransferredDepositedEvent.parameters.push(
     new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address))
   );
-  stakeDelayedAlreadyTransferredEvent.parameters.push(
+  stakeDelayedAlreadyTransferredDepositedEvent.parameters.push(
     new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID))
   );
-  stakeDelayedAlreadyTransferredEvent.parameters.push(
+  stakeDelayedAlreadyTransferredDepositedEvent.parameters.push(
     new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount))
   );
 
-  return stakeDelayedAlreadyTransferredEvent;
+  return stakeDelayedAlreadyTransferredDepositedEvent;
 }
 
 export function createStakeDelayedAlreadyTransferredWithdrawnEvent(

--- a/subgraph/core/tests/sortition-module-utils.ts
+++ b/subgraph/core/tests/sortition-module-utils.ts
@@ -88,7 +88,12 @@ export function createStakeLockedEvent(_address: Address, _relativeAmount: BigIn
   return stakeLockedEvent;
 }
 
-export function createStakeSetEvent(_address: Address, _courtID: BigInt, _amount: BigInt): StakeSet {
+export function createStakeSetEvent(
+  _address: Address,
+  _courtID: BigInt,
+  _amount: BigInt,
+  _amountAllCourts: BigInt
+): StakeSet {
   let stakeSetEvent = newMockEvent();
 
   stakeSetEvent.parameters = new Array();
@@ -96,6 +101,9 @@ export function createStakeSetEvent(_address: Address, _courtID: BigInt, _amount
   stakeSetEvent.parameters.push(new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address)));
   stakeSetEvent.parameters.push(new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID)));
   stakeSetEvent.parameters.push(new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount)));
+  stakeSetEvent.parameters.push(
+    new ethereum.EventParam("_amountAllCourts", ethereum.Value.fromUnsignedBigInt(_amountAllCourts))
+  );
 
   return stakeSetEvent;
 }

--- a/subgraph/core/tests/sortition-module.test.ts
+++ b/subgraph/core/tests/sortition-module.test.ts
@@ -10,8 +10,9 @@ describe("Describe event", () => {
   beforeAll(() => {
     let courtId = BigInt.fromI32(1);
     let amount = BigInt.fromI32(1000);
+    let amountAllCourts = BigInt.fromI32(1000);
     let jurorAddress = Address.fromString("0x922911F4f80a569a4425fa083456239838F7F003");
-    let newStakeSetEvent = createStakeSetEvent(jurorAddress, courtId, amount);
+    let newStakeSetEvent = createStakeSetEvent(jurorAddress, courtId, amount, amountAllCourts);
     handleStakeSet(newStakeSetEvent);
   });
 

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "drtVersion": "0.11.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `StakeSet` event to include an additional parameter, `amountAllCourts`, and modifies related code to handle this change. It also refines event names and updates the version of the package.

### Detailed summary
- Updated `StakeSet` event to include `amountAllCourts`.
- Modified `createStakeSetEvent` function to accept the new parameter.
- Adjusted event handling in `handleStakeSet` to utilize the new parameter.
- Renamed `StakeDelayedAlreadyTransferred` to `StakeDelayedAlreadyTransferredDeposited`.
- Updated related tests to reflect the new event structure and parameters.
- Incremented package version from `0.12.0` to `0.13.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced staking event logs with additional details for improved tracking and transparency.
  - Introduced notifications covering delayed and locked stake scenarios.

- **Tests**
  - Updated validations to ensure the expanded event details are correctly captured during stake operations.
  - Adjusted assertions in tests to reflect changes in event names and parameters.
  - Added new parameters in test cases to align with updated event structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->