### PR TITLE
chore: revert stakeset handling in this subgraph and add new event parameter

### DIFF
--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -161,6 +161,6 @@ dataSources:
           handler: handleStakeDelayedNotTransferred
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core-neo/subgraph.yaml
+++ b/subgraph/core-neo/subgraph.yaml
@@ -149,7 +149,6 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrum/SortitionModuleNeo.json

--- a/subgraph/core-university/src/SortitionModule.ts
+++ b/subgraph/core-university/src/SortitionModule.ts
@@ -1,28 +1,17 @@
-import { SortitionModule, StakeLocked, StakeSet as StakeSetEvent } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity } from "../generated/schema";
+import { SortitionModule, StakeLocked, StakeSet } from "../generated/SortitionModule/SortitionModule";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
 import { ZERO } from "./utils";
 
-export function handleStakeSet(event: StakeSetEvent): void {
+export function handleStakeSet(event: StakeSet): void {
   const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
-
-  const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const juror = ensureUser(jurorAddress);
-  stakeSet.juror = juror.id;
-  stakeSet.courtID = event.params._courtID;
-  stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
-  stakeSet.blocknumber = event.block.number;
-  stakeSet.timestamp = event.block.timestamp;
-  stakeSet.logIndex = event.logIndex;
-  stakeSet.save();
 }
 
 export function handleStakeLocked(event: StakeLocked): void {

--- a/subgraph/core-university/subgraph.yaml
+++ b/subgraph/core-university/subgraph.yaml
@@ -149,7 +149,6 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModuleUniversity.json

--- a/subgraph/core-university/subgraph.yaml
+++ b/subgraph/core-university/subgraph.yaml
@@ -155,6 +155,6 @@ dataSources:
       eventHandlers:
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core/schema.graphql
+++ b/subgraph/core/schema.graphql
@@ -354,17 +354,6 @@ type ClassicContribution implements Contribution @entity {
   rewardWithdrawn: Boolean!
 }
 
-type StakeSet @entity(immutable: true) {
-  id: ID! # event.transaction.hash.toHex() + - + event.logIndex.toString()
-  juror: User!
-  courtID: BigInt!
-  stake: BigInt!
-  newTotalStake: BigInt!
-  blocknumber: BigInt!
-  timestamp: BigInt!
-  logIndex: BigInt!
-}
-
 type _Schema_
   @fulltext(
     name: "evidenceSearch"

--- a/subgraph/core/src/SortitionModule.ts
+++ b/subgraph/core/src/SortitionModule.ts
@@ -4,9 +4,8 @@ import {
   StakeDelayedAlreadyTransferredWithdrawn,
   StakeDelayedNotTransferred,
   StakeLocked,
-  StakeSet as StakeSetEvent,
+  StakeSet,
 } from "../generated/SortitionModule/SortitionModule";
-import { StakeSet as StakeSetEntity } from "../generated/schema";
 
 import { updateJurorDelayedStake, updateJurorStake } from "./entities/JurorTokensPerCourt";
 import { ensureUser } from "./entities/User";
@@ -24,24 +23,14 @@ export function handleStakeDelayedNotTransferred(event: StakeDelayedNotTransferr
   updateJurorDelayedStake(event.params._address.toHexString(), event.params._courtID.toString(), event.params._amount);
 }
 
-export function handleStakeSet(event: StakeSetEvent): void {
+export function handleStakeSet(event: StakeSet): void {
   const jurorAddress = event.params._address.toHexString();
+  ensureUser(jurorAddress);
   const courtID = event.params._courtID.toString();
 
   updateJurorStake(jurorAddress, courtID.toString(), SortitionModule.bind(event.address), event.block.timestamp);
   //stake is updated instantly so no delayed amount, set delay amount to zero
   updateJurorDelayedStake(jurorAddress, courtID, ZERO);
-
-  const stakeSet = new StakeSetEntity(event.transaction.hash.toHex() + "-" + event.logIndex.toString());
-  const juror = ensureUser(jurorAddress);
-  stakeSet.juror = juror.id;
-  stakeSet.courtID = event.params._courtID;
-  stakeSet.stake = event.params._amount;
-  stakeSet.newTotalStake = juror.totalStake;
-  stakeSet.blocknumber = event.block.number;
-  stakeSet.timestamp = event.block.timestamp;
-  stakeSet.logIndex = event.logIndex;
-  stakeSet.save();
 }
 
 export function handleStakeLocked(event: StakeLocked): void {}

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -149,7 +149,6 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - JurorTokensPerCourt
-        - StakeSet
       abis:
         - name: SortitionModule
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/SortitionModule.json

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -161,6 +161,6 @@ dataSources:
           handler: handleStakeDelayedNotTransferred
         - event: StakeLocked(indexed address,uint256,bool)
           handler: handleStakeLocked
-        - event: StakeSet(indexed address,uint256,uint256)
+        - event: StakeSet(indexed address,uint256,uint256,uint256)
           handler: handleStakeSet
       file: ./src/SortitionModule.ts

--- a/subgraph/core/tests/sortition-module-utils.ts
+++ b/subgraph/core/tests/sortition-module-utils.ts
@@ -88,7 +88,12 @@ export function createStakeLockedEvent(_address: Address, _relativeAmount: BigIn
   return stakeLockedEvent;
 }
 
-export function createStakeSetEvent(_address: Address, _courtID: BigInt, _amount: BigInt): StakeSet {
+export function createStakeSetEvent(
+  _address: Address,
+  _courtID: BigInt,
+  _amount: BigInt,
+  _amountAllCourts: BigInt
+): StakeSet {
   let stakeSetEvent = newMockEvent();
 
   stakeSetEvent.parameters = new Array();
@@ -96,6 +101,9 @@ export function createStakeSetEvent(_address: Address, _courtID: BigInt, _amount
   stakeSetEvent.parameters.push(new ethereum.EventParam("_address", ethereum.Value.fromAddress(_address)));
   stakeSetEvent.parameters.push(new ethereum.EventParam("_courtID", ethereum.Value.fromUnsignedBigInt(_courtID)));
   stakeSetEvent.parameters.push(new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(_amount)));
+  stakeSetEvent.parameters.push(
+    new ethereum.EventParam("_amountAllCourts", ethereum.Value.fromUnsignedBigInt(_amountAllCourts))
+  );
 
   return stakeSetEvent;
 }

--- a/subgraph/core/tests/sortition-module.test.ts
+++ b/subgraph/core/tests/sortition-module.test.ts
@@ -10,8 +10,9 @@ describe("Describe event", () => {
   beforeAll(() => {
     let courtId = BigInt.fromI32(1);
     let amount = BigInt.fromI32(1000);
+    let amountAllCourts = BigInt.fromI32(1000);
     let jurorAddress = Address.fromString("0x922911F4f80a569a4425fa083456239838F7F003");
-    let newStakeSetEvent = createStakeSetEvent(jurorAddress, courtId, amount);
+    let newStakeSetEvent = createStakeSetEvent(jurorAddress, courtId, amount, amountAllCourts);
     handleStakeSet(newStakeSetEvent);
   });
 

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "drtVersion": "0.11.0",
   "license": "MIT",
   "scripts": {

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.12.0",
+  "version": "0.11.0",
   "drtVersion": "0.11.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
add the new _amountAllCourts to the StakeSet events

also reverts #1901 as discussed since we don't want to handle this entity in this subgraph due to entity overload since StakeSet is very frequent

frontend unaffected

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `StakeSet` event handling in the Kleros V2 subgraph, including changes to the event structure, the addition of a new parameter, and updates to related functions and schemas.

### Detailed summary
- Bumped version in `subgraph/package.json` from `0.12.0` to `0.13.0`.
- Modified `StakeSet` type in `schema.graphql` to include an additional parameter.
- Updated `createStakeSetEvent` function to accept a new parameter `_amountAllCourts`.
- Adjusted the creation of `newStakeSetEvent` to include the new parameter.
- Changed event handler signature from `StakeSetEvent` to `StakeSet`.
- Removed the saving of `StakeSetEntity` in `handleStakeSet` function.
- Updated event handlers in `subgraph.yaml` files to match the new `StakeSet` signature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the staking data model by removing the `StakeSet` entity from the `SortitionModule`.
  - Updated event handling to accommodate a new parameter for the `StakeSet` event, enhancing data processing.
  - Adjusted stake management to focus solely on updating user stakes without persisting extra data.

- **Chores**
  - Incremented the package version from 0.12.0 to 0.13.0 for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->