### PR TITLE
feat(DK): pass commit and appeal quicker

### DIFF
--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -577,7 +577,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         } else if (dispute.period == Period.appeal) {
             if (
                 block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)] &&
-                !disputeKits[round.disputeKitID].appealFundingIsFinished(_disputeID)
+                !disputeKits[round.disputeKitID].isAppealFunded(_disputeID)
             ) {
                 revert AppealPeriodNotPassed();
             }

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -575,7 +575,10 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
             dispute.period = Period.appeal;
             emit AppealPossible(_disputeID, dispute.arbitrated);
         } else if (dispute.period == Period.appeal) {
-            if (block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)]) {
+            if (
+                block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)] &&
+                !disputeKits[round.disputeKitID].appealFundingIsFinished(_disputeID)
+            ) {
                 revert AppealPeriodNotPassed();
             }
             dispute.period = Period.execution;

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -517,12 +517,32 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     }
 
     /// @dev Returns true if all of the jurors have cast their votes for the last round.
+    /// Note that this function is to be called directly by the core contract and is not for off-chain usage.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core.
     /// @return Whether all of the jurors have cast their votes for the last round.
     function areVotesAllCast(uint256 _coreDisputeID) external view override returns (bool) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
-        return round.totalVoted == round.votes.length;
+
+        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
+        (, bool hiddenVotes, , , , , ) = core.courts(courtID);
+        uint256 expectedTotalVoted = hiddenVotes ? round.totalCommitted : round.votes.length;
+
+        return round.totalVoted == expectedTotalVoted;
+    }
+
+    /// @dev Returns true if the appeal funding is finished prematurely (e.g. when losing side didn't fund).
+    /// Note that this function is to be called directly by the core contract and is not for off-chain usage.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether the appeal funding is finished.
+    function appealFundingIsFinished(uint256 _coreDisputeID) external view override returns (bool) {
+        (uint256 appealPeriodStart, uint256 appealPeriodEnd) = core.appealPeriod(_coreDisputeID);
+
+        uint256[] memory fundedChoices = getFundedChoices(_coreDisputeID);
+        // Uses block.timestamp from the current tx when called by the core contract.
+        return (fundedChoices.length == 0 &&
+            block.timestamp - appealPeriodStart >=
+            ((appealPeriodEnd - appealPeriodStart) * LOSER_APPEAL_PERIOD_MULTIPLIER) / ONE_BASIS_POINT);
     }
 
     /// @dev Returns true if the specified voter was active in this round.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -535,7 +535,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     /// Note that this function is to be called directly by the core contract and is not for off-chain usage.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @return Whether the appeal funding is finished.
-    function appealFundingIsFinished(uint256 _coreDisputeID) external view override returns (bool) {
+    function isAppealFunded(uint256 _coreDisputeID) external view override returns (bool) {
         (uint256 appealPeriodStart, uint256 appealPeriodEnd) = core.appealPeriod(_coreDisputeID);
 
         uint256[] memory fundedChoices = getFundedChoices(_coreDisputeID);

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -95,7 +95,7 @@ interface IDisputeKit {
     /// @dev Returns true if the appeal funding is finished prematurely (e.g. when losing side didn't fund).
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @return Whether the appeal funding is finished.
-    function appealFundingIsFinished(uint256 _coreDisputeID) external view returns (bool);
+    function isAppealFunded(uint256 _coreDisputeID) external view returns (bool);
 
     /// @dev Returns true if the specified voter was active in this round.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -92,6 +92,11 @@ interface IDisputeKit {
     /// @return Whether all of the jurors have cast their votes for the last round.
     function areVotesAllCast(uint256 _coreDisputeID) external view returns (bool);
 
+    /// @dev Returns true if the appeal funding is finished prematurely (e.g. when losing side didn't fund).
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether the appeal funding is finished.
+    function appealFundingIsFinished(uint256 _coreDisputeID) external view returns (bool);
+
     /// @dev Returns true if the specified voter was active in this round.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the appeal process in the `KlerosCoreBase` contract by adding checks for appeal funding and modifying voting mechanisms in dispute kits.

### Detailed summary
- Added a check in `KlerosCoreBase` to ensure appeal funding is completed before moving to the execution period.
- Introduced `isAppealFunded` function in `IDisputeKit` to verify if appeal funding is finished.
- Updated `areVotesAllCast` in `DisputeKitClassicBase` to account for hidden votes.
- Implemented appeal funding logic in `isAppealFunded` to check if the appeal period has ended.
- Added tests in `KlerosCoreTest` for quick passing of periods during voting and appeal phases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the dispute resolution process by verifying both the timing and appeal funding conditions before transitioning between phases.
	- Refined vote counting to better handle different voting scenarios, ensuring smoother phase transitions.
	- Added a check to determine if appeal funding is finished, improving dispute funding status visibility.

- **Tests**
	- Introduced new tests simulating rapid voting and appeal period transitions.
	- Updated existing tests to confirm proper phase changes and event emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->