### PR TITLE
Fix typo in SafeERC20.sol - "Recepient" to "Recipient"

### DIFF
--- a/contracts/src/libraries/SafeERC20.sol
+++ b/contracts/src/libraries/SafeERC20.sol
@@ -24,7 +24,7 @@ library SafeERC20 {
 
     /// @dev Calls transfer() without reverting.
     /// @param _token Token to transfer.
-    /// @param _to Recepient address.
+    /// @param _to Recipient address.
     /// @param _value Amount transferred.
     /// @return Whether transfer succeeded or not.
     function safeTransfer(IERC20 _token, address _to, uint256 _value) internal returns (bool) {
@@ -35,7 +35,7 @@ library SafeERC20 {
     /// @dev Calls transferFrom() without reverting.
     /// @param _token Token to transfer.
     /// @param _from Sender address.
-    /// @param _to Recepient address.
+    /// @param _to Recipient address.
     /// @param _value Amount transferred.
     /// @return Whether transfer succeeded or not.
     function safeTransferFrom(IERC20 _token, address _from, address _to, uint256 _value) internal returns (bool) {


### PR DESCRIPTION


**Description:**
This PR fixes a spelling error in the comments of SafeERC20.sol library where "Recepient" was incorrectly spelled. Changed to the correct spelling "Recipient" in two locations:

- Line 27: In the comment for safeTransfer() function
- Line 38: In the comment for safeTransferFrom() function

This is a documentation-only change that improves code readability and maintains consistent terminology.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the documentation comments of the `safeTransfer` and `safeTransferFrom` functions within the `SafeERC20` library.

### Detailed summary
- Updated the comment for the `_to` parameter in `safeTransfer` from "Recepient" to "Recipient".
- Updated the comment for the `_to` parameter in `safeTransferFrom` from "Recepient" to "Recipient".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling errors in parameter descriptions within user-facing comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->