### PR TITLE
feat: allow choosing the disputekit in the resolver flow

### DIFF
--- a/web/src/consts/index.ts
+++ b/web/src/consts/index.ts
@@ -42,3 +42,15 @@ export const INVALID_DISPUTE_DATA_ERROR = `The dispute data is not valid, please
 export const RPC_ERROR = `RPC Error: Unable to fetch dispute data. Please avoid voting.`;
 
 export const spamEvidencesIds: string[] = (import.meta.env.REACT_APP_SPAM_EVIDENCES_IDS ?? "").split(",");
+
+export const getDisputeKitName = (id: number): string | undefined => {
+  const universityDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
+  const neoDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
+  const testnetDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
+  const devnetDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit", 2: "Shutter Dispute Kit" };
+
+  if (isKlerosUniversity()) return universityDisputeKits[id];
+  if (isKlerosNeo()) return neoDisputeKits[id];
+  if (isTestnetDeployment()) return testnetDisputeKits[id];
+  return devnetDisputeKits[id];
+};

--- a/web/src/context/NewDisputeContext.tsx
+++ b/web/src/context/NewDisputeContext.tsx
@@ -47,6 +47,7 @@ interface IDisputeData extends IDisputeTemplate {
   numberOfJurors: number;
   arbitrationCost?: string;
   aliasesArray?: AliasArray[];
+  disputeKitId?: number;
 }
 
 interface INewDisputeContext {
@@ -71,6 +72,7 @@ const getInitialDisputeData = (): IDisputeData => ({
     { title: "", id: "2", description: "" },
   ],
   aliasesArray: [{ name: "", address: "", id: "1" }],
+  disputeKitId: 1,
   version: "1.0",
 });
 
@@ -117,7 +119,7 @@ export const NewDisputeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
 const constructDisputeTemplate = (disputeData: IDisputeData) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { courtId, numberOfJurors, arbitrationCost, ...baseTemplate } = disputeData;
+  const { courtId, numberOfJurors, arbitrationCost, disputeKitId, ...baseTemplate } = disputeData;
 
   if (!isUndefined(baseTemplate.aliasesArray)) {
     baseTemplate.aliasesArray = baseTemplate.aliasesArray.filter((item) => item.address !== "" && item.isValid);

--- a/web/src/hooks/queries/useSupportedDisputeKits.ts
+++ b/web/src/hooks/queries/useSupportedDisputeKits.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { useGraphqlBatcher } from "context/GraphqlBatcher";
+import { graphql } from "src/graphql";
+import { SupportedDisputeKitsQuery } from "src/graphql/graphql";
+
+const supportedDisputeKitsQuery = graphql(`
+  query SupportedDisputeKits($id: ID!) {
+    court(id: $id) {
+      supportedDisputeKits {
+        id
+      }
+    }
+  }
+`);
+
+export const useSupportedDisputeKits = (courtId?: string) => {
+  const { graphqlBatcher } = useGraphqlBatcher();
+  return useQuery<SupportedDisputeKitsQuery>({
+    enabled: !!courtId,
+    queryKey: ["SupportedDisputeKits", courtId],
+    staleTime: Infinity,
+    queryFn: async () =>
+      await graphqlBatcher.fetch({
+        id: crypto.randomUUID(),
+        document: supportedDisputeKitsQuery,
+        variables: { id: courtId },
+      }),
+  });
+};

--- a/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
+++ b/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
@@ -42,13 +42,16 @@ const SubmitDisputeButton: React.FC = () => {
     return userBalance && userBalance.value < arbitrationCost;
   }, [userBalance, disputeData]);
 
-  // TODO: decide which dispute kit to use
   const { data: submitCaseConfig, error } = useSimulateDisputeResolverCreateDisputeForTemplate({
     query: {
       enabled: !insufficientBalance && isTemplateValid(disputeTemplate),
     },
     args: [
-      prepareArbitratorExtradata(disputeData.courtId ?? "1", disputeData.numberOfJurors ?? "", 1),
+      prepareArbitratorExtradata(
+        disputeData.courtId ?? "1",
+        disputeData.numberOfJurors ?? "",
+        disputeData.disputeKitId ?? 1
+      ),
       JSON.stringify(disputeTemplate),
       "",
       BigInt(disputeTemplate.answers.length),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the dispute resolution functionality by introducing support for different dispute kits, updating dispute data handling, and refining the UI components for selecting courts and dispute kits.

### Detailed summary
- Added `disputeKitId` to `IDisputeData` and initialized it in `getInitialDisputeData`.
- Updated `prepareArbitratorExtradata` to include `disputeKitId`.
- Introduced `getDisputeKitName` function to map IDs to kit names.
- Created `useSupportedDisputeKits` hook for fetching supported kits.
- Updated `Court` component to handle court and dispute kit selections.
- Added a dropdown for selecting dispute kits in the `Court` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dropdown for users to select a dispute kit when submitting a dispute, with options dynamically adjusted based on the selected court.
  - Introduced dynamic fetching of supported dispute kits per court to provide accurate selection options.

- **Enhancements**
  - The dispute kit selection now defaults to "Classic Dispute Kit" but allows for other options (like "Shutter Dispute Kit") when applicable.
  - Dispute kit selection is preserved or updated appropriately when changing courts during dispute creation.
  - Dispute kit ID is now integrated into dispute data and used dynamically during dispute submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->