### PR TITLE
fix: bug fix in subgraph

### DIFF
--- a/subgraph/core/src/DisputeKitClassic.ts
+++ b/subgraph/core/src/DisputeKitClassic.ts
@@ -161,7 +161,7 @@ export function handleChoiceFunded(event: ChoiceFunded): void {
     const localDispute = ClassicDispute.load(`${disputeKitID}-${coreDisputeID}`);
     if (!localDispute) return;
 
-    if (BigInt.fromString(disputeKitID) === newDisputeKitID) {
+    if (BigInt.fromString(disputeKitID).equals(newDisputeKitID)) {
       const newRoundIndex = localDispute.currentLocalRoundIndex.plus(ONE);
       const numberOfChoices = localDispute.numberOfChoices;
       localDispute.currentLocalRoundIndex = newRoundIndex;

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "drtVersion": "0.12.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@kleros/kleros-v2-subgraph` package and modifies a conditional check in the `DisputeKitClassic.ts` file to use the `equals` method for comparing `BigInt` values.

### Detailed summary
- Updated `version` in `subgraph/package.json` from `0.16.1` to `0.16.2`.
- Changed the conditional check in `subgraph/core/src/DisputeKitClassic.ts` from `if (BigInt.fromString(disputeKitID) === newDisputeKitID)` to `if (BigInt.fromString(disputeKitID).equals(newDisputeKitID))`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->