### PR TITLE
fix(web): remove-rfa-option-in-duplicate-flow

### DIFF
--- a/web/src/pages/Resolver/Landing/index.tsx
+++ b/web/src/pages/Resolver/Landing/index.tsx
@@ -86,7 +86,10 @@ const Landing: React.FC = () => {
     if (isUndefined(populatedDispute) || isUndefined(roundData) || isInvalidDispute) return;
 
     const answers = populatedDispute.answers.reduce<Answer[]>((acc, val) => {
-      acc.push({ ...val, id: parseInt(val.id, 16).toString() });
+      const id = parseInt(val.id, 16);
+      // don't duplicate RFA option
+      if (id === 0) return acc;
+      acc.push({ ...val, id: id.toString() });
       return acc;
     }, []);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the handling of `answers` in the `populatedDispute` object by preventing the addition of duplicate `RFA` options based on the `id` value. It ensures that only valid `id`s are pushed to the accumulator.

### Detailed summary
- Introduced a variable `id` to store the parsed integer value of `val.id`.
- Added a condition to skip pushing to `acc` if `id` equals `0`, preventing duplicates of the `RFA` option.
- Updated the way `id` is stored in the pushed object to ensure it is a string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where duplicate "RFA option" entries could appear in the answers list by filtering out invalid answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->