### PR TITLE
fix: avoid unnecessary calls draw() when no juror is available

### DIFF
--- a/contracts/deploy/upgrade-all.ts
+++ b/contracts/deploy/upgrade-all.ts
@@ -81,7 +81,7 @@ const deployUpgradeAll: DeployFunction = async (hre: HardhatRuntimeEnvironment) 
   await upgrade(disputeKitClassic, "initialize6", []);
   await upgrade(disputeTemplateRegistry, "initialize2", []);
   await upgrade(evidence, "initialize2", []);
-  await upgrade(core, "initialize4", []);
+  await upgrade(core, "initialize5", []);
   await upgrade(policyRegistry, "initialize2", []);
   await upgrade(sortition, "initialize3", []);
 };

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -8,7 +8,7 @@ import {KlerosCoreBase, IDisputeKit, ISortitionModule, IERC20} from "./KlerosCor
 /// Core arbitrator contract for Kleros v2.
 /// Note that this contract trusts the PNK token, the dispute kit and the sortition module contracts.
 contract KlerosCore is KlerosCoreBase {
-    string public constant override version = "0.9.3";
+    string public constant override version = "0.9.4";
 
     // ************************************* //
     // *            Constructor            * //
@@ -56,7 +56,7 @@ contract KlerosCore is KlerosCoreBase {
         );
     }
 
-    function initialize4() external reinitializer(4) {
+    function initialize5() external reinitializer(5) {
         // NOP
     }
 

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -593,7 +593,8 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
     /// @dev Draws jurors for the dispute. Can be called in parts.
     /// @param _disputeID The ID of the dispute.
     /// @param _iterations The number of iterations to run.
-    function draw(uint256 _disputeID, uint256 _iterations) external {
+    /// @return nbDrawnJurors The total number of jurors drawn in the round.
+    function draw(uint256 _disputeID, uint256 _iterations) external returns (uint256 nbDrawnJurors) {
         Dispute storage dispute = disputes[_disputeID];
         uint256 currentRound = dispute.rounds.length - 1;
         Round storage round = dispute.rounds[currentRound];
@@ -616,6 +617,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
             }
         }
         round.drawIterations += i;
+        return round.drawnJurors.length;
     }
 
     /// @dev Appeals the ruling of a specified dispute.

--- a/contracts/src/arbitration/KlerosCoreNeo.sol
+++ b/contracts/src/arbitration/KlerosCoreNeo.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 /// Core arbitrator contract for Kleros v2.
 /// Note that this contract trusts the PNK token, the dispute kit and the sortition module contracts.
 contract KlerosCoreNeo is KlerosCoreBase {
-    string public constant override version = "0.8.0";
+    string public constant override version = "0.9.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -67,7 +67,7 @@ contract KlerosCoreNeo is KlerosCoreBase {
         jurorNft = _jurorNft;
     }
 
-    function initialize4() external reinitializer(4) {
+    function initialize5() external reinitializer(5) {
         // NOP
     }
 

--- a/contracts/src/arbitration/KlerosCoreNeo.sol
+++ b/contracts/src/arbitration/KlerosCoreNeo.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 /// Core arbitrator contract for Kleros v2.
 /// Note that this contract trusts the PNK token, the dispute kit and the sortition module contracts.
 contract KlerosCoreNeo is KlerosCoreBase {
-    string public constant override version = "0.9.0";
+    string public constant override version = "0.9.4";
 
     // ************************************* //
     // *             Storage               * //


### PR DESCRIPTION
⚠️ Requires upgrading KlerosCore

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading the `KlerosCore` and `KlerosCoreNeo` contracts to a new version and updating related initialization functions. It also enhances the `draw` function in `KlerosCoreBase` to return the number of drawn jurors and introduces logic in the `keeperBot` script for handling juror draws.

### Detailed summary
- Updated `KlerosCore` and `KlerosCoreNeo` contracts' version from `0.9.3` and `0.8.0` to `0.9.4`.
- Changed initialization function name from `initialize4` to `initialize5` in both `KlerosCore` and `KlerosCoreNeo`.
- Modified `draw` function in `KlerosCoreBase` to return `nbDrawnJurors`.
- Added logic in `keeperBot` for simulating draw iterations and logging juror availability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The draw function now returns the total number of jurors drawn, providing more transparency after each operation.

- **Bug Fixes**
  - Improved the juror drawing process to avoid unnecessary draw attempts when no additional jurors can be drawn, reducing wasted transactions.

- **Chores**
  - Updated contract versions to 0.9.4.
  - Changed the contract upgrade process to use a new initializer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->