### PR TITLE
chore: timeline clarify remaining time

### DIFF
--- a/web/src/pages/Cases/CaseDetails/Timeline.tsx
+++ b/web/src/pages/Cases/CaseDetails/Timeline.tsx
@@ -83,11 +83,10 @@ const AppealBanner: React.FC = () => {
   const { fundedChoices } = useFundingContext();
 
   const text = useMemo(() => {
-    if (loserSideCountdown)
-      return `${secondsToDayHourMinute(loserSideCountdown)} left until losing options can be funded`;
+    if (loserSideCountdown) return `${secondsToDayHourMinute(loserSideCountdown)} remaining to fund losing options`;
     // only show if loosing option was funded and winner needs funding, else no action is needed from user
     if (winnerSideCountdown && !isUndefined(fundedChoices) && fundedChoices.length > 0)
-      return `${secondsToDayHourMinute(winnerSideCountdown)} left until winning option can be funded`;
+      return `${secondsToDayHourMinute(winnerSideCountdown)} remaining to fund winning option`;
     return;
   }, [loserSideCountdown, winnerSideCountdown, fundedChoices]);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the wording in the `Timeline.tsx` file for better clarity regarding funding options for losing and winning cases.

### Detailed summary
- Changed the text for the countdown of losing options from "left until losing options can be funded" to "remaining to fund losing options".
- Changed the text for the countdown of winning options from "left until winning option can be funded" to "remaining to fund winning option".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated countdown messages in the AppealBanner for improved clarity and consistency. The banner now uses "remaining to fund" phrasing in countdown messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->