### PR TITLE
fix: bug in color loading text in file viewer

### DIFF
--- a/web/src/components/FileViewer/index.tsx
+++ b/web/src/components/FileViewer/index.tsx
@@ -24,6 +24,10 @@ const StyledDocViewer = styled(DocViewer)`
   #pdf-controls {
     z-index: 3;
   }
+
+  [class*="--loading"] {
+    color: ${({ theme }) => theme.secondaryText};
+  }
 `;
 
 /**


### PR DESCRIPTION
(before)
![WhatsApp Image 2025-05-28 at 01 28 28 (1)](https://github.com/user-attachments/assets/2da8b8ec-faff-4020-a0b7-3808395f00a3)


<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new CSS rule for loading states in the `FileViewer` component, enhancing its styling during loading.

### Detailed summary
- Added a new CSS rule for elements with a class containing `--loading`.
- The new rule sets the `color` property to the `secondaryText` value from the theme.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated loading state text color in the file viewer to improve visual consistency with the app’s theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->