### PR TITLE
feat(kleros-sdk): predefined-lambdas-for-mustache

### DIFF
--- a/kleros-sdk/src/dataMappings/utils/lambdas.ts
+++ b/kleros-sdk/src/dataMappings/utils/lambdas.ts
@@ -1,7 +1,7 @@
 export const lambdas = {
   // Converts a value to hex representation
   hex: function () {
-    return function (text: string, render: Function) {
+    return function (text: string, render: (value: string) => string) {
       const originalValueStr = render(text);
       const num = parseInt(originalValueStr, 10);
       if (!isNaN(num)) {

--- a/kleros-sdk/src/dataMappings/utils/lambdas.ts
+++ b/kleros-sdk/src/dataMappings/utils/lambdas.ts
@@ -1,0 +1,13 @@
+export const lambdas = {
+  // Converts a value to hex representation
+  hex: function () {
+    return function (text: string, render: Function) {
+      const originalValueStr = render(text);
+      const num = parseInt(originalValueStr, 10);
+      if (!isNaN(num)) {
+        return "0x" + num.toString(16).toLowerCase();
+      }
+      return originalValueStr;
+    };
+  },
+};

--- a/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
+++ b/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
@@ -1,9 +1,10 @@
 import mustache from "mustache";
 import { DisputeDetails } from "./disputeDetailsTypes";
 import DisputeDetailsSchema, { RefuseToArbitrateAnswer } from "./disputeDetailsSchema";
+import { lambdas } from "./lambdas";
 
 export const populateTemplate = (mustacheTemplate: string, data: any): DisputeDetails => {
-  const render = mustache.render(mustacheTemplate, data);
+  const render = mustache.render(mustacheTemplate, { ...data, ...lambdas });
   const dispute = JSON.parse(render);
 
   const validation = DisputeDetailsSchema.safeParse(dispute);

--- a/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
+++ b/kleros-sdk/src/dataMappings/utils/populateTemplate.ts
@@ -4,7 +4,7 @@ import DisputeDetailsSchema, { RefuseToArbitrateAnswer } from "./disputeDetailsS
 import { lambdas } from "./lambdas";
 
 export const populateTemplate = (mustacheTemplate: string, data: any): DisputeDetails => {
-  const render = mustache.render(mustacheTemplate, { ...data, ...lambdas });
+  const render = mustache.render(mustacheTemplate, { ...lambdas, ...data });
   const dispute = JSON.parse(render);
 
   const validation = DisputeDetailsSchema.safeParse(dispute);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new utility function for converting values to hex representation and integrates it into the `populateTemplate` function to enhance data rendering capabilities.

### Detailed summary
- Added a new `lambdas` object in `lambdas.ts` with a `hex` function.
- The `hex` function converts a string value to its hexadecimal representation.
- Updated the `populateTemplate` function to include `lambdas` in the rendering process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom template functions, including a new function to convert numbers to hexadecimal format within templates.
- **Enhancements**
  - Templates can now utilize additional built-in functions during rendering for more flexible data formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->