### PR TITLE
feat: ens in evidence

### DIFF
--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import styled, { css } from "styled-components";
 
-import Identicon from "react-identicons";
 import ReactMarkdown from "react-markdown";
 import { useParams } from "react-router-dom";
 
@@ -11,7 +10,6 @@ import AttachmentIcon from "svgs/icons/attachment.svg";
 
 import { formatDate } from "utils/date";
 import { getIpfsUrl } from "utils/getIpfsUrl";
-import { shortenAddress } from "utils/shortenAddress";
 
 import { type Evidence } from "src/graphql/graphql";
 import { getTxnExplorerLink } from "src/utils";
@@ -22,6 +20,7 @@ import { responsiveSize } from "styles/responsiveSize";
 
 import { ExternalLink } from "./ExternalLink";
 import { InternalLink } from "./InternalLink";
+import JurorTitle from "pages/Home/TopJurors/JurorCard/JurorTitle";
 
 const StyledCard = styled(Card)`
   width: 100%;
@@ -100,15 +99,12 @@ const BottomShade = styled.div`
 `;
 
 const BottomLeftContent = styled.div`
-  display: block;
-
-  & > *:not(:last-child) {
-    margin-bottom: 8px;
-  }
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
 
   ${landscapeStyle(
     () => css`
-      display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: center;
@@ -119,24 +115,6 @@ const BottomLeftContent = styled.div`
       }
     `
   )}
-`;
-
-const AccountContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 8px;
-  align-items: center;
-
-  canvas {
-    width: 24px;
-    height: 24px;
-  }
-
-  > * {
-    flex-basis: 1;
-    flex-shrink: 0;
-    margin: 0;
-  }
 `;
 
 const ExternalLinkHoverStyle = css`
@@ -151,14 +129,6 @@ const ExternalLinkHoverStyle = css`
       color: ${({ theme }) => theme.primaryBlue};
       cursor: pointer;
     }
-  }
-`;
-
-const Address = styled.p`
-  margin: 0;
-
-  :hover {
-    color: ${({ theme }) => theme.secondaryBlue};
   }
 `;
 
@@ -199,6 +169,23 @@ const StyledInternalLink = styled(InternalLink)`
 
 const FileLinkContainer = styled.div`
   margin-left: auto;
+`;
+
+const StyledJurorInternalLink = styled(InternalLink)`
+  label {
+    color: ${({ theme }) => theme.primaryText};
+  }
+
+  :hover {
+    label {
+      cursor: pointer;
+      color: ${({ theme }) => theme.secondaryBlue};
+    }
+  }
+
+  svg {
+    display: none;
+  }
 `;
 
 const AttachedFileText: React.FC = () => (
@@ -248,12 +235,9 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({
       </TopContent>
       <BottomShade>
         <BottomLeftContent>
-          <AccountContainer>
-            <Identicon size="24" string={sender} />
-            <InternalLink to={profileLink}>
-              <Address>{shortenAddress(sender)}</Address>
-            </InternalLink>
-          </AccountContainer>
+          <StyledJurorInternalLink to={profileLink}>
+            <JurorTitle address={sender} />
+          </StyledJurorInternalLink>
           <StyledExternalLink to={transactionExplorerLink} rel="noopener noreferrer" target="_blank">
             <label>{formatDate(Number(timestamp), true)}</label>
           </StyledExternalLink>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `EvidenceCard` component in `EvidenceCard.tsx`. It simplifies the layout and styling, removes unused imports, and updates the structure for displaying juror information.

### Detailed summary
- Removed unused imports: `Identicon` and `shortenAddress`.
- Added import for `JurorTitle`.
- Updated `BottomLeftContent` to use `flex` layout with a gap.
- Removed `AccountContainer` and replaced it with `StyledJurorInternalLink` using `JurorTitle`.
- Simplified styles for `StyledJurorInternalLink`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display of sender information in evidence cards for a more streamlined and consistent look.
  - Improved layout and responsiveness of the sender information section.
- **Style**
  - Enhanced visual styling and hover effects for sender identity links in evidence cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->