### PR TITLE
Support for Gated Dispute Kits and other improvements

### DIFF
--- a/web/src/consts/index.ts
+++ b/web/src/consts/index.ts
@@ -43,14 +43,9 @@ export const RPC_ERROR = `RPC Error: Unable to fetch dispute data. Please avoid 
 
 export const spamEvidencesIds: string[] = (import.meta.env.REACT_APP_SPAM_EVIDENCES_IDS ?? "").split(",");
 
-export const getDisputeKitName = (id: number): string | undefined => {
-  const universityDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
-  const neoDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
-  const testnetDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit" };
-  const devnetDisputeKits: Record<number, string> = { 1: "Classic Dispute Kit", 2: "Shutter Dispute Kit" };
-
-  if (isKlerosUniversity()) return universityDisputeKits[id];
-  if (isKlerosNeo()) return neoDisputeKits[id];
-  if (isTestnetDeployment()) return testnetDisputeKits[id];
-  return devnetDisputeKits[id];
-};
+export enum DisputeKits {
+  Classic = "Classic Dispute Kit",
+  Shutter = "Shutter Dispute Kit",
+  Gated = "Gated Dispute Kit",
+  GatedShutter = "Gated Shutter Dispute Kit",
+}

--- a/web/src/context/NewDisputeContext.tsx
+++ b/web/src/context/NewDisputeContext.tsx
@@ -51,6 +51,22 @@ interface IDisputeData extends IDisputeTemplate {
   arbitrationCost?: string;
   aliasesArray?: AliasArray[];
   disputeKitId?: number;
+  disputeKitData?: IDisputeKitData;
+}
+
+export type IDisputeKitData = IGatedDisputeData | ISomeFutureDisputeData;
+
+export interface IGatedDisputeData {
+  type: "gated";
+  isERC1155: boolean;
+  tokenGate: string;
+  tokenId: string;
+}
+
+// Placeholder
+export interface ISomeFutureDisputeData {
+  type: "future";
+  contract: string;
 }
 
 interface INewDisputeContext {

--- a/web/src/hooks/queries/useDisputeDetailsQuery.ts
+++ b/web/src/hooks/queries/useDisputeDetailsQuery.ts
@@ -30,6 +30,7 @@ const disputeDetailsQuery = graphql(`
         nbVotes
         disputeKit {
           id
+          address
         }
       }
       currentRoundIndex

--- a/web/src/hooks/queries/useSupportedDisputeKits.ts
+++ b/web/src/hooks/queries/useSupportedDisputeKits.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
+
 import { useGraphqlBatcher } from "context/GraphqlBatcher";
+
 import { graphql } from "src/graphql";
 import { SupportedDisputeKitsQuery } from "src/graphql/graphql";
 
@@ -8,6 +10,7 @@ const supportedDisputeKitsQuery = graphql(`
     court(id: $id) {
       supportedDisputeKits {
         id
+        address
       }
     }
   }

--- a/web/src/hooks/useDisputeKitAddresses.ts
+++ b/web/src/hooks/useDisputeKitAddresses.ts
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+
+import { useChainId } from "wagmi";
+
+import { DisputeKits } from "consts/index";
+
+interface UseDisputeKitAddressesParams {
+  disputeKitAddress?: string;
+}
+
+interface UseDisputeKitAddressesAllReturn {
+  availableDisputeKits: Record<string, DisputeKits>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const DISPUTE_KIT_CONFIG = {
+  [DisputeKits.Classic]: "disputeKitClassicAddress",
+  [DisputeKits.Shutter]: "disputeKitShutterAddress",
+  [DisputeKits.Gated]: "disputeKitGatedAddress",
+  [DisputeKits.GatedShutter]: "disputeKitGatedShutterAddress",
+} as const;
+
+/**
+ * Hook to get dispute kit name based on address
+ * @param disputeKitAddress - Optional specific dispute kit address to identify
+ * @returns The human-readable name of the dispute kit and loading state
+ */
+export const useDisputeKitAddresses = ({ disputeKitAddress }: UseDisputeKitAddressesParams = {}) => {
+  const chainId = useChainId();
+  const [disputeKitName, setDisputeKitName] = useState<DisputeKits | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadDisputeKitName = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // If no dispute kit address is provided, we can't determine the type
+        if (!disputeKitAddress) {
+          setDisputeKitName(undefined);
+          setIsLoading(false);
+          return;
+        }
+
+        // If no chainId, we can't look up from generated contracts
+        if (!chainId) {
+          setDisputeKitName(undefined);
+          setIsLoading(false);
+          return;
+        }
+
+        // Dynamic import to handle cases where generated contracts might not be available
+        try {
+          const generatedContracts = await import("hooks/contracts/generated");
+
+          // Check each dispute kit to see if the address matches
+          for (const [humanName, contractKey] of Object.entries(DISPUTE_KIT_CONFIG)) {
+            const addressMapping = generatedContracts[contractKey as keyof typeof generatedContracts];
+
+            if (addressMapping && typeof addressMapping === "object" && chainId in addressMapping) {
+              const contractAddress = addressMapping[chainId as keyof typeof addressMapping] as string;
+              if (
+                contractAddress &&
+                typeof contractAddress === "string" &&
+                contractAddress.toLowerCase() === disputeKitAddress.toLowerCase()
+              ) {
+                setDisputeKitName(humanName as DisputeKits);
+                return;
+              }
+            }
+          }
+
+          // If no address matches, return undefined
+          setDisputeKitName(undefined);
+        } catch {
+          // If we can't import generated contracts, return undefined
+          setDisputeKitName(undefined);
+        }
+      } catch (err) {
+        console.error("Failed to determine dispute kit name:", err);
+        setError("Failed to determine dispute kit type");
+        setDisputeKitName(undefined);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadDisputeKitName();
+  }, [chainId, disputeKitAddress]);
+
+  return {
+    disputeKitName,
+    isLoading,
+    error,
+  };
+};
+
+/**
+ * Hook to get all dispute kit addresses for the current chain
+ * @returns All dispute kit addresses, loading state, and error state
+ */
+export const useDisputeKitAddressesAll = (): UseDisputeKitAddressesAllReturn => {
+  const chainId = useChainId();
+  const [availableDisputeKits, setAvailableDisputeKits] = useState<Record<string, DisputeKits>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadAllDisputeKitAddresses = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // If no chainId, we can't look up from generated contracts
+        if (!chainId) {
+          setAvailableDisputeKits({});
+          setIsLoading(false);
+          return;
+        }
+
+        // Dynamic import to handle cases where generated contracts might not be available
+        try {
+          const generatedContracts = await import("hooks/contracts/generated");
+          const newAvailableDisputeKits: Record<string, DisputeKits> = {};
+
+          // Iterate through all dispute kits and get their addresses
+          for (const [humanName, contractKey] of Object.entries(DISPUTE_KIT_CONFIG)) {
+            const addressMapping = generatedContracts[contractKey as keyof typeof generatedContracts];
+
+            if (addressMapping && typeof addressMapping === "object" && chainId in addressMapping) {
+              const contractAddress = addressMapping[chainId as keyof typeof addressMapping] as string;
+              if (contractAddress && typeof contractAddress === "string") {
+                newAvailableDisputeKits[contractAddress.toLowerCase()] = humanName as DisputeKits;
+              }
+            }
+          }
+
+          setAvailableDisputeKits(newAvailableDisputeKits);
+        } catch {
+          // If we can't import generated contracts, return empty object
+          setAvailableDisputeKits({});
+        }
+      } catch (err) {
+        console.error("Failed to load dispute kit addresses:", err);
+        setError("Failed to load dispute kit addresses");
+        setAvailableDisputeKits({});
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadAllDisputeKitAddresses();
+  }, [chainId]);
+
+  return {
+    availableDisputeKits,
+    isLoading,
+    error,
+  };
+};

--- a/web/src/pages/Cases/CaseDetails/Appeal/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Appeal/index.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import styled, { css } from "styled-components";
 
-import { useToggle } from "react-use";
 import { useParams } from "react-router-dom";
+import { useToggle } from "react-use";
 
+import { DisputeKits } from "consts/index";
 import { Periods } from "consts/periods";
-import { getDisputeKitName } from "consts/index";
+import { useDisputeKitAddresses } from "hooks/useDisputeKitAddresses";
+
 import { useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
 
 import { landscapeStyle } from "styles/landscapeStyle";
@@ -49,11 +51,10 @@ const Appeal: React.FC<{ currentPeriodIndex: number }> = ({ currentPeriodIndex }
   const [isAppealMiniGuideOpen, toggleAppealMiniGuide] = useToggle(false);
   const { id } = useParams();
   const { data: disputeData } = useDisputeDetailsQuery(id);
-  const disputeKitId = disputeData?.dispute?.currentRound?.disputeKit?.id;
-  const disputeKitName = disputeKitId ? getDisputeKitName(Number(disputeKitId))?.toLowerCase() : "";
-  const isClassicDisputeKit = disputeKitName?.includes("classic") ?? false;
-  const isShutterDisputeKit = disputeKitName?.includes("shutter") ?? false;
-
+  const disputeKitAddress = disputeData?.dispute?.currentRound?.disputeKit?.address;
+  const { disputeKitName } = useDisputeKitAddresses({ disputeKitAddress });
+  const isClassicDisputeKit = disputeKitName === DisputeKits.Classic;
+  const isShutterDisputeKit = disputeKitName === DisputeKits.Shutter;
   return (
     <Container>
       {Periods.appeal === currentPeriodIndex ? (

--- a/web/src/pages/Cases/CaseDetails/Voting/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/Voting/index.tsx
@@ -7,7 +7,9 @@ import { useAccount } from "wagmi";
 
 import VoteIcon from "svgs/icons/voted.svg";
 
+import { DisputeKits } from "consts/index";
 import { Periods } from "consts/periods";
+import { useDisputeKitAddresses } from "hooks/useDisputeKitAddresses";
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
 import { useVotingContext } from "hooks/useVotingContext";
 import { formatDate } from "utils/date";
@@ -17,8 +19,8 @@ import { isLastRound } from "utils/isLastRound";
 import { useAppealCost } from "queries/useAppealCost";
 import { DisputeDetailsQuery, useDisputeDetailsQuery } from "queries/useDisputeDetailsQuery";
 
-import { responsiveSize } from "styles/responsiveSize";
 import { landscapeStyle } from "styles/landscapeStyle";
+import { responsiveSize } from "styles/responsiveSize";
 
 import { getPeriodEndTimestamp } from "components/DisputeView";
 import InfoCard from "components/InfoCard";
@@ -27,8 +29,6 @@ import Popup, { PopupType } from "components/Popup";
 import Classic from "./Classic";
 import Shutter from "./Shutter";
 import VotingHistory from "./VotingHistory";
-
-import { getDisputeKitName } from "consts/index";
 
 const Container = styled.div`
   padding: 20px 16px 16px;
@@ -70,10 +70,10 @@ const Voting: React.FC<IVoting> = ({ arbitrable, currentPeriodIndex, dispute }) 
   const timesPerPeriod = disputeData?.dispute?.court?.timesPerPeriod;
   const finalDate = useFinalDate(lastPeriodChange, currentPeriodIndex, timesPerPeriod);
 
-  const disputeKitId = disputeData?.dispute?.currentRound?.disputeKit?.id;
-  const disputeKitName = disputeKitId ? getDisputeKitName(Number(disputeKitId)) : undefined;
-  const isClassicDisputeKit = disputeKitName?.toLowerCase().includes("classic") ?? false;
-  const isShutterDisputeKit = disputeKitName?.toLowerCase().includes("shutter") ?? false;
+  const disputeKitAddress = disputeData?.dispute?.currentRound?.disputeKit?.address;
+  const { disputeKitName } = useDisputeKitAddresses({ disputeKitAddress });
+  const isClassicDisputeKit = disputeKitName === DisputeKits.Classic;
+  const isShutterDisputeKit = disputeKitName === DisputeKits.Shutter;
 
   const isCommitOrVotePeriod = useMemo(
     () => [Periods.vote, Periods.commit].includes(currentPeriodIndex),

--- a/web/src/pages/Resolver/Briefing/Description.tsx
+++ b/web/src/pages/Resolver/Briefing/Description.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { Textarea } from "@kleros/ui-components-library";
@@ -17,6 +17,7 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
 `;
+
 const StyledTextArea = styled(Textarea)`
   width: 84vw;
   height: 300px;
@@ -26,15 +27,26 @@ const StyledTextArea = styled(Textarea)`
     `
   )}
 `;
+
 const Description: React.FC = () => {
   const { disputeData, setDisputeData } = useNewDisputeContext();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleWrite = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setDisputeData({ ...disputeData, description: event.target.value });
   };
 
+  useEffect(() => {
+    if (containerRef.current) {
+      const textareaElement = containerRef.current.querySelector("textarea");
+      if (textareaElement) {
+        textareaElement.focus();
+      }
+    }
+  }, []);
+
   return (
-    <Container>
+    <Container ref={containerRef}>
       <Header text="Describe the case" />
       <StyledTextArea
         dir="auto"
@@ -46,4 +58,5 @@ const Description: React.FC = () => {
     </Container>
   );
 };
+
 export default Description;

--- a/web/src/pages/Resolver/Briefing/Title.tsx
+++ b/web/src/pages/Resolver/Briefing/Title.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { Field } from "@kleros/ui-components-library";
@@ -33,15 +33,26 @@ const StyledField = styled(Field)`
     `
   )}
 `;
+
 const Title: React.FC = () => {
   const { disputeData, setDisputeData } = useNewDisputeContext();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleWrite = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDisputeData({ ...disputeData, title: event.target.value });
   };
 
+  useEffect(() => {
+    if (containerRef.current) {
+      const inputElement = containerRef.current.querySelector("input");
+      if (inputElement) {
+        inputElement.focus();
+      }
+    }
+  }, []);
+
   return (
-    <Container>
+    <Container ref={containerRef}>
       <Header text="Choose a title" />
       <StyledField
         dir="auto"
@@ -53,4 +64,5 @@ const Title: React.FC = () => {
     </Container>
   );
 };
+
 export default Title;

--- a/web/src/pages/Resolver/NavigationButtons/SubmitBatchDisputesButton.tsx
+++ b/web/src/pages/Resolver/NavigationButtons/SubmitBatchDisputesButton.tsx
@@ -52,7 +52,8 @@ const SubmitBatchDisputesButton: React.FC = () => {
         prepareArbitratorExtradata(
           disputeData.courtId ?? "1",
           disputeData.numberOfJurors ?? 3,
-          disputeData.disputeKitId ?? 1
+          disputeData.disputeKitId ?? 1,
+          disputeData.disputeKitData
         ),
         JSON.stringify(disputeTemplate),
         "",

--- a/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
+++ b/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
@@ -55,7 +55,8 @@ const SubmitDisputeButton: React.FC = () => {
       prepareArbitratorExtradata(
         disputeData.courtId ?? "1",
         disputeData.numberOfJurors ?? "",
-        disputeData.disputeKitId ?? 1
+        disputeData.disputeKitId ?? 1,
+        disputeData.disputeKitData
       ),
       JSON.stringify(disputeTemplate),
       "",

--- a/web/src/pages/Resolver/Parameters/Category.tsx
+++ b/web/src/pages/Resolver/Parameters/Category.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { Field } from "@kleros/ui-components-library";
@@ -40,12 +40,23 @@ const StyledField = styled(Field)`
 
 const Category: React.FC = () => {
   const { disputeData, setDisputeData } = useNewDisputeContext();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleWrite = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDisputeData({ ...disputeData, category: event.target.value });
   };
+
+  useEffect(() => {
+    if (containerRef.current) {
+      const inputElement = containerRef.current.querySelector("input");
+      if (inputElement) {
+        inputElement.focus();
+      }
+    }
+  }, []);
+
   return (
-    <Container>
+    <Container ref={containerRef}>
       <Header text="Choose a category" />
       <StyledField
         dir="auto"
@@ -59,4 +70,5 @@ const Category: React.FC = () => {
     </Container>
   );
 };
+
 export default Category;

--- a/web/src/pages/Resolver/Parameters/Court.tsx
+++ b/web/src/pages/Resolver/Parameters/Court.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { AlertMessage, DropdownCascader, DropdownSelect } from "@kleros/ui-components-library";
+import { AlertMessage, Checkbox, DropdownCascader, DropdownSelect, Field } from "@kleros/ui-components-library";
 
-import { useNewDisputeContext } from "context/NewDisputeContext";
+import { DisputeKits } from "consts/index";
+import { IGatedDisputeData, useNewDisputeContext } from "context/NewDisputeContext";
 import { rootCourtToItems, useCourtTree } from "hooks/queries/useCourtTree";
 import { useDisputeKitAddressesAll } from "hooks/useDisputeKitAddresses";
 import { isUndefined } from "utils/index";
@@ -62,34 +63,103 @@ const StyledDropdownSelect = styled(DropdownSelect)`
   )}
 `;
 
+const StyledField = styled(Field)`
+  width: 84vw;
+  margin-top: 24px;
+  ${landscapeStyle(
+    () => css`
+      width: ${responsiveSize(442, 700, 900)};
+    `
+  )}
+  > small {
+    margin-top: 16px;
+  }
+`;
+
+const StyledCheckbox = styled(Checkbox)`
+  width: 84vw;
+  margin-top: 24px;
+  ${landscapeStyle(
+    () => css`
+      width: ${responsiveSize(442, 700, 900)};
+    `
+  )}
+`;
+
 const Court: React.FC = () => {
   const { disputeData, setDisputeData } = useNewDisputeContext();
+  const [isGatedDisputeKit, setIsGatedDisputeKit] = useState(false);
   const { data: courtTree } = useCourtTree();
   const { data: supportedDisputeKits } = useSupportedDisputeKits(disputeData.courtId);
   const items = useMemo(() => !isUndefined(courtTree?.court) && [rootCourtToItems(courtTree.court)], [courtTree]);
   const { availableDisputeKits } = useDisputeKitAddressesAll();
+
   const disputeKitOptions = useMemo(() => {
     return (
-      supportedDisputeKits?.court?.supportedDisputeKits.map((dk) => ({
-        text: availableDisputeKits[dk.address.toLowerCase()] ?? "",
-        value: dk.id,
-      })) || []
+      supportedDisputeKits?.court?.supportedDisputeKits.map((dk) => {
+        const text = availableDisputeKits[dk.address.toLowerCase()] ?? "";
+        return {
+          text,
+          value: dk.id,
+          gated: text === DisputeKits.Gated || text === DisputeKits.GatedShutter,
+        };
+      }) || []
     );
   }, [supportedDisputeKits, availableDisputeKits]);
 
-  const defaultDisputeKitValue = useMemo(() => {
+  const selectedDisputeKitId = useMemo(() => {
+    // If there's only 1 supported dispute kit, select it by default
     if (disputeKitOptions.length === 1) {
-      return disputeKitOptions[0].value; // If there's only 1 supported dispute kit, select it by default
+      return disputeKitOptions[0].value;
     }
-    return disputeData.disputeKitId ?? 1;
+    // If there's no saved selection, select nothing
+    return disputeData.disputeKitId ?? -1;
   }, [disputeKitOptions, disputeData.disputeKitId]);
 
-  const handleCourtWrite = (courtId: string) => {
-    setDisputeData({ ...disputeData, courtId, disputeKitId: undefined });
+  const handleCourtChange = (courtId: string) => {
+    if (disputeData.courtId !== courtId) {
+      setDisputeData({ ...disputeData, courtId, disputeKitId: undefined });
+    }
   };
 
-  const handleDisputeKitChange = (newValue: string | number) =>
-    setDisputeData({ ...disputeData, disputeKitId: Number(newValue) });
+  const handleDisputeKitChange = (newValue: string | number) => {
+    const options = disputeKitOptions.find((dk) => dk.value === String(newValue));
+    const isNewValueGated = options?.gated ?? false;
+    const gatedDisputeKitData: IGatedDisputeData | undefined = isNewValueGated
+      ? {
+          type: "gated",
+          tokenGate: "",
+          isERC1155: false,
+          tokenId: "0",
+        }
+      : undefined;
+    setIsGatedDisputeKit(isNewValueGated);
+    setDisputeData({ ...disputeData, disputeKitId: Number(newValue), disputeKitData: gatedDisputeKitData });
+  };
+
+  const handleTokenAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const currentData = disputeData.disputeKitData as IGatedDisputeData;
+    setDisputeData({
+      ...disputeData,
+      disputeKitData: { ...currentData, tokenGate: event.target.value },
+    });
+  };
+
+  const handleERC1155TokenChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const currentData = disputeData.disputeKitData as IGatedDisputeData;
+    setDisputeData({
+      ...disputeData,
+      disputeKitData: { ...currentData, isERC1155: event.target.checked },
+    });
+  };
+
+  const handleTokenIdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const currentData = disputeData.disputeKitData as IGatedDisputeData;
+    setDisputeData({
+      ...disputeData,
+      disputeKitData: { ...currentData, tokenId: event.target.value },
+    });
+  };
 
   return (
     <Container>
@@ -97,20 +167,44 @@ const Court: React.FC = () => {
       {items ? (
         <StyledDropdownCascader
           items={items}
-          onSelect={(path: string | number) => typeof path === "string" && handleCourtWrite(path.split("/").pop()!)}
+          onSelect={(path: string | number) => typeof path === "string" && handleCourtChange(path.split("/").pop()!)}
           placeholder="Select Court"
           value={`/courts/${disputeData.courtId}`}
         />
       ) : (
         <StyledSkeleton width={240} height={42} />
       )}
-      {disputeData?.courtId && (
+      {disputeData?.courtId && disputeKitOptions.length > 0 && (
         <StyledDropdownSelect
           items={disputeKitOptions}
           placeholder={{ text: "Select Dispute Kit" }}
-          defaultValue={defaultDisputeKitValue}
+          defaultValue={selectedDisputeKitId}
           callback={handleDisputeKitChange}
         />
+      )}
+      {isGatedDisputeKit && (
+        <>
+          <StyledField
+            dir="auto"
+            onChange={handleTokenAddressChange}
+            value={(disputeData.disputeKitData as IGatedDisputeData)?.tokenGate ?? ""}
+            placeholder="Eg. 0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
+          />
+          <StyledCheckbox
+            onChange={handleERC1155TokenChange}
+            checked={(disputeData.disputeKitData as IGatedDisputeData)?.isERC1155 ?? false}
+            label="ERC-1155 token"
+            small={true}
+          />
+          {(disputeData.disputeKitData as IGatedDisputeData)?.isERC1155 && (
+            <StyledField
+              dir="auto"
+              onChange={handleTokenIdChange}
+              value={(disputeData.disputeKitData as IGatedDisputeData)?.tokenId ?? "0"}
+              placeholder="Eg. 1"
+            />
+          )}
+        </>
       )}
       <AlertMessageContainer>
         <AlertMessage

--- a/web/src/pages/Resolver/Parameters/VotingOptions/index.tsx
+++ b/web/src/pages/Resolver/Parameters/VotingOptions/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { AlertMessage } from "@kleros/ui-components-library";
@@ -39,13 +39,23 @@ const AlertMessageContainer = styled.div`
 
 const VotingOptions: React.FC = () => {
   const { disputeData, setDisputeData } = useNewDisputeContext();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleQuestionWrite = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDisputeData({ ...disputeData, question: event.target.value });
   };
 
+  useEffect(() => {
+    if (containerRef.current) {
+      const inputElement = containerRef.current.querySelector("input");
+      if (inputElement) {
+        inputElement.focus();
+      }
+    }
+  }, []);
+
   return (
-    <Container>
+    <Container ref={containerRef}>
       <Header text="Voting options" />
       <QuestionField
         label="Question"
@@ -67,4 +77,5 @@ const VotingOptions: React.FC = () => {
     </Container>
   );
 };
+
 export default VotingOptions;

--- a/web/src/utils/prepareArbitratorExtradata.ts
+++ b/web/src/utils/prepareArbitratorExtradata.ts
@@ -1,12 +1,65 @@
+import { ethers } from "ethers";
+
+import { IDisputeKitData, IGatedDisputeData, ISomeFutureDisputeData } from "context/NewDisputeContext";
+
+/**
+ * Encodes gated dispute kit data
+ * @param data Gated dispute kit data
+ * @returns Encoded hex string
+ */
+const encodeGatedDisputeData = (data: IGatedDisputeData): string => {
+  // Packing of tokenGate and isERC1155
+  // uint88 (padding 11 bytes) + bool (1 byte) + address (20 bytes) = 32 bytes
+  const packed = ethers.utils.solidityPack(["uint88", "bool", "address"], [0, data.isERC1155, data.tokenGate]);
+  if (!data.tokenId || !data.isERC1155) data.tokenId = "0";
+  return ethers.utils.defaultAbiCoder.encode(["bytes32", "uint256"], [packed, data.tokenId]);
+};
+
+/**
+ * Encodes future dispute kit data
+ * @param data Future dispute kit data
+ * @returns Encoded hex string
+ */
+const encodeFutureDisputeData = (data: ISomeFutureDisputeData): string => {
+  return ethers.utils.defaultAbiCoder.encode(["address"], [data.contract]);
+};
+
+/**
+ * Registry of encoding functions for different dispute kit data types
+ */
+const disputeKitDataEncoders = {
+  gated: encodeGatedDisputeData,
+  future: encodeFutureDisputeData,
+} as const;
+
 /**
  * @param subcourtID ID  of the court the dispute will take place in
  * @param noOfVotes Number of votes the dispute will have
  * @param disputeKit Id of the dispute kit to use
+ * @param disputeKitData Optional dispute kit specific data
  * @returns arbitrator extradata passed in while creating a dispute or querying costs
  */
-export const prepareArbitratorExtradata = (subcourtID: string, noOfVotes: number, disputeKit: number = 1) =>
-  `0x${
-    parseInt(subcourtID, 10).toString(16).padStart(64, "0") +
-    noOfVotes.toString(16).padStart(64, "0") +
-    disputeKit.toString(16).padStart(64, "0")
-  }` as `0x{string}`;
+export const prepareArbitratorExtradata = (
+  subcourtID: string,
+  noOfVotes: number,
+  disputeKit: number = 1,
+  disputeKitData?: IDisputeKitData
+) => {
+  let extraData = ethers.utils.defaultAbiCoder.encode(
+    ["uint256", "uint256", "uint256"],
+    [subcourtID, noOfVotes, disputeKit]
+  ) as `0x{string}`;
+  if (!disputeKitData) {
+    console.log("extraData", extraData);
+    return extraData;
+  }
+
+  const encoder = disputeKitDataEncoders[disputeKitData.type];
+  if (!encoder) {
+    throw new Error(`Unknown dispute kit data type: ${disputeKitData.type}`);
+  }
+  const encodedDisputeKitData = encoder(disputeKitData as any);
+  extraData = ethers.utils.hexConcat([extraData, encodedDisputeKitData]) as `0x{string}`;
+  console.log("extraData", extraData);
+  return extraData;
+};


### PR DESCRIPTION
- Support for Gate and GatedShutter dispute kits
- DisputeKits matching by address
- Future-proof DK-specific `extraData` encoding

⚠️ There is regression where navigating back and forth doesn't display the selected dispute kit (although the dispute data state is correct). 