### PR TITLE
fix(DK): no empty addresses after draw

### DIFF
--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -230,11 +230,14 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
 
         drawnAddress = sortitionModule.draw(key, _coreDisputeID, _nonce);
 
-        if (_postDrawCheck(round, _coreDisputeID, drawnAddress)) {
-            round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));
-            alreadyDrawn[localDisputeID][localRoundID][drawnAddress] = true;
-        } else {
-            drawnAddress = address(0);
+        if (drawnAddress != address(0)) {
+            // Sortition can return 0 address if no one has staked yet.
+            if (_postDrawCheck(round, _coreDisputeID, drawnAddress)) {
+                round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));
+                alreadyDrawn[localDisputeID][localRoundID][drawnAddress] = true;
+            } else {
+                drawnAddress = address(0);
+            }
         }
     }
 

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -229,15 +229,16 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
         bytes32 key = bytes32(uint256(courtID)); // Get the ID of the tree.
 
         drawnAddress = sortitionModule.draw(key, _coreDisputeID, _nonce);
-
-        if (drawnAddress != address(0)) {
+        if (drawnAddress == address(0)) {
             // Sortition can return 0 address if no one has staked yet.
-            if (_postDrawCheck(round, _coreDisputeID, drawnAddress)) {
-                round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));
-                alreadyDrawn[localDisputeID][localRoundID][drawnAddress] = true;
-            } else {
-                drawnAddress = address(0);
-            }
+            return drawnAddress;
+        }
+
+        if (_postDrawCheck(round, _coreDisputeID, drawnAddress)) {
+            round.votes.push(Vote({account: drawnAddress, commit: bytes32(0), choice: 0, voted: false}));
+            alreadyDrawn[localDisputeID][localRoundID][drawnAddress] = true;
+        } else {
+            drawnAddress = address(0);
         }
     }
 

--- a/contracts/test/foundry/KlerosCore.t.sol
+++ b/contracts/test/foundry/KlerosCore.t.sol
@@ -1447,6 +1447,26 @@ contract KlerosCoreTest is Test {
         }
     }
 
+    function test_draw_noEmptyAddresses() public {
+        uint256 disputeID = 0;
+        uint256 roundID = 0;
+
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.roll(block.number + rngLookahead + 1);
+        sortitionModule.passPhase(); // Drawing phase
+
+        core.draw(disputeID, DEFAULT_NB_OF_JURORS); // No one is staked so check that the empty addresses are not drawn.
+
+        KlerosCoreBase.Round memory round = core.getRoundInfo(disputeID, roundID);
+        assertEq(round.drawIterations, 3, "Wrong drawIterations number");
+
+        (, , , , uint256 nbVoters, ) = disputeKit.getRoundInfo(disputeID, roundID, 0);
+        assertEq(nbVoters, 0, "nbVoters should be 0");
+    }
+
     function test_draw_parentCourts() public {
         uint96 newCourtID = 2;
         uint256 disputeID = 0;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `DisputeKitClassicBase` by adding a check to handle cases where no addresses are drawn due to lack of stakes, along with a new test to ensure that empty addresses are not returned during the drawing phase.

### Detailed summary
- Added a check in `DisputeKitClassicBase.sol` to return `drawnAddress` if it is `address(0)`.
- Introduced a new test function `test_draw_noEmptyAddresses` in `KlerosCore.t.sol` to verify that no empty addresses are drawn when no one has staked.
- Validated that `nbVoters` is `0` in the new test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling to ensure that empty (zero) addresses are not processed during juror selection.

* **Tests**
  * Added a test to verify that no empty addresses are drawn when there are no jurors staked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->