### PR TITLE
Enabled Hardhat viaIR compilation with solc v0.8.30

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -26,9 +26,9 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.28",
+        version: "0.8.30",
         settings: {
-          // viaIR: true,
+          viaIR: true,
           optimizer: {
             enabled: true,
             runs: 100,
@@ -44,7 +44,7 @@ const config: HardhatUserConfig = {
         // For Vea
         version: "0.8.24",
         settings: {
-          // viaIR: true,
+          viaIR: true,
           optimizer: {
             enabled: true,
             runs: 100,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -131,7 +131,7 @@
     "gluegun": "^5.2.0",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.2",
-    "hardhat": "2.25.0",
+    "hardhat": "2.26.2",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^1.0.4",
     "hardhat-deploy-ethers": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6147,7 +6147,7 @@ __metadata:
     gluegun: "npm:^5.2.0"
     graphql: "npm:^16.9.0"
     graphql-request: "npm:^7.1.2"
-    hardhat: "npm:2.25.0"
+    hardhat: "npm:2.26.2"
     hardhat-contract-sizer: "npm:^2.10.0"
     hardhat-deploy: "npm:^1.0.4"
     hardhat-deploy-ethers: "npm:^0.4.2"
@@ -7655,7 +7655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr@npm:^0.11.1":
+"@nomicfoundation/edr@npm:^0.11.3":
   version: 0.11.3
   resolution: "@nomicfoundation/edr@npm:0.11.3"
   dependencies:
@@ -10274,13 +10274,6 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10/4e5aed58cabb2bbf6f725da13421aa50a49abb6bc17bfab6c31b8774b073fa7b50d557c61f961a09a85f6056151190f8ac95f13f5b48136ba5841f7d4484ec56
-  languageName: node
-  linkType: hard
-
-"@types/lru-cache@npm:^5.1.0":
-  version: 5.1.1
-  resolution: "@types/lru-cache@npm:5.1.1"
-  checksum: 10/0afadefc983306684a8ef95b6337a0d9e3f687e7e89e1f1f3f2e1ce3fbab5b018bb84cf277d781f871175a2c8f0176762b69e58b6f4296ee1b816cea94d5ef06
   languageName: node
   linkType: hard
 
@@ -20259,17 +20252,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:2.25.0":
-  version: 2.25.0
-  resolution: "hardhat@npm:2.25.0"
+"hardhat@npm:2.26.2":
+  version: 2.26.2
+  resolution: "hardhat@npm:2.26.2"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.1.2"
-    "@nomicfoundation/edr": "npm:^0.11.1"
+    "@nomicfoundation/edr": "npm:^0.11.3"
     "@nomicfoundation/solidity-analyzer": "npm:^0.1.0"
     "@sentry/node": "npm:^5.18.1"
-    "@types/bn.js": "npm:^5.1.0"
-    "@types/lru-cache": "npm:^5.1.0"
     adm-zip: "npm:^0.4.16"
     aggregate-error: "npm:^3.0.0"
     ansi-escapes: "npm:^4.3.0"
@@ -20314,7 +20305,7 @@ __metadata:
       optional: true
   bin:
     hardhat: internal/cli/bootstrap.js
-  checksum: 10/b74e83cf8b48e782dd9b7db0d640bcd68fe303c9e269686f9aa4ddcdd7b80e1ca932907003fd42fda005f38d486e4e59726b0f38fd8bf0b981e5810abcc907db
+  checksum: 10/ef9f5f232264ed45a406a7053ccce71e67b0ce084de2de6fa2c24ff0bb1ec0d7b69f61769b3ac94a50445709b25bcf0d8ee135e1509e53331a3fea44d01cbb63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
And `hardhat` bumped to v2.26.2.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `hardhat` in the `package.json` and `yarn.lock` files, modifies the `version` of the Solidity compiler in `hardhat.config.ts`, and updates a dependency version in `yarn.lock`. It also enables the `viaIR` setting for the compiler.

### Detailed summary
- Updated `hardhat` from `2.25.0` to `2.26.2` in `package.json` and `yarn.lock`.
- Changed Solidity compiler `version` from `0.8.28` to `0.8.30` in `hardhat.config.ts`.
- Enabled `viaIR` setting in `hardhat.config.ts`.
- Updated `@nomicfoundation/edr` version from `^0.11.1` to `^0.11.3` in `yarn.lock`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solidity compiler version for contract builds.
  * Enabled advanced compiler optimization settings.
  * Upgraded Hardhat development tool to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->