### PR TITLE
chore: viaIR compilation enabled for Foundry with explicit solc v0.8.30

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,15 +1,24 @@
 
 [profile.default]
+solc = "0.8.30"
+via_ir = true
+optimizer = true
+optimizer_runs = 500
+optimizer_details = { yulDetails = { stackAllocation = true } }
+additional_compiler_profiles = [
+    { name = "tests", via_ir = false }
+]
+compilation_restrictions = [
+    { paths = "test/foundry/KlerosCore.t.sol", via_ir = false },
+]
 src = 'src'
 out = 'out'
 libs = ['../node_modules', 'lib']
 
 [rpc_endpoints]
 arbitrumSepolia = "https://sepolia-rollup.arbitrum.io/rpc"
-arbitrumGoerli = "https://goerli-rollup.arbitrum.io/rpc"
 arbitrum = "https://arb1.arbitrum.io/rpc"
 sepolia = "https://sepolia.infura.io/v3/${INFURA_API_KEY}"
-goerli = "https://goerli.infura.io/v3/${INFURA_API_KEY}"
 mainnet = "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
 chiado = "https://rpc.chiado.gnosis.gateway.fm"
 gnosischain = "https://rpc.gnosis.gateway.fm"

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -31,23 +31,7 @@ const config: HardhatUserConfig = {
           viaIR: true,
           optimizer: {
             enabled: true,
-            runs: 100,
-          },
-          outputSelection: {
-            "*": {
-              "*": ["storageLayout"],
-            },
-          },
-        },
-      },
-      {
-        // For Vea
-        version: "0.8.24",
-        settings: {
-          viaIR: true,
-          optimizer: {
-            enabled: true,
-            runs: 100,
+            runs: 10000,
           },
           outputSelection: {
             "*": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -154,7 +154,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^1.4.0",
-    "@kleros/vea-contracts": "^0.6.0",
+    "@kleros/vea-contracts": "^0.7.0",
     "@openzeppelin/contracts": "^5.4.0",
     "@shutter-network/shutter-sdk": "0.0.2",
     "isomorphic-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6123,7 +6123,7 @@ __metadata:
     "@kleros/kleros-v2-eslint-config": "workspace:^"
     "@kleros/kleros-v2-prettier-config": "workspace:^"
     "@kleros/kleros-v2-tsconfig": "workspace:^"
-    "@kleros/vea-contracts": "npm:^0.6.0"
+    "@kleros/vea-contracts": "npm:^0.7.0"
     "@logtail/pino": "npm:^0.5.0"
     "@nomicfoundation/hardhat-chai-matchers": "npm:^2.1.0"
     "@nomicfoundation/hardhat-ethers": "npm:^3.1.0"
@@ -6402,10 +6402,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kleros/vea-contracts@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@kleros/vea-contracts@npm:0.6.0"
-  checksum: 10/1dafd94620d3392c2e00e09e7d1ca923007143f8625b4b584411a7b49404ae5630e870d3e260685964d37ccb9c4c4ab406523b8ec4dd9f89bcf6099a4f5976ec
+"@kleros/vea-contracts@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@kleros/vea-contracts@npm:0.7.0"
+  checksum: 10/bba12886020cd4bfce39938de56edf2b56472627871ef91b10b721de655e5c20f632a8cb57679927d868375218007898b12033d769b7d33cd3f18447ca093896
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Also bumped @kleros/vea-contracts to v0.7.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating the version of the `@kleros/vea-contracts` package from `0.6.0` to `0.7.0` across various configuration files and adjusting optimization settings in the `hardhat.config.ts` file.

### Detailed summary
- Updated `@kleros/vea-contracts` version from `0.6.0` to `0.7.0` in `package.json` and `yarn.lock`.
- Increased optimizer `runs` from `100` to `10000` in `hardhat.config.ts`.
- Updated Solidity compiler version to `0.8.30` in `foundry.toml`.
- Added new optimizer settings in `foundry.toml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Solidity compiler settings for improved optimization and compatibility.
  * Removed outdated compiler versions and RPC endpoints from configuration files.
  * Upgraded the "@kleros/vea-contracts" dependency to version ^0.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->