### PR TITLE
fix: coverage script breaking after enabling viaIR

### DIFF
--- a/contracts/.solcover.js
+++ b/contracts/.solcover.js
@@ -7,6 +7,7 @@ const shell = require("shelljs");
 module.exports = {
   istanbulReporter: ["lcov"],
   configureYulOptimizer: true,
+  irMinimum: true,
   onCompileComplete: async function (_config) {
     await run("typechain");
   },

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -28,7 +28,7 @@ const config: HardhatUserConfig = {
       {
         version: "0.8.30",
         settings: {
-          viaIR: true,
+          viaIR: process.env.VIA_IR !== "false", // Defaults to true
           optimizer: {
             enabled: true,
             runs: 10000,

--- a/contracts/scripts/coverage.sh
+++ b/contracts/scripts/coverage.sh
@@ -21,6 +21,7 @@ fi
 # Generate the Hardhat coverage report
 yarn clean
 echo "Building contracts with Hardhat..."
+export VIA_IR=false
 yarn build
 echo "Running Hardhat coverage..."
 yarn hardhat coverage --solcoverjs ./.solcover.js --temp artifacts --show-stack-traces --testfiles "test/**/*.ts"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the configuration for Solidity contract coverage in a Hardhat project. It introduces new environment variable handling and adjustments to the optimizer settings.

### Detailed summary
- In `contracts/.solcover.js`: Added `irMinimum: true`.
- In `contracts/hardhat.config.ts`: Changed `viaIR` to depend on `process.env.VIA_IR`.
- In `contracts/scripts/coverage.sh`: Added `export VIA_IR=false` before running coverage commands.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enabled IR-minimum mode in coverage configuration for improved compatibility.
  - Adjusted coverage workflow to allow disabling IR-based compilation during coverage runs for more reliable reports.
- **Chores**
  - Added an environment-controlled toggle to make IR usage configurable without changing defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->