### PR TITLE
Contracts: interfaces pragma set to any 0.8 solc version

### DIFF
--- a/contracts/src/arbitration/interfaces/IArbitrableV2.sol
+++ b/contracts/src/arbitration/interfaces/IArbitrableV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./IArbitratorV2.sol";
 

--- a/contracts/src/arbitration/interfaces/IArbitratorV2.sol
+++ b/contracts/src/arbitration/interfaces/IArbitratorV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IArbitrableV2.sol";

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./IArbitratorV2.sol";
 

--- a/contracts/src/arbitration/interfaces/IDisputeTemplateRegistry.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeTemplateRegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @title IDisputeTemplate
 /// @notice Dispute Template interface.

--- a/contracts/src/arbitration/interfaces/IEvidence.sol
+++ b/contracts/src/arbitration/interfaces/IEvidence.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @title IEvidence
 interface IEvidence {

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../../libraries/Constants.sol";
 

--- a/contracts/src/gateway/interfaces/IForeignGateway.sol
+++ b/contracts/src/gateway/interfaces/IForeignGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../../arbitration/interfaces/IArbitratorV2.sol";
 import "@kleros/vea-contracts/src/interfaces/gateways/IReceiverGateway.sol";

--- a/contracts/src/gateway/interfaces/IHomeGateway.sol
+++ b/contracts/src/gateway/interfaces/IHomeGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@kleros/vea-contracts/src/interfaces/gateways/ISenderGateway.sol";

--- a/contracts/src/rng/IRandomizer.sol
+++ b/contracts/src/rng/IRandomizer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 // Randomizer protocol interface
 interface IRandomizer {

--- a/contracts/src/rng/RNG.sol
+++ b/contracts/src/rng/RNG.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.0 <0.9.0;
 
 interface RNG {
     /// @dev Request a random number.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Solidity version pragma across multiple contract files to allow for a broader range of compatible compiler versions, specifically from `0.8.0` to less than `0.9.0`.

### Detailed summary
- Updated `pragma solidity` from `^0.8.24` to `>=0.8.0 <0.9.0` in the following files:
  - `contracts/src/rng/RNG.sol`
  - `contracts/src/arbitration/interfaces/IDisputeKit.sol`
  - `contracts/src/arbitration/interfaces/IArbitrableV2.sol`
  - `contracts/src/rng/IRandomizer.sol`
  - `contracts/src/arbitration/interfaces/IEvidence.sol`
  - `contracts/src/arbitration/interfaces/ISortitionModule.sol`
  - `contracts/src/arbitration/interfaces/IDisputeTemplateRegistry.sol`
  - `contracts/src/arbitration/interfaces/IArbitratorV2.sol`
  - `contracts/src/gateway/interfaces/IHomeGateway.sol`
  - `contracts/src/gateway/interfaces/IForeignGateway.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded Solidity compiler compatibility to all 0.8.x versions across arbitration, gateway, and RNG modules.
  - No changes to public interfaces, events, or contract behavior.
  - Improves build flexibility and ecosystem compatibility without requiring updates from users.
  - Existing deployments and integrations continue to work; projects can compile with a wider range of 0.8.x toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->