### PR TITLE
KlerosCore: do not pass the period to voting if all the commits are cast

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 - Bump `hardhat` to v2.26.2 ([#2069](https://github.com/kleros/kleros-v2/issues/2069))
 - Bump `@kleros/vea-contracts` to v0.7.0 ([#2073](https://github.com/kleros/kleros-v2/issues/2073))
 
+### Fixed
+
+- Do not pass to Voting period if all the commits are cast because it breaks the current Shutter auto-reveal process. ([#2085](https://github.com/kleros/kleros-v2/issues/2085))
+
 ## [0.12.0] - 2025-08-05
 
 ### Changed

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -566,10 +566,8 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
             if (round.drawnJurors.length != round.nbVotes) revert DisputeStillDrawing();
             dispute.period = court.hiddenVotes ? Period.commit : Period.vote;
         } else if (dispute.period == Period.commit) {
-            if (
-                block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)] &&
-                !disputeKits[round.disputeKitID].areCommitsAllCast(_disputeID)
-            ) {
+            // Note that we do not want to pass to Voting period if all the commits are cast because it breaks the Shutter auto-reveal currently.
+            if (block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)]) {
                 revert CommitPeriodNotPassed();
             }
             dispute.period = Period.vote;

--- a/contracts/test/foundry/KlerosCore.t.sol
+++ b/contracts/test/foundry/KlerosCore.t.sol
@@ -1622,6 +1622,7 @@ contract KlerosCoreTest is Test {
         }
 
         // Check reveal in the next period
+        vm.warp(block.timestamp + timesPerPeriod[1]);
         core.passPeriod(disputeID);
 
         // Check the require with the wrong choice and then with the wrong salt


### PR DESCRIPTION
It turns out that the Commit period optimization is really close to breaking the Shutter auto-reveal automation. In the Beta dispute 88, decryption time was scheduled barely 30 minutes before the end of the reveal period, leaving about ~3 runs of the bot.

For a court with an equal duration for the commit and reveal period, if all the commits are cast in the first 5 minutes in the period, the decryption time falls ~5 minutes before the end of the reveal period (depending on when the bot passed the period from commit to reveal exactly).

If the same thing happens in a court where the commit period is longer than the reveal period, then it cannot be auto-reveal at all, the decryption time falls after the end of the reveal period.

So in the short term and until Shutter releases event-based decryption, we should revert [the optimisation of the commit period](https://github.com/kleros/kleros-v2/blob/831b062b79f6aefb9fe78ae9063007967908a902/contracts/src/arbitration/KlerosCoreBase.sol#L568-L571). We can keep voting and appeal period optimisations. The impact is only slowing down non-Shutter commit-reveal disputes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the transition between periods in the `KlerosCore` smart contract to prevent issues with the auto-reveal process when all commits are cast. It updates the logic to ensure that the voting period is only entered when appropriate.

### Detailed summary
- Added a check to prevent passing to the Voting period if all commits are cast in `KlerosCore.t.sol`.
- Updated the `KlerosCoreBase.sol` logic to ensure the `CommitPeriodNotPassed` revert is triggered appropriately.
- Updated the `CHANGELOG.md` to reflect the fix and version bump for `@kleros/vea-contracts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Voting now begins only after the commit period’s time window elapses, no longer transitioning early when all commits are submitted. This ensures consistent period progression and avoids premature transitions.

* **Documentation**
  * Updated the changelog to note the fix regarding commit-to-vote period transition timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->