### PR TITLE
fix(web): timeline-bug-fix

### DIFF
--- a/web/src/pages/Cases/CaseDetails/Timeline.tsx
+++ b/web/src/pages/Cases/CaseDetails/Timeline.tsx
@@ -130,16 +130,16 @@ const useTimeline = (dispute: DisputeDetailsQuery["dispute"], currentPeriodIndex
     }
     return [<StyledSkeleton key={index} width={60} />];
   };
-  return titles
-    .map((title, i) => {
-      // if not hidden votes, skip commit index
-      if (!dispute?.court.hiddenVotes && i === Periods.commit) return;
-      return {
+  return titles.flatMap((title, i) => {
+    // if not hidden votes, skip commit index
+    if (!dispute?.court.hiddenVotes && i === Periods.commit) return [];
+    return [
+      {
         title: i + 1 < titles.length && isDesktop ? `${title} Period` : title,
         subitems: getSubitems(i),
-      };
-    })
-    .filter((item) => !isUndefined(item));
+      },
+    ];
+  });
 };
 
 export const getDeadline = (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `useTimeline` function in the `Timeline.tsx` file to streamline the handling of timeline items based on the current period index instead of the current item index, improving clarity and functionality.

### Detailed summary
- Changed `useTimeline` to accept only `currentPeriodIndex`.
- Updated the calculation of `getSubitems` to use `currentPeriodIndex` instead of `currentItemIndex`.
- Simplified the `titles` array to always include "Commit" unless hidden votes are present.
- Refactored the return statement of `titles` to use `flatMap` for cleaner handling of conditional items.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline now correctly identifies and highlights the current period for countdowns and past/current states.
  * “Commit” period appears only when applicable, avoiding incorrect or duplicate phases.
  * Period titles are consistent across cases; “Executed” remains without subitems.

* **Refactor**
  * Streamlined period handling and title determination for more predictable Timeline behavior and fewer UI inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->