### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - Install NodeJS 16:
   - on Red Hat Linux: `sudo dnf module install nodejs:16`
   - on Ubuntu Linux: `sudo snap install node --classic`
-  - on MacOS via [brew](https://brew.sh/): `brew install node`
+  - on MacOS via [Homebrew](https://brew.sh/): `brew install node`
 - Install Yarn v1.22: `npm install -g yarn`
   - Then [upgrade](https://yarnpkg.com/getting-started/install#updating-to-the-latest-versions) Yarn to v3: `yarn set version berry`
 - Install Volta.sh: `curl https://get.volta.sh | bash`
@@ -60,7 +60,7 @@
 - Shell utilities: [jq](https://stedolan.github.io/jq/), [yq](https://mikefarah.gitbook.io/yq/)
   - on Red Hat Linux: `sudo dnf install jq yq`
   - on Ubuntu Linux: `sudo snap install jq yq`
-  - on MacOS via [brew](https://brew.sh/): `brew install jq yq`
+  - on MacOS via [Homebrew](https://brew.sh/): `brew install jq yq`
 
 ### Install the dependencies
 


### PR DESCRIPTION
made an addition to the documentation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the README.md file to improve consistency in naming for the package manager on MacOS, changing "brew" to "Homebrew".

### Detailed summary
- Changed "on MacOS via `brew`" to "on MacOS via `Homebrew`" for consistency in naming.
- Updated the section for installing `jq` and `yq` on MacOS to reflect the same naming change as above.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS prerequisites in README to use “Homebrew” instead of “brew” in display text.
  * Installation commands remain the same (brew install node; brew install jq yq); no functional changes.
  * Improves clarity for new users without altering setup steps or links.
  * Helps avoid confusion for users unfamiliar with the shorthand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->