### PR TITLE
fix: withdraw amounts fix

### DIFF
--- a/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
@@ -81,7 +81,10 @@ const InputDisplay: React.FC<IInputDisplay> = ({ action, amount, setAmount }) =>
 
   const parsedBalance = formatPNK(balance ?? 0n, 0, true);
 
-  const parsedStake = formatPNK(jurorBalance?.[2] ?? 0n, 0, true);
+  const maxWithdrawAmount = jurorBalance
+    ? BigInt(Math.min(Number(jurorBalance[2]), Number(jurorBalance[0] - jurorBalance[1])))
+    : 0n;
+  const parsedMaxWithdrawAmount = formatPNK(maxWithdrawAmount, 0, true);
   const isStaking = useMemo(() => action === ActionType.stake, [action]);
 
   useEffect(() => {
@@ -89,8 +92,8 @@ const InputDisplay: React.FC<IInputDisplay> = ({ action, amount, setAmount }) =>
       setErrorMsg("You need a non-zero PNK balance to stake");
     } else if (isStaking && balance && parsedAmount > balance) {
       setErrorMsg("Insufficient balance to stake this amount");
-    } else if (!isStaking && jurorBalance && parsedAmount > jurorBalance[2]) {
-      setErrorMsg("Insufficient staked amount to withdraw this amount");
+    } else if (!isStaking && jurorBalance && parsedAmount > maxWithdrawAmount) {
+      setErrorMsg("Insufficient available amount to withdraw this amount");
     } else if (
       action === ActionType.stake &&
       courtDetails &&
@@ -102,15 +105,15 @@ const InputDisplay: React.FC<IInputDisplay> = ({ action, amount, setAmount }) =>
     } else {
       setErrorMsg(undefined);
     }
-  }, [parsedAmount, isStaking, balance, jurorBalance, action, courtDetails]);
+  }, [parsedAmount, isStaking, balance, jurorBalance, action, courtDetails, maxWithdrawAmount]);
 
   return (
     <>
       <LabelArea>
-        <label>{`Available ${isStaking ? parsedBalance : parsedStake} PNK`}</label>
+        <label>{`Available ${isStaking ? parsedBalance : parsedMaxWithdrawAmount} PNK`}</label>
         <StyledLabel
           onClick={() => {
-            const amount = isStaking ? parsedBalance : parsedStake;
+            const amount = isStaking ? parsedBalance : parsedMaxWithdrawAmount;
             setAmount(amount);
           }}
         >

--- a/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/InputDisplay.tsx
@@ -82,7 +82,9 @@ const InputDisplay: React.FC<IInputDisplay> = ({ action, amount, setAmount }) =>
   const parsedBalance = formatPNK(balance ?? 0n, 0, true);
 
   const maxWithdrawAmount = jurorBalance
-    ? BigInt(Math.min(Number(jurorBalance[2]), Number(jurorBalance[0] - jurorBalance[1])))
+    ? jurorBalance[2] < jurorBalance[0] - jurorBalance[1]
+      ? jurorBalance[2]
+      : jurorBalance[0] - jurorBalance[1]
     : 0n;
   const parsedMaxWithdrawAmount = formatPNK(maxWithdrawAmount, 0, true);
   const isStaking = useMemo(() => action === ActionType.stake, [action]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `InputDisplay` component by calculating the maximum withdrawable amount for jurors and updating related error messages and displayed values accordingly.

### Detailed summary
- Introduced `maxWithdrawAmount` calculation based on `jurorBalance`.
- Replaced `parsedStake` with `parsedMaxWithdrawAmount` in labels and logic.
- Updated error message for insufficient withdrawal amounts.
- Added `maxWithdrawAmount` to the dependency array in `useEffect`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrects the maximum withdrawable amount to prevent withdrawing more than available.
  - “Withdraw all” now respects the actual available amount.
  - Validation re-runs when availability changes and shows a clearer message: “Insufficient available amount to withdraw this amount.”
  - Display of available amount and quick-fill actions now accurately reflect the current maximum withdrawable balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->