### PR TITLE
Dispute kit can force an early court jump and override the next round nbVotes

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 - Bump `hardhat` to v2.26.2 ([#2069](https://github.com/kleros/kleros-v2/issues/2069))
 - Bump `@kleros/vea-contracts` to v0.7.0 ([#2073](https://github.com/kleros/kleros-v2/issues/2073))
 
+### Added
+
+- Allow the dispute kits to force an early court jump and to override the number of votes after an appeal (future-proofing) ([#2110](https://github.com/kleros/kleros-v2/issues/2110))
+
 ### Fixed
 
 - Do not pass to Voting period if all the commits are cast because it breaks the current Shutter auto-reveal process. ([#2085](https://github.com/kleros/kleros-v2/issues/2085))

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -31,7 +31,7 @@ const config: HardhatUserConfig = {
           viaIR: process.env.VIA_IR !== "false", // Defaults to true
           optimizer: {
             enabled: true,
-            runs: 10000,
+            runs: 2000,
           },
           outputSelection: {
             "*": {

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -930,7 +930,10 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
 
         (, uint256 newDisputeKitID, bool courtJump, ) = _getCourtAndDisputeKitJumps(dispute, round, court, _disputeID);
 
-        uint256 nbVotesAfterAppeal = disputeKits[newDisputeKitID].getNbVotesAfterAppeal(round.nbVotes);
+        uint256 nbVotesAfterAppeal = disputeKits[newDisputeKitID].getNbVotesAfterAppeal(
+            disputeKits[round.disputeKitID],
+            round.nbVotes
+        );
 
         if (courtJump) {
             // Jump to parent court.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -627,6 +627,19 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
             ((appealPeriodEnd - appealPeriodStart) * LOSER_APPEAL_PERIOD_MULTIPLIER) / ONE_BASIS_POINT);
     }
 
+    /// @dev Returns true if the dispute is jumping to a parent court.
+    /// @return Whether the dispute is jumping to a parent court or not.
+    function earlyCourtJump(uint256 /* _coreDisputeID */) external pure override returns (bool) {
+        return false;
+    }
+
+    /// @dev Returns the number of votes after the appeal.
+    /// @param _currentNbVotes The number of votes before the appeal.
+    /// @return The number of votes after the appeal.
+    function getNbVotesAfterAppeal(uint256 _currentNbVotes) external pure override returns (uint256) {
+        return (_currentNbVotes * 2) + 1;
+    }
+
     /// @dev Returns true if the specified voter was active in this round.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -636,7 +636,10 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     /// @dev Returns the number of votes after the appeal.
     /// @param _currentNbVotes The number of votes before the appeal.
     /// @return The number of votes after the appeal.
-    function getNbVotesAfterAppeal(uint256 _currentNbVotes) external pure override returns (uint256) {
+    function getNbVotesAfterAppeal(
+        IDisputeKit /* _previousDisputeKit */,
+        uint256 _currentNbVotes
+    ) external pure override returns (uint256) {
         return (_currentNbVotes * 2) + 1;
     }
 

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -113,6 +113,16 @@ interface IDisputeKit {
     /// @return Whether the appeal funding is finished.
     function isAppealFunded(uint256 _coreDisputeID) external view returns (bool);
 
+    /// @dev Returns true if the dispute is jumping to a parent court.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether the dispute is jumping to a parent court or not.
+    function earlyCourtJump(uint256 _coreDisputeID) external view returns (bool);
+
+    /// @dev Returns the number of votes after the appeal.
+    /// @param _currentNbVotes The number of votes before the appeal.
+    /// @return The number of votes after the appeal.
+    function getNbVotesAfterAppeal(uint256 _currentNbVotes) external view returns (uint256);
+
     /// @dev Returns true if the specified voter was active in this round.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -119,9 +119,13 @@ interface IDisputeKit {
     function earlyCourtJump(uint256 _coreDisputeID) external view returns (bool);
 
     /// @dev Returns the number of votes after the appeal.
+    /// @param _previousDisputeKit The previous Dispute Kit.
     /// @param _currentNbVotes The number of votes before the appeal.
     /// @return The number of votes after the appeal.
-    function getNbVotesAfterAppeal(uint256 _currentNbVotes) external view returns (uint256);
+    function getNbVotesAfterAppeal(
+        IDisputeKit _previousDisputeKit,
+        uint256 _currentNbVotes
+    ) external view returns (uint256); // TODO: remove previousDisputeKit
 
     /// @dev Returns true if the specified voter was active in this round.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the dispute resolution process in the Kleros system by introducing new functionalities to manage court jumps and vote counting after appeals, alongside updates to the `hardhat.config.ts` and the `CHANGELOG.md`.

### Detailed summary
- Updated `optimizer` runs from `10000` to `2000` in `hardhat.config.ts`.
- Added functionality in `DisputeKitClassicBase.sol` for early court jumps and vote counting after appeals.
- Updated `IDisputeKit.sol` to include new functions for court jumps and vote management.
- Refactored court jump logic in `KlerosCoreBase.sol` to utilize new helper functions.
- Enhanced `getNbVotesAfterAppeal` to calculate votes based on appeal status.
- Updated `CHANGELOG.md` to reflect new features and fixes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dispute kits can trigger early court jumps and report post-appeal vote counts.
  - Appeal costs now use post-appeal vote counts for more accurate pricing.

- Refactor
  - Centralized court/jump logic for more consistent, predictable appeal flows and signaling.

- Chores
  - Reduced Solidity optimizer runs to 2000.

- Documentation
  - Changelog updated noting added early-jump and post-appeal vote behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->