### PR TITLE
Sortition module: externalize delayed stakes to a library

### DIFF
--- a/contracts/src/libraries/DelayedStakes.sol
+++ b/contracts/src/libraries/DelayedStakes.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+import {KlerosCore} from "../arbitration/KlerosCore.sol";
+
+/// @title DelayedStakes
+/// @notice Library for managing delayed stakes in the sortition module
+library DelayedStakes {
+    struct Stake {
+        address account; // The address of the juror.
+        uint96 courtID; // The ID of the court.
+        uint256 stake; // The new stake.
+        bool alreadyTransferred; // DEPRECATED. True if tokens were already transferred before delayed stake's execution.
+    }
+
+    struct Queue {
+        uint256 writeIndex; // The index of the last `delayedStake` item that was written to the array. 0 index is skipped.
+        uint256 readIndex; // The index of the next `delayedStake` item that should be processed. Starts at 1 because 0 index is skipped.
+        mapping(uint256 => Stake) stakes; // The delayed stakes storage
+        mapping(address jurorAccount => mapping(uint96 courtId => uint256)) latestDelayedStakeIndex; // DEPRECATED. Maps the juror to its latest delayed stake.
+    }
+
+    /// @notice Initialize the queue
+    /// @param queue The queue to initialize
+    function initialize(Queue storage queue) internal {
+        queue.readIndex = 1; // Skip index 0
+    }
+
+    /// @notice Add a new delayed stake to the queue
+    /// @param queue The delayed stakes queue
+    /// @param account The address of the juror
+    /// @param courtID The ID of the court
+    /// @param stake The new stake amount
+    function add(Queue storage queue, address account, uint96 courtID, uint256 stake) internal {
+        uint256 newWriteIndex = ++queue.writeIndex;
+        Stake storage delayedStake = queue.stakes[newWriteIndex];
+        delayedStake.account = account;
+        delayedStake.courtID = courtID;
+        delayedStake.stake = stake;
+    }
+
+    /// @notice Execute pending delayed stakes
+    /// @param queue The delayed stakes queue
+    /// @param core The KlerosCore instance
+    /// @param iterations The maximum number of stakes to execute
+    /// @return success True if there were stakes to execute, false otherwise
+    function execute(Queue storage queue, KlerosCore core, uint256 iterations) internal returns (bool success) {
+        if (queue.writeIndex < queue.readIndex) {
+            return false; // Nothing to execute.
+        }
+
+        uint256 actualIterations = calculateIterations(queue.writeIndex, queue.readIndex, iterations);
+        uint256 newReadIndex = queue.readIndex + actualIterations;
+
+        for (uint256 i = queue.readIndex; i < newReadIndex; i++) {
+            Stake storage delayedStake = queue.stakes[i];
+            core.setStakeBySortitionModule(delayedStake.account, delayedStake.courtID, delayedStake.stake);
+            delete queue.stakes[i];
+        }
+
+        queue.readIndex = newReadIndex;
+        return true;
+    }
+
+    /// @notice Calculate the actual number of iterations to process
+    /// @param writeIndex The current write index
+    /// @param readIndex The current read index
+    /// @param requestedIterations The requested number of iterations
+    /// @return The actual number of iterations that can be processed
+    function calculateIterations(
+        uint256 writeIndex,
+        uint256 readIndex,
+        uint256 requestedIterations
+    ) internal pure returns (uint256) {
+        if (readIndex + requestedIterations - 1 > writeIndex) {
+            return writeIndex - readIndex + 1;
+        } else {
+            return requestedIterations;
+        }
+    }
+
+    /// @notice Get the number of pending stakes
+    /// @param queue The delayed stakes queue
+    /// @return The number of stakes waiting to be executed
+    function pendingStakesCount(Queue storage queue) internal view returns (uint256) {
+        if (queue.writeIndex < queue.readIndex) {
+            return 0;
+        }
+        return queue.writeIndex - queue.readIndex + 1;
+    }
+}

--- a/contracts/test/arbitration/staking-neo.ts
+++ b/contracts/test/arbitration/staking-neo.ts
@@ -428,10 +428,10 @@ describe("Staking", async () => {
 
       describe("When stake is increased", () => {
         it("Should delay the stake increase", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await pnk.approve(core.target, PNK(1000));
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(3000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(3000));
@@ -443,9 +443,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
         });
       });
@@ -467,11 +467,11 @@ describe("Staking", async () => {
             PNK(3000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(2);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(2);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 1)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should transfer PNK after delayed stake execution", async () => {
@@ -495,9 +495,9 @@ describe("Staking", async () => {
 
       describe("When stake is decreased", async () => {
         it("Should delay the stake decrease", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await expect(core.setStake(2, PNK(1000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(1000));
@@ -509,9 +509,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
         });
       });
@@ -532,11 +532,11 @@ describe("Staking", async () => {
             PNK(1000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(2);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(2);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 1)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should withdraw some PNK", async () => {
@@ -560,9 +560,9 @@ describe("Staking", async () => {
 
       describe("When stake is decreased", async () => {
         it("Should delay the stake decrease", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await expect(core.setStake(2, PNK(1000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(1000));
@@ -574,9 +574,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
         });
       });
@@ -584,7 +584,6 @@ describe("Staking", async () => {
       describe("When stake is increased back to the previous amount", () => {
         it("Should delay the stake increase", async () => {
           balanceBefore = await pnk.balanceOf(deployer);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(2000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(2000));
@@ -596,9 +595,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([deployer, 2, PNK(2000), false]);
         });
@@ -623,11 +622,11 @@ describe("Staking", async () => {
             PNK(2000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(3);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(3);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should not transfer any PNK", async () => {
@@ -651,10 +650,10 @@ describe("Staking", async () => {
 
       describe("When stake is increased", () => {
         it("Should delay the stake increase", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await pnk.approve(core.target, PNK(1000));
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(3000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(3000));
@@ -666,9 +665,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
         });
       });
@@ -676,7 +675,6 @@ describe("Staking", async () => {
       describe("When stake is decreased back to the previous amount", () => {
         it("Should cancel out the stake decrease back", async () => {
           balanceBefore = await pnk.balanceOf(deployer);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(2000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(2000));
@@ -688,9 +686,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([deployer, 2, PNK(2000), false]);
         });
@@ -713,11 +711,11 @@ describe("Staking", async () => {
             PNK(2000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(3);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(3);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should not transfer any PNK", async () => {

--- a/contracts/test/arbitration/staking.ts
+++ b/contracts/test/arbitration/staking.ts
@@ -79,10 +79,10 @@ describe("Staking", async () => {
 
       describe("When stake is increased", () => {
         it("Should delay the stake increase", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await pnk.approve(core.target, PNK(1000));
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(3000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(3000));
@@ -94,9 +94,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
         });
       });
@@ -118,11 +118,11 @@ describe("Staking", async () => {
             PNK(3000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(2);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(2);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 1)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should transfer PNK after delayed stake execution", async () => {
@@ -144,9 +144,9 @@ describe("Staking", async () => {
 
       describe("When stake is decreased", async () => {
         it("Should delay the stake decrease", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await expect(core.setStake(2, PNK(1000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(1000));
@@ -158,9 +158,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
         });
       });
@@ -181,11 +181,11 @@ describe("Staking", async () => {
             PNK(1000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(2);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(2);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 1)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should withdraw some PNK", async () => {
@@ -207,9 +207,9 @@ describe("Staking", async () => {
 
       describe("When stake is decreased", async () => {
         it("Should delay the stake decrease", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await expect(core.setStake(2, PNK(1000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(1000));
@@ -221,9 +221,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
         });
       });
@@ -231,7 +231,6 @@ describe("Staking", async () => {
       describe("When stake is increased back to the previous amount", () => {
         it("Should delay the stake increase", async () => {
           balanceBefore = await pnk.balanceOf(deployer);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(2000))).to.emit(sortition, "StakeDelayed");
           expect(await sortition.getJurorBalance(deployer, 2)).to.be.deep.equal([PNK(4000), 0, PNK(2000), 2]); // stake unchanged, delayed
         });
@@ -241,9 +240,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(1000), false]);
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([deployer, 2, PNK(2000), false]);
         });
@@ -268,11 +267,11 @@ describe("Staking", async () => {
             PNK(2000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(3);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(3);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should not transfer any PNK", async () => {
@@ -294,10 +293,10 @@ describe("Staking", async () => {
 
       describe("When stake is increased", () => {
         it("Should delay the stake increase", async () => {
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(0);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(0);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           await pnk.approve(core.target, PNK(1000));
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(3000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(3000));
@@ -309,9 +308,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(1);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(1);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
         });
       });
@@ -319,7 +318,6 @@ describe("Staking", async () => {
       describe("When stake is decreased back to the previous amount", () => {
         it("Should cancel out the stake decrease back", async () => {
           balanceBefore = await pnk.balanceOf(deployer);
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
           await expect(core.setStake(2, PNK(2000)))
             .to.emit(sortition, "StakeDelayed")
             .withArgs(deployer, 2, PNK(2000));
@@ -331,9 +329,9 @@ describe("Staking", async () => {
         });
 
         it("Should store the delayed stake for later", async () => {
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(1);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(1);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([deployer, 2, PNK(3000), false]);
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([deployer, 2, PNK(2000), false]);
         });
@@ -356,11 +354,11 @@ describe("Staking", async () => {
             PNK(2000),
             2,
           ]); // stake unchanged, delayed
-          expect(await sortition.delayedStakeWriteIndex()).to.be.equal(2);
-          expect(await sortition.delayedStakeReadIndex()).to.be.equal(3);
+          let delayedStakesQueue = await sortition.delayedStakesQueue();
+          expect(delayedStakesQueue.writeIndex).to.be.equal(2);
+          expect(delayedStakesQueue.readIndex).to.be.equal(3);
           expect(await sortition.delayedStakes(1)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 1st delayed stake got deleted
           expect(await sortition.delayedStakes(2)).to.be.deep.equal([ethers.ZeroAddress, 0, 0, false]); // the 2nd delayed stake got deleted
-          expect(await sortition.latestDelayedStakeIndex(deployer, 2)).to.be.equal(0); // Deprecated. Always 0
         });
 
         it("Should not transfer any PNK", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on enhancing the staking functionality within the Kleros arbitration system. It introduces a new `DelayedStakes` library for managing delayed stakes, updates function signatures for clarity, and improves gas efficiency.

### Detailed summary
- Reduced `runs` in `hardhat.config.ts` optimizer from 10,000 to 2,000.
- Increased `gasLimit` in `setStake` from 300,000 to 500,000.
- Updated `draw` function in `IDisputeKit` to return `fromSubcourtID`.
- Added `setStakePenalty` function in `ISortitionModule`.
- Removed `penalizeStake` function.
- Updated `draw` function in `ISortitionModule` to return `fromSubcourtID`.
- Modified `getJurorBalance` to include `fromSubcourtID`.
- Introduced `DelayedStakes` library for handling delayed stakes.
- Replaced direct delayed stake management with `DelayedStakes` library methods.
- Updated tests to reflect changes in delayed stake handling and assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-subcourt juror tracking enables accurate penalties, unstaking, and rewards based on the juror’s origin court.
  - Expanded visibility: query juror balances per court and inspect delayed stakes, including queue length and individual entries.
- Refactor
  - Migrated delayed-stake processing to a queue for more reliable and scalable stake execution.
- Chores
  - Updated Solidity compiler optimizer runs for improved build characteristics.
- Tests
  - Test suites updated to the new delayed-stakes queue and struct-based accessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->