### PR TITLE
Sortition trees extracted to a library

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 - Make the primary VRF-based RNG fall back to `BlockhashRNG` if the VRF request is not fulfilled within a timeout ([#2054](https://github.com/kleros/kleros-v2/issues/2054))
 - Authenticate the calls to the RNGs to prevent 3rd parties from depleting the Chainlink VRF subscription funds ([#2054](https://github.com/kleros/kleros-v2/issues/2054))
 - Use `block.timestamp` rather than `block.number` for `BlockhashRNG` for better reliability on Arbitrum as block production is sporadic depending on network conditions. ([#2054](https://github.com/kleros/kleros-v2/issues/2054))
+- Replace the `bytes32 _key` parameter in `SortitionTrees.createTree()` and `SortitionTrees.draw()` by `uint96 courtID` ([#2113](https://github.com/kleros/kleros-v2/issues/2113))
+- Extract the sortition sum trees logic into a library `SortitionTrees` ([#2113](https://github.com/kleros/kleros-v2/issues/2113))
 - Set the Hardhat Solidity version to v0.8.30 and enable the IR pipeline ([#2069](https://github.com/kleros/kleros-v2/issues/2069))
 - Set the Foundry Solidity version to v0.8.30 and enable the IR pipeline ([#2073](https://github.com/kleros/kleros-v2/issues/2073))
 - Widen the allowed solc version to any v0.8.x for the interfaces only ([#2083](https://github.com/kleros/kleros-v2/issues/2083))

--- a/contracts/src/arbitration/KlerosCoreBase.sol
+++ b/contracts/src/arbitration/KlerosCoreBase.sol
@@ -223,7 +223,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         // FORKING_COURT
         // TODO: Fill the properties for the Forking court, emit CourtCreated.
         courts.push();
-        sortitionModule.createTree(bytes32(uint256(FORKING_COURT)), _sortitionExtraData);
+        sortitionModule.createTree(FORKING_COURT, _sortitionExtraData);
 
         // GENERAL_COURT
         Court storage court = courts.push();
@@ -236,7 +236,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         court.jurorsForCourtJump = _courtParameters[3];
         court.timesPerPeriod = _timesPerPeriod;
 
-        sortitionModule.createTree(bytes32(uint256(GENERAL_COURT)), _sortitionExtraData);
+        sortitionModule.createTree(GENERAL_COURT, _sortitionExtraData);
 
         uint256[] memory supportedDisputeKits = new uint256[](1);
         supportedDisputeKits[0] = DISPUTE_KIT_CLASSIC;
@@ -343,7 +343,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         if (_supportedDisputeKits.length == 0) revert UnsupportedDisputeKit();
         if (_parent == FORKING_COURT) revert InvalidForkingCourtAsParent();
 
-        uint256 courtID = courts.length;
+        uint96 courtID = uint96(courts.length);
         Court storage court = courts.push();
 
         for (uint256 i = 0; i < _supportedDisputeKits.length; i++) {
@@ -364,7 +364,7 @@ abstract contract KlerosCoreBase is IArbitratorV2, Initializable, UUPSProxiable 
         court.jurorsForCourtJump = _jurorsForCourtJump;
         court.timesPerPeriod = _timesPerPeriod;
 
-        sortitionModule.createTree(bytes32(courtID), _sortitionExtraData);
+        sortitionModule.createTree(courtID, _sortitionExtraData);
 
         // Update the parent.
         courts[_parent].children.push(courtID);

--- a/contracts/src/arbitration/SortitionModuleBase.sol
+++ b/contracts/src/arbitration/SortitionModuleBase.sol
@@ -7,24 +7,19 @@ import {ISortitionModule} from "./interfaces/ISortitionModule.sol";
 import {IDisputeKit} from "./interfaces/IDisputeKit.sol";
 import {Initializable} from "../proxy/Initializable.sol";
 import {UUPSProxiable} from "../proxy/UUPSProxiable.sol";
+import {SortitionTrees, TreeKey, CourtID} from "../libraries/SortitionTrees.sol";
 import {IRNG} from "../rng/IRNG.sol";
 import "../libraries/Constants.sol";
 
 /// @title SortitionModuleBase
 /// @dev A factory of trees that keeps track of staked values for sortition.
 abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSProxiable {
+    using SortitionTrees for SortitionTrees.Tree;
+    using SortitionTrees for mapping(TreeKey key => SortitionTrees.Tree);
+
     // ************************************* //
     // *         Enums / Structs           * //
     // ************************************* //
-
-    struct SortitionSumTree {
-        uint256 K; // The maximum number of children per node.
-        uint256[] stack; // We use this to keep track of vacant positions in the tree after removing a leaf. This is for keeping the tree as balanced as possible without spending gas on moving nodes around.
-        uint256[] nodes; // The tree nodes.
-        // Two-way mapping of IDs to node indexes. Note that node index 0 is reserved for the root node, and means the ID does not have a node.
-        mapping(bytes32 stakePathID => uint256 nodeIndex) IDsToNodeIndexes;
-        mapping(uint256 nodeIndex => bytes32 stakePathID) nodeIndexesToIDs;
-    }
 
     struct DelayedStake {
         address account; // The address of the juror.
@@ -56,7 +51,7 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     uint256 public rngLookahead; // DEPRECATED: to be removed in the next redeploy
     uint256 public delayedStakeWriteIndex; // The index of the last `delayedStake` item that was written to the array. 0 index is skipped.
     uint256 public delayedStakeReadIndex; // The index of the next `delayedStake` item that should be processed. Starts at 1 because 0 index is skipped.
-    mapping(bytes32 treeHash => SortitionSumTree) sortitionSumTrees; // The mapping trees by keys.
+    mapping(TreeKey key => SortitionTrees.Tree) sortitionSumTrees; // The mapping of sortition trees by keys.
     mapping(address account => Juror) public jurors; // The jurors.
     mapping(uint256 => DelayedStake) public delayedStakes; // Stores the stakes that were changed during Drawing phase, to update them when the phase is switched to Staking.
     mapping(address jurorAccount => mapping(uint96 courtId => uint256)) public latestDelayedStakeIndex; // DEPRECATED. Maps the juror to its latest delayed stake. If there is already a delayed stake for this juror then it'll be replaced. latestDelayedStakeIndex[juror][courtID].
@@ -185,15 +180,12 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     }
 
     /// @dev Create a sortition sum tree at the specified key.
-    /// @param _key The key of the new tree.
+    /// @param _courtID The ID of the court.
     /// @param _extraData Extra data that contains the number of children each node in the tree should have.
-    function createTree(bytes32 _key, bytes memory _extraData) external override onlyByCore {
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
+    function createTree(uint96 _courtID, bytes memory _extraData) external override onlyByCore {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
         uint256 K = _extraDataToTreeK(_extraData);
-        if (tree.K != 0) revert TreeAlreadyExists();
-        if (K <= 1) revert KMustBeGreaterThanOne();
-        tree.K = K;
-        tree.nodes.push(0);
+        sortitionSumTrees.createTree(key, K);
     }
 
     /// @dev Executes the next delayed stakes.
@@ -398,12 +390,13 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
         }
 
         // Update the sortition sum tree.
-        bytes32 stakePathID = _accountAndCourtIDToStakePathID(_account, _courtID);
+        bytes32 stakePathID = SortitionTrees.toStakePathID(_account, _courtID);
         bool finished = false;
         uint96 currentCourtID = _courtID;
         while (!finished) {
             // Tokens are also implicitly staked in parent courts through sortition module to increase the chance of being drawn.
-            _set(bytes32(uint256(currentCourtID)), _newStake, stakePathID);
+            TreeKey key = CourtID.wrap(currentCourtID).toTreeKey();
+            sortitionSumTrees[key].set(_newStake, stakePathID);
             if (currentCourtID == GENERAL_COURT) {
                 finished = true;
             } else {
@@ -477,7 +470,7 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
 
     /// @dev Draw an ID from a tree using a number.
     /// Note that this function reverts if the sum of all values in the tree is 0.
-    /// @param _key The key of the tree.
+    /// @param _courtID The ID of the court.
     /// @param _coreDisputeID Index of the dispute in Kleros Core.
     /// @param _nonce Nonce to hash with random number.
     /// @return drawnAddress The drawn address.
@@ -485,41 +478,14 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     /// `k` is the maximum number of children per node in the tree,
     ///  and `n` is the maximum number of nodes ever appended.
     function draw(
-        bytes32 _key,
+        uint96 _courtID,
         uint256 _coreDisputeID,
         uint256 _nonce
     ) public view override returns (address drawnAddress, uint96 fromSubcourtID) {
         if (phase != Phase.drawing) revert NotDrawingPhase();
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
 
-        if (tree.nodes[0] == 0) {
-            return (address(0), 0); // No jurors staked.
-        }
-
-        uint256 currentDrawnNumber = uint256(keccak256(abi.encodePacked(randomNumber, _coreDisputeID, _nonce))) %
-            tree.nodes[0];
-
-        // While it still has children
-        uint256 treeIndex = 0;
-        while ((tree.K * treeIndex) + 1 < tree.nodes.length) {
-            for (uint256 i = 1; i <= tree.K; i++) {
-                // Loop over children.
-                uint256 nodeIndex = (tree.K * treeIndex) + i;
-                uint256 nodeValue = tree.nodes[nodeIndex];
-
-                if (currentDrawnNumber >= nodeValue) {
-                    // Go to the next child.
-                    currentDrawnNumber -= nodeValue;
-                } else {
-                    // Pick this child.
-                    treeIndex = nodeIndex;
-                    break;
-                }
-            }
-        }
-
-        bytes32 stakePathID = tree.nodeIndexesToIDs[treeIndex];
-        (drawnAddress, fromSubcourtID) = _stakePathIDToAccountAndCourtID(stakePathID);
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        (drawnAddress, fromSubcourtID) = sortitionSumTrees[key].draw(_coreDisputeID, _nonce, randomNumber);
     }
 
     /// @dev Get the stake of a juror in a court.
@@ -527,21 +493,9 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     /// @param _courtID The ID of the court.
     /// @return value The stake of the juror in the court.
     function stakeOf(address _juror, uint96 _courtID) public view returns (uint256) {
-        bytes32 stakePathID = _accountAndCourtIDToStakePathID(_juror, _courtID);
-        return stakeOf(bytes32(uint256(_courtID)), stakePathID);
-    }
-
-    /// @dev Get the stake of a juror in a court.
-    /// @param _key The key of the tree, corresponding to a court.
-    /// @param _stakePathID The stake path ID, corresponding to a juror.
-    /// @return The stake of the juror in the court.
-    function stakeOf(bytes32 _key, bytes32 _stakePathID) public view returns (uint256) {
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
-        uint treeIndex = tree.IDsToNodeIndexes[_stakePathID];
-        if (treeIndex == 0) {
-            return 0;
-        }
-        return tree.nodes[treeIndex];
+        bytes32 stakePathID = SortitionTrees.toStakePathID(_juror, _courtID);
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return sortitionSumTrees[key].stakeOf(stakePathID);
     }
 
     /// @dev Gets the balance of a juror in a court.
@@ -590,26 +544,6 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     // *            Internal               * //
     // ************************************* //
 
-    /// @dev Update all the parents of a node.
-    /// @param _key The key of the tree to update.
-    /// @param _treeIndex The index of the node to start from.
-    /// @param _plusOrMinus Whether to add (true) or substract (false).
-    /// @param _value The value to add or substract.
-    /// `O(log_k(n))` where
-    /// `k` is the maximum number of children per node in the tree,
-    ///  and `n` is the maximum number of nodes ever appended.
-    function _updateParents(bytes32 _key, uint256 _treeIndex, bool _plusOrMinus, uint256 _value) private {
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
-
-        uint256 parentIndex = _treeIndex;
-        while (parentIndex != 0) {
-            parentIndex = (parentIndex - 1) / tree.K;
-            tree.nodes[parentIndex] = _plusOrMinus
-                ? tree.nodes[parentIndex] + _value
-                : tree.nodes[parentIndex] - _value;
-        }
-    }
-
     function _extraDataToTreeK(bytes memory _extraData) internal pure returns (uint256 K) {
         if (_extraData.length >= 32) {
             assembly {
@@ -618,151 +552,6 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
             }
         } else {
             K = DEFAULT_K;
-        }
-    }
-
-    /// @dev Set a value in a tree.
-    /// @param _key The key of the tree.
-    /// @param _value The new value.
-    /// @param _stakePathID The ID of the value.
-    /// `O(log_k(n))` where
-    /// `k` is the maximum number of children per node in the tree,
-    ///  and `n` is the maximum number of nodes ever appended.
-    function _set(bytes32 _key, uint256 _value, bytes32 _stakePathID) internal {
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
-        uint256 treeIndex = tree.IDsToNodeIndexes[_stakePathID];
-
-        if (treeIndex == 0) {
-            // No existing node.
-            if (_value != 0) {
-                // Non zero value.
-                // Append.
-                // Add node.
-                if (tree.stack.length == 0) {
-                    // No vacant spots.
-                    // Get the index and append the value.
-                    treeIndex = tree.nodes.length;
-                    tree.nodes.push(_value);
-
-                    // Potentially append a new node and make the parent a sum node.
-                    if (treeIndex != 1 && (treeIndex - 1) % tree.K == 0) {
-                        // Is first child.
-                        uint256 parentIndex = treeIndex / tree.K;
-                        bytes32 parentID = tree.nodeIndexesToIDs[parentIndex];
-                        uint256 newIndex = treeIndex + 1;
-                        tree.nodes.push(tree.nodes[parentIndex]);
-                        delete tree.nodeIndexesToIDs[parentIndex];
-                        tree.IDsToNodeIndexes[parentID] = newIndex;
-                        tree.nodeIndexesToIDs[newIndex] = parentID;
-                    }
-                } else {
-                    // Some vacant spot.
-                    // Pop the stack and append the value.
-                    treeIndex = tree.stack[tree.stack.length - 1];
-                    tree.stack.pop();
-                    tree.nodes[treeIndex] = _value;
-                }
-
-                // Add label.
-                tree.IDsToNodeIndexes[_stakePathID] = treeIndex;
-                tree.nodeIndexesToIDs[treeIndex] = _stakePathID;
-
-                _updateParents(_key, treeIndex, true, _value);
-            }
-        } else {
-            // Existing node.
-            if (_value == 0) {
-                // Zero value.
-                // Remove.
-                // Remember value and set to 0.
-                uint256 value = tree.nodes[treeIndex];
-                tree.nodes[treeIndex] = 0;
-
-                // Push to stack.
-                tree.stack.push(treeIndex);
-
-                // Clear label.
-                delete tree.IDsToNodeIndexes[_stakePathID];
-                delete tree.nodeIndexesToIDs[treeIndex];
-
-                _updateParents(_key, treeIndex, false, value);
-            } else if (_value != tree.nodes[treeIndex]) {
-                // New, non zero value.
-                // Set.
-                bool plusOrMinus = tree.nodes[treeIndex] <= _value;
-                uint256 plusOrMinusValue = plusOrMinus
-                    ? _value - tree.nodes[treeIndex]
-                    : tree.nodes[treeIndex] - _value;
-                tree.nodes[treeIndex] = _value;
-
-                _updateParents(_key, treeIndex, plusOrMinus, plusOrMinusValue);
-            }
-        }
-    }
-
-    /// @dev Packs an account and a court ID into a stake path ID: [20 bytes of address][12 bytes of courtID] = 32 bytes total.
-    /// @param _account The address of the juror to pack.
-    /// @param _courtID The court ID to pack.
-    /// @return stakePathID The stake path ID.
-    function _accountAndCourtIDToStakePathID(
-        address _account,
-        uint96 _courtID
-    ) internal pure returns (bytes32 stakePathID) {
-        assembly {
-            // solium-disable-line security/no-inline-assembly
-            let ptr := mload(0x40)
-
-            // Write account address (first 20 bytes)
-            for {
-                let i := 0x00
-            } lt(i, 0x14) {
-                i := add(i, 0x01)
-            } {
-                mstore8(add(ptr, i), byte(add(0x0c, i), _account))
-            }
-
-            // Write court ID (last 12 bytes)
-            for {
-                let i := 0x14
-            } lt(i, 0x20) {
-                i := add(i, 0x01)
-            } {
-                mstore8(add(ptr, i), byte(i, _courtID))
-            }
-            stakePathID := mload(ptr)
-        }
-    }
-
-    /// @dev Retrieves both juror's address and court ID from the stake path ID.
-    /// @param _stakePathID The stake path ID to unpack.
-    /// @return account The account.
-    /// @return courtID The court ID.
-    function _stakePathIDToAccountAndCourtID(
-        bytes32 _stakePathID
-    ) internal pure returns (address account, uint96 courtID) {
-        assembly {
-            // solium-disable-line security/no-inline-assembly
-            let ptr := mload(0x40)
-
-            // Read account address (first 20 bytes)
-            for {
-                let i := 0x00
-            } lt(i, 0x14) {
-                i := add(i, 0x01)
-            } {
-                mstore8(add(add(ptr, 0x0c), i), byte(i, _stakePathID))
-            }
-            account := mload(ptr)
-
-            // Read court ID (last 12 bytes)
-            for {
-                let i := 0x00
-            } lt(i, 0x0c) {
-                i := add(i, 0x01)
-            } {
-                mstore8(add(add(ptr, 0x14), i), byte(add(i, 0x14), _stakePathID))
-            }
-            courtID := mload(ptr)
         }
     }
 
@@ -776,8 +565,6 @@ abstract contract SortitionModuleBase is ISortitionModule, Initializable, UUPSPr
     error NoDisputesThatNeedJurors();
     error RandomNumberNotReady();
     error DisputesWithoutJurorsAndMaxDrawingTimeNotPassed();
-    error TreeAlreadyExists();
-    error KMustBeGreaterThanOne();
     error NotStakingPhase();
     error NoDelayedStakeToExecute();
     error NotEligibleForWithdrawal();

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -232,9 +232,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
 
         ISortitionModule sortitionModule = core.sortitionModule();
         (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
-        bytes32 key = bytes32(uint256(courtID)); // Get the ID of the tree.
-
-        (drawnAddress, fromSubcourtID) = sortitionModule.draw(key, _coreDisputeID, _nonce);
+        (drawnAddress, fromSubcourtID) = sortitionModule.draw(courtID, _coreDisputeID, _nonce);
         if (drawnAddress == address(0)) {
             // Sortition can return 0 address if no one has staked yet.
             return (drawnAddress, fromSubcourtID);

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -13,7 +13,7 @@ interface ISortitionModule {
 
     event NewPhase(Phase _phase);
 
-    function createTree(bytes32 _key, bytes memory _extraData) external;
+    function createTree(uint96 _courtID, bytes memory _extraData) external;
 
     function validateStake(
         address _account,
@@ -49,7 +49,7 @@ interface ISortitionModule {
     function notifyRandomNumber(uint256 _drawnNumber) external;
 
     function draw(
-        bytes32 _court,
+        uint96 _courtID,
         uint256 _coreDisputeID,
         uint256 _nonce
     ) external view returns (address drawnAddress, uint96 fromSubcourtID);

--- a/contracts/src/arbitration/university/SortitionModuleUniversity.sol
+++ b/contracts/src/arbitration/university/SortitionModuleUniversity.sol
@@ -112,7 +112,7 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
         transientJuror = _juror;
     }
 
-    function createTree(bytes32 _key, bytes memory _extraData) external {
+    function createTree(uint96 _courtID, bytes memory _extraData) external {
         // NOP
     }
 
@@ -345,11 +345,7 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
     /// @dev Draw an ID from a tree using a number.
     /// Note that this function reverts if the sum of all values in the tree is 0.
     /// @return drawnAddress The drawn address.
-    function draw(
-        bytes32,
-        uint256,
-        uint256
-    ) public view override returns (address drawnAddress, uint96 fromSubcourtID) {
+    function draw(uint96, uint256, uint256) public view override returns (address drawnAddress, uint96 fromSubcourtID) {
         drawnAddress = transientJuror;
     }
 

--- a/contracts/src/libraries/SortitionTrees.sol
+++ b/contracts/src/libraries/SortitionTrees.sol
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+type TreeKey is bytes32;
+type CourtID is uint96;
+
+using {toTreeKey} for CourtID global;
+
+function toTreeKey(CourtID _courtID) pure returns (TreeKey) {
+    return TreeKey.wrap(bytes32(uint256(CourtID.unwrap(_courtID))));
+}
+
+library SortitionTrees {
+    struct Tree {
+        uint256 K; // The maximum number of children per node.
+        uint256[] stack; // We use this to keep track of vacant positions in the tree after removing a leaf. This is for keeping the tree as balanced as possible without spending gas on moving nodes around.
+        uint256[] nodes; // The tree nodes.
+        // Two-way mapping of IDs to node indexes. Note that node index 0 is reserved for the root node, and means the ID does not have a node.
+        mapping(bytes32 stakePathID => uint256 nodeIndex) IDsToNodeIndexes;
+        mapping(uint256 nodeIndex => bytes32 stakePathID) nodeIndexesToIDs;
+    }
+
+    /// @dev Create a sortition sum tree at the specified key.
+    /// @param _trees The mapping of sortition sum trees.
+    /// @param _key The key of the new tree.
+    /// @param _k The maximum number of children per node.
+    function createTree(mapping(TreeKey key => Tree) storage _trees, TreeKey _key, uint256 _k) internal {
+        Tree storage tree = _trees[_key];
+        if (tree.K != 0) revert TreeAlreadyExists();
+        if (_k <= 1) revert KMustBeGreaterThanOne();
+        tree.K = _k;
+        tree.nodes.push(0);
+    }
+
+    /// @dev Draw an ID from a tree using a number.
+    /// Note that this function reverts if the sum of all values in the tree is 0.
+    /// @param _tree The sortition sum tree.
+    /// @param _coreDisputeID Index of the dispute in Kleros Core.
+    /// @param _nonce Nonce to hash with random number.
+    /// @return drawnAddress The drawn address.
+    /// `O(k * log_k(n))` where
+    /// `k` is the maximum number of children per node in the tree,
+    ///  and `n` is the maximum number of nodes ever appended.
+    function draw(
+        Tree storage _tree,
+        uint256 _coreDisputeID,
+        uint256 _nonce,
+        uint256 _randomNumber
+    ) internal view returns (address drawnAddress, uint96 fromSubcourtID) {
+        if (_tree.nodes[0] == 0) {
+            return (address(0), 0); // No jurors staked.
+        }
+
+        uint256 currentDrawnNumber = uint256(keccak256(abi.encodePacked(_randomNumber, _coreDisputeID, _nonce))) %
+            _tree.nodes[0];
+
+        // While it still has children
+        uint256 treeIndex = 0;
+        while ((_tree.K * treeIndex) + 1 < _tree.nodes.length) {
+            for (uint256 i = 1; i <= _tree.K; i++) {
+                // Loop over children.
+                uint256 nodeIndex = (_tree.K * treeIndex) + i;
+                uint256 nodeValue = _tree.nodes[nodeIndex];
+
+                if (currentDrawnNumber >= nodeValue) {
+                    // Go to the next child.
+                    currentDrawnNumber -= nodeValue;
+                } else {
+                    // Pick this child.
+                    treeIndex = nodeIndex;
+                    break;
+                }
+            }
+        }
+
+        bytes32 stakePathID = _tree.nodeIndexesToIDs[treeIndex];
+        (drawnAddress, fromSubcourtID) = toAccountAndCourtID(stakePathID);
+    }
+
+    /// @dev Set a value in a tree.
+    /// @param _tree The sortition sum tree.
+    /// @param _value The new value.
+    /// @param _stakePathID The ID of the value.
+    /// `O(log_k(n))` where
+    /// `k` is the maximum number of children per node in the tree,
+    ///  and `n` is the maximum number of nodes ever appended.
+    function set(Tree storage _tree, uint256 _value, bytes32 _stakePathID) internal {
+        uint256 treeIndex = _tree.IDsToNodeIndexes[_stakePathID];
+
+        if (treeIndex == 0) {
+            // No existing node.
+            if (_value != 0) {
+                // Non zero value.
+                // Append.
+                // Add node.
+                if (_tree.stack.length == 0) {
+                    // No vacant spots.
+                    // Get the index and append the value.
+                    treeIndex = _tree.nodes.length;
+                    _tree.nodes.push(_value);
+
+                    // Potentially append a new node and make the parent a sum node.
+                    if (treeIndex != 1 && (treeIndex - 1) % _tree.K == 0) {
+                        // Is first child.
+                        uint256 parentIndex = treeIndex / _tree.K;
+                        bytes32 parentID = _tree.nodeIndexesToIDs[parentIndex];
+                        uint256 newIndex = treeIndex + 1;
+                        _tree.nodes.push(_tree.nodes[parentIndex]);
+                        delete _tree.nodeIndexesToIDs[parentIndex];
+                        _tree.IDsToNodeIndexes[parentID] = newIndex;
+                        _tree.nodeIndexesToIDs[newIndex] = parentID;
+                    }
+                } else {
+                    // Some vacant spot.
+                    // Pop the stack and append the value.
+                    treeIndex = _tree.stack[_tree.stack.length - 1];
+                    _tree.stack.pop();
+                    _tree.nodes[treeIndex] = _value;
+                }
+
+                // Add label.
+                _tree.IDsToNodeIndexes[_stakePathID] = treeIndex;
+                _tree.nodeIndexesToIDs[treeIndex] = _stakePathID;
+
+                updateParents(_tree, treeIndex, true, _value);
+            }
+        } else {
+            // Existing node.
+            if (_value == 0) {
+                // Zero value.
+                // Remove.
+                // Remember value and set to 0.
+                uint256 value = _tree.nodes[treeIndex];
+                _tree.nodes[treeIndex] = 0;
+
+                // Push to stack.
+                _tree.stack.push(treeIndex);
+
+                // Clear label.
+                delete _tree.IDsToNodeIndexes[_stakePathID];
+                delete _tree.nodeIndexesToIDs[treeIndex];
+
+                updateParents(_tree, treeIndex, false, value);
+            } else if (_value != _tree.nodes[treeIndex]) {
+                // New, non zero value.
+                // Set.
+                bool plusOrMinus = _tree.nodes[treeIndex] <= _value;
+                uint256 plusOrMinusValue = plusOrMinus
+                    ? _value - _tree.nodes[treeIndex]
+                    : _tree.nodes[treeIndex] - _value;
+                _tree.nodes[treeIndex] = _value;
+
+                updateParents(_tree, treeIndex, plusOrMinus, plusOrMinusValue);
+            }
+        }
+    }
+
+    /// @dev Update all the parents of a node.
+    /// @param _tree The sortition sum tree.
+    /// @param _treeIndex The index of the node to start from.
+    /// @param _plusOrMinus Whether to add (true) or substract (false).
+    /// @param _value The value to add or substract.
+    /// `O(log_k(n))` where
+    /// `k` is the maximum number of children per node in the tree,
+    ///  and `n` is the maximum number of nodes ever appended.
+    function updateParents(Tree storage _tree, uint256 _treeIndex, bool _plusOrMinus, uint256 _value) private {
+        uint256 parentIndex = _treeIndex;
+        while (parentIndex != 0) {
+            parentIndex = (parentIndex - 1) / _tree.K;
+            _tree.nodes[parentIndex] = _plusOrMinus
+                ? _tree.nodes[parentIndex] + _value
+                : _tree.nodes[parentIndex] - _value;
+        }
+    }
+
+    /// @dev Get the stake of a juror in a court.
+    /// @param _tree The sortition sum tree.
+    /// @param _stakePathID The stake path ID, corresponding to a juror.
+    /// @return The stake of the juror in the court.
+    function stakeOf(Tree storage _tree, bytes32 _stakePathID) internal view returns (uint256) {
+        uint256 treeIndex = _tree.IDsToNodeIndexes[_stakePathID];
+        if (treeIndex == 0) {
+            return 0;
+        }
+        return _tree.nodes[treeIndex];
+    }
+
+    /// @dev Packs an account and a court ID into a stake path ID: [20 bytes of address][12 bytes of courtID] = 32 bytes total.
+    /// @param _account The address of the juror to pack.
+    /// @param _courtID The court ID to pack.
+    /// @return stakePathID The stake path ID.
+    function toStakePathID(address _account, uint96 _courtID) internal pure returns (bytes32 stakePathID) {
+        assembly {
+            // solium-disable-line security/no-inline-assembly
+            let ptr := mload(0x40)
+
+            // Write account address (first 20 bytes)
+            for {
+                let i := 0x00
+            } lt(i, 0x14) {
+                i := add(i, 0x01)
+            } {
+                mstore8(add(ptr, i), byte(add(0x0c, i), _account))
+            }
+
+            // Write court ID (last 12 bytes)
+            for {
+                let i := 0x14
+            } lt(i, 0x20) {
+                i := add(i, 0x01)
+            } {
+                mstore8(add(ptr, i), byte(i, _courtID))
+            }
+            stakePathID := mload(ptr)
+        }
+    }
+
+    /// @dev Retrieves both juror's address and court ID from the stake path ID.
+    /// @param _stakePathID The stake path ID to unpack.
+    /// @return account The account.
+    /// @return courtID The court ID.
+    function toAccountAndCourtID(bytes32 _stakePathID) internal pure returns (address account, uint96 courtID) {
+        assembly {
+            // solium-disable-line security/no-inline-assembly
+            let ptr := mload(0x40)
+
+            // Read account address (first 20 bytes)
+            for {
+                let i := 0x00
+            } lt(i, 0x14) {
+                i := add(i, 0x01)
+            } {
+                mstore8(add(add(ptr, 0x0c), i), byte(i, _stakePathID))
+            }
+            account := mload(ptr)
+
+            // Read court ID (last 12 bytes)
+            for {
+                let i := 0x00
+            } lt(i, 0x0c) {
+                i := add(i, 0x01)
+            } {
+                mstore8(add(add(ptr, 0x14), i), byte(add(i, 0x14), _stakePathID))
+            }
+            courtID := mload(ptr)
+        }
+    }
+
+    error TreeAlreadyExists();
+    error KMustBeGreaterThanOne();
+}

--- a/contracts/src/libraries/SortitionTrees.sol
+++ b/contracts/src/libraries/SortitionTrees.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.24;
 type TreeKey is bytes32;
 type CourtID is uint96;
 
-using {toTreeKey} for CourtID global;
-
-function toTreeKey(CourtID _courtID) pure returns (TreeKey) {
-    return TreeKey.wrap(bytes32(uint256(CourtID.unwrap(_courtID))));
-}
+using {SortitionTrees.toTreeKey} for CourtID global;
 
 library SortitionTrees {
+    // ************************************* //
+    // *         Enums / Structs           * //
+    // ************************************* //
+
     struct Tree {
         uint256 K; // The maximum number of children per node.
         uint256[] stack; // We use this to keep track of vacant positions in the tree after removing a leaf. This is for keeping the tree as balanced as possible without spending gas on moving nodes around.
@@ -20,6 +20,14 @@ library SortitionTrees {
         mapping(bytes32 stakePathID => uint256 nodeIndex) IDsToNodeIndexes;
         mapping(uint256 nodeIndex => bytes32 stakePathID) nodeIndexesToIDs;
     }
+
+    function toTreeKey(CourtID _courtID) internal pure returns (TreeKey) {
+        return TreeKey.wrap(bytes32(uint256(CourtID.unwrap(_courtID))));
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
 
     /// @dev Create a sortition sum tree at the specified key.
     /// @param _trees The mapping of sortition sum trees.
@@ -174,6 +182,10 @@ library SortitionTrees {
         }
     }
 
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
     /// @dev Get the stake of a juror in a court.
     /// @param _tree The sortition sum tree.
     /// @param _stakePathID The stake path ID, corresponding to a juror.
@@ -246,6 +258,10 @@ library SortitionTrees {
             courtID := mload(ptr)
         }
     }
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
 
     error TreeAlreadyExists();
     error KMustBeGreaterThanOne();

--- a/contracts/src/test/SortitionModuleMock.sol
+++ b/contracts/src/test/SortitionModuleMock.sol
@@ -3,12 +3,13 @@
 pragma solidity ^0.8.24;
 
 import "../arbitration/SortitionModule.sol";
+import {SortitionTrees, TreeKey} from "../libraries/SortitionTrees.sol";
 
 /// @title SortitionModuleMock
 /// @dev Adds getter functions to sortition module for Foundry tests.
 contract SortitionModuleMock is SortitionModule {
     function getSortitionProperties(bytes32 _key) external view returns (uint256 K, uint256 nodeLength) {
-        SortitionSumTree storage tree = sortitionSumTrees[_key];
+        SortitionTrees.Tree storage tree = sortitionSumTrees[TreeKey.wrap(_key)];
         K = tree.K;
         nodeLength = tree.nodes.length;
     }

--- a/contracts/src/test/SortitionTreesMock.sol
+++ b/contracts/src/test/SortitionTreesMock.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../libraries/SortitionTrees.sol";
+
+/// @title SortitionTreesMock
+/// @dev Test contract to expose SortitionTrees library functions for testing
+contract SortitionTreesMock {
+    using SortitionTrees for mapping(TreeKey => SortitionTrees.Tree);
+
+    // Storage for multiple test trees
+    mapping(TreeKey => SortitionTrees.Tree) public trees;
+
+    // Court hierarchy helpers (for testing parent-child relationships)
+    mapping(uint96 => uint96[]) public childCourts;
+    mapping(uint96 => uint96) public parentCourt;
+
+    // ************************************* //
+    // *         Main Functions            * //
+    // ************************************* //
+
+    /// @dev Create a sortition sum tree for a court
+    function createTree(uint96 _courtID, uint256 _k) external {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        trees.createTree(key, _k);
+    }
+
+    /// @dev Set stake for a juror in a specific court
+    function set(uint96 _courtID, address _account, uint256 _value) external {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        bytes32 stakePathID = SortitionTrees.toStakePathID(_account, _courtID);
+        SortitionTrees.set(trees[key], _value, stakePathID);
+    }
+
+    /// @dev Draw a juror from a court's tree
+    function draw(
+        uint96 _courtID,
+        uint256 _disputeID,
+        uint256 _nonce,
+        uint256 _randomNumber
+    ) external view returns (address drawnAddress, uint96 fromSubcourtID) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return SortitionTrees.draw(trees[key], _disputeID, _nonce, _randomNumber);
+    }
+
+    /// @dev Get stake of a juror in a specific court
+    function stakeOf(uint96 _courtID, address _account) external view returns (uint256) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        bytes32 stakePathID = SortitionTrees.toStakePathID(_account, _courtID);
+        return SortitionTrees.stakeOf(trees[key], stakePathID);
+    }
+
+    // ************************************* //
+    // *      Multi-Court Operations       * //
+    // ************************************* //
+
+    /// @dev Set stake for a juror across multiple courts (for testing hierarchy)
+    function setStakeInHierarchy(uint96[] calldata _courtIDs, address _account, uint256 _value) external {
+        for (uint256 i = 0; i < _courtIDs.length; i++) {
+            this.set(_courtIDs[i], _account, _value);
+        }
+    }
+
+    /// @dev Get stakes of a juror across multiple courts
+    function getStakesAcrossCourts(
+        address _account,
+        uint96[] calldata _courtIDs
+    ) external view returns (uint256[] memory stakes) {
+        stakes = new uint256[](_courtIDs.length);
+        for (uint256 i = 0; i < _courtIDs.length; i++) {
+            stakes[i] = this.stakeOf(_courtIDs[i], _account);
+        }
+    }
+
+    // ************************************* //
+    // *       Court Hierarchy Setup      * //
+    // ************************************* //
+
+    /// @dev Set parent court for testing hierarchy
+    function setParentCourt(uint96 _childCourt, uint96 _parentCourt) external {
+        parentCourt[_childCourt] = _parentCourt;
+    }
+
+    /// @dev Add child court for testing hierarchy
+    function addChildCourt(uint96 _parentCourt, uint96 _childCourt) external {
+        childCourts[_parentCourt].push(_childCourt);
+    }
+
+    /// @dev Get child courts
+    function getChildCourts(uint96 _parentCourt) external view returns (uint96[] memory) {
+        return childCourts[_parentCourt];
+    }
+
+    // ************************************* //
+    // *       Tree State Inspection      * //
+    // ************************************* //
+
+    /// @dev Get all nodes in a tree
+    function getTreeNodes(uint96 _courtID) external view returns (uint256[] memory) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return trees[key].nodes;
+    }
+
+    /// @dev Get tree K value
+    function getTreeK(uint96 _courtID) external view returns (uint256) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return trees[key].K;
+    }
+
+    /// @dev Get tree stack
+    function getTreeStack(uint96 _courtID) external view returns (uint256[] memory) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return trees[key].stack;
+    }
+
+    /// @dev Get node index for a juror in a court
+    function getNodeIndex(uint96 _courtID, address _account) external view returns (uint256) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        bytes32 stakePathID = SortitionTrees.toStakePathID(_account, _courtID);
+        return trees[key].IDsToNodeIndexes[stakePathID];
+    }
+
+    /// @dev Check if a court tree exists
+    function courtExists(uint96 _courtID) external view returns (bool) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        return trees[key].K != 0;
+    }
+
+    /// @dev Get the root sum (total stakes) of a court
+    function getRootSum(uint96 _courtID) external view returns (uint256) {
+        TreeKey key = CourtID.wrap(_courtID).toTreeKey();
+        if (trees[key].nodes.length == 0) return 0;
+        return trees[key].nodes[0];
+    }
+
+    // ************************************* //
+    // *         Utility Functions        * //
+    // ************************************* //
+
+    /// @dev Test function to pack address and court ID
+    function testToStakePathID(address _account, uint96 _courtID) external pure returns (bytes32) {
+        return SortitionTrees.toStakePathID(_account, _courtID);
+    }
+
+    /// @dev Test function to unpack stake path ID
+    function testToAccountAndCourtID(bytes32 _stakePathID) external pure returns (address account, uint96 courtID) {
+        return SortitionTrees.toAccountAndCourtID(_stakePathID);
+    }
+
+    /// @dev Test function to convert court ID to tree key
+    function testToTreeKey(uint96 _courtID) external pure returns (TreeKey) {
+        return CourtID.wrap(_courtID).toTreeKey();
+    }
+}

--- a/contracts/test/sortition/index.ts
+++ b/contracts/test/sortition/index.ts
@@ -1,0 +1,698 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SortitionTreesMock } from "../../typechain-types";
+
+describe("SortitionTrees", function () {
+  let sortitionTree: SortitionTreesMock;
+  let accounts: any[];
+
+  beforeEach("Setup", async () => {
+    const factory = await ethers.getContractFactory("SortitionTreesMock");
+    sortitionTree = (await factory.deploy()) as SortitionTreesMock;
+    accounts = await ethers.getSigners();
+  });
+
+  // Helper function to create a test juror address
+  const getTestAddress = (index: number): string => accounts[index % accounts.length].address;
+
+  describe("Stake Path ID Utilities", function () {
+    it("Should convert correctly between stakePathID and account+courtID", async function () {
+      // Test various combinations of addresses and court IDs
+      const testCases = [
+        {
+          address: "0x1234567890123456789012345678901234567890",
+          courtID: 0,
+        },
+        {
+          address: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+          courtID: 0xffffffffffff, // max uint96
+        },
+        {
+          address: "0x0000000000000000000000000000000000000001",
+          courtID: 1,
+        },
+        {
+          address: "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+          courtID: 123456789,
+        },
+      ];
+
+      for (const testCase of testCases) {
+        // Test packing
+        const stakePathID = await sortitionTree.testToStakePathID(testCase.address, testCase.courtID);
+
+        // Test unpacking
+        const [unpackedAddress, unpackedCourtID] = await sortitionTree.testToAccountAndCourtID(stakePathID);
+
+        // Verify round-trip equivalence
+        expect(unpackedAddress.toLowerCase()).to.equal(testCase.address.toLowerCase());
+        expect(unpackedCourtID).to.equal(testCase.courtID);
+
+        // Verify the packed format is as expected: [20 bytes address][12 bytes courtID]
+        const expectedPackedValue = ethers.solidityPacked(["address", "uint96"], [testCase.address, testCase.courtID]);
+        expect(stakePathID).to.equal(expectedPackedValue);
+      }
+    });
+
+    it("Should handle TreeKey conversion correctly", async function () {
+      const courtIDs = [
+        0,
+        1,
+        100,
+        0xffffffffffff, // max uint96
+      ];
+
+      for (const courtID of courtIDs) {
+        const treeKey = await sortitionTree.testToTreeKey(courtID);
+
+        // TreeKey should be the courtID padded to 32 bytes
+        const expectedTreeKey = ethers.zeroPadValue(ethers.toBeHex(courtID), 32);
+        expect(treeKey).to.equal(expectedTreeKey);
+
+        // Court ID 0 will result in zero key, others should not
+        if (courtID === 0) {
+          expect(treeKey).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+        } else {
+          expect(treeKey).to.not.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+        }
+      }
+    });
+  });
+
+  describe("Tree Creation & Validation", function () {
+    it("Should create trees with valid K values", async function () {
+      const testCases = [
+        { courtID: 0, k: 2 },
+        { courtID: 1, k: 5 },
+        { courtID: 100, k: 10 },
+        { courtID: 999, k: 100 },
+      ];
+
+      for (const testCase of testCases) {
+        await sortitionTree.createTree(testCase.courtID, testCase.k);
+
+        // Verify tree was created
+        expect(await sortitionTree.courtExists(testCase.courtID)).to.be.true;
+        expect(await sortitionTree.getTreeK(testCase.courtID)).to.equal(testCase.k);
+
+        // Verify initial state
+        const nodes = await sortitionTree.getTreeNodes(testCase.courtID);
+        expect(nodes.length).to.equal(1);
+        expect(nodes[0]).to.equal(0); // Root starts at 0
+
+        const stack = await sortitionTree.getTreeStack(testCase.courtID);
+        expect(stack.length).to.equal(0); // Empty stack initially
+      }
+    });
+
+    it("Should reject invalid K values", async function () {
+      // K must be greater than 1
+      await expect(sortitionTree.createTree(0, 0)).to.be.reverted;
+      await expect(sortitionTree.createTree(1, 1)).to.be.reverted;
+    });
+
+    it("Should reject creating duplicate trees", async function () {
+      await sortitionTree.createTree(0, 2);
+      await expect(sortitionTree.createTree(0, 3)).to.be.reverted;
+    });
+
+    it("Should create multiple independent trees", async function () {
+      await sortitionTree.createTree(0, 2);
+      await sortitionTree.createTree(1, 3);
+      await sortitionTree.createTree(2, 5);
+
+      expect(await sortitionTree.getTreeK(0)).to.equal(2);
+      expect(await sortitionTree.getTreeK(1)).to.equal(3);
+      expect(await sortitionTree.getTreeK(2)).to.equal(5);
+    });
+  });
+
+  describe("Single Court Stake Management", function () {
+    beforeEach(async function () {
+      // Create a test tree with K=2 for court 0
+      await sortitionTree.createTree(0, 2);
+    });
+
+    describe("Adding New Stakes", function () {
+      it("Should add first juror to empty tree", async function () {
+        const juror = getTestAddress(0);
+        const stake = 100;
+
+        await sortitionTree.set(0, juror, stake);
+
+        // Verify stake was set
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(stake);
+        expect(await sortitionTree.getRootSum(0)).to.equal(stake);
+
+        // Verify tree structure
+        const nodes = await sortitionTree.getTreeNodes(0);
+        expect(nodes[0]).to.equal(stake); // Root should equal juror stake
+        expect(nodes[1]).to.equal(stake); // First leaf
+      });
+
+      it("Should add multiple jurors sequentially", async function () {
+        const stakes = [100, 200, 300];
+
+        for (let i = 0; i < stakes.length; i++) {
+          const juror = getTestAddress(i);
+          await sortitionTree.set(0, juror, stakes[i]);
+          expect(await sortitionTree.stakeOf(0, juror)).to.equal(stakes[i]);
+        }
+
+        // Verify total stake
+        const expectedTotal = stakes.reduce((sum, stake) => sum + stake, 0);
+        expect(await sortitionTree.getRootSum(0)).to.equal(expectedTotal);
+      });
+
+      it("Should handle tree restructuring when K threshold is reached", async function () {
+        // Add enough jurors to trigger tree restructuring
+        const stakes = [100, 200, 300, 400]; // More than K=2
+
+        for (let i = 0; i < stakes.length; i++) {
+          const juror = getTestAddress(i);
+          await sortitionTree.set(0, juror, stakes[i]);
+        }
+
+        const nodes = await sortitionTree.getTreeNodes(0);
+        expect(nodes.length).to.be.greaterThan(4); // Should have expanded
+
+        const expectedTotal = stakes.reduce((sum, stake) => sum + stake, 0);
+        expect(await sortitionTree.getRootSum(0)).to.equal(expectedTotal);
+      });
+    });
+
+    describe("Updating Existing Stakes", function () {
+      beforeEach(async function () {
+        // Add initial jurors
+        await sortitionTree.set(0, getTestAddress(0), 100);
+        await sortitionTree.set(0, getTestAddress(1), 200);
+      });
+
+      it("Should increase stake values correctly", async function () {
+        const juror = getTestAddress(0);
+        const oldStake = await sortitionTree.stakeOf(0, juror);
+        const newStake = 250;
+
+        await sortitionTree.set(0, juror, newStake);
+
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(newStake);
+
+        // Root should reflect the change
+        const rootSum = await sortitionTree.getRootSum(0);
+        expect(rootSum).to.equal(200 + newStake);
+      });
+
+      it("Should decrease stake values correctly", async function () {
+        const juror = getTestAddress(0);
+        const newStake = 50;
+
+        await sortitionTree.set(0, juror, newStake);
+
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(newStake);
+        expect(await sortitionTree.getRootSum(0)).to.equal(200 + newStake);
+      });
+
+      it("Should be no-op when setting same value", async function () {
+        const juror = getTestAddress(0);
+        const currentStake = await sortitionTree.stakeOf(0, juror);
+        const initialRoot = await sortitionTree.getRootSum(0);
+
+        await sortitionTree.set(0, juror, currentStake);
+
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(currentStake);
+        expect(await sortitionTree.getRootSum(0)).to.equal(initialRoot);
+      });
+    });
+
+    describe("Removing Stakes", function () {
+      beforeEach(async function () {
+        // Add initial jurors
+        await sortitionTree.set(0, getTestAddress(0), 100);
+        await sortitionTree.set(0, getTestAddress(1), 200);
+        await sortitionTree.set(0, getTestAddress(2), 300);
+      });
+
+      it("Should remove juror by setting stake to 0", async function () {
+        const juror = getTestAddress(1);
+        const initialRoot = await sortitionTree.getRootSum(0);
+
+        await sortitionTree.set(0, juror, 0);
+
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(0);
+        expect(await sortitionTree.getRootSum(0)).to.equal(initialRoot - 200n);
+        expect(await sortitionTree.getNodeIndex(0, juror)).to.equal(0); // Should be cleared
+      });
+
+      it("Should manage stack for removed positions", async function () {
+        const juror = getTestAddress(1);
+        const initialStackLength = (await sortitionTree.getTreeStack(0)).length;
+
+        await sortitionTree.set(0, juror, 0);
+
+        const newStackLength = (await sortitionTree.getTreeStack(0)).length;
+        expect(newStackLength).to.be.greaterThan(initialStackLength);
+      });
+
+      it("Should reuse vacant positions from stack", async function () {
+        const juror1 = getTestAddress(1);
+        const juror4 = getTestAddress(4);
+
+        // Remove a juror
+        await sortitionTree.set(0, juror1, 0);
+        const stackAfterRemoval = await sortitionTree.getTreeStack(0);
+
+        // Add a new juror (should reuse vacant position)
+        await sortitionTree.set(0, juror4, 150);
+        const stackAfterAdd = await sortitionTree.getTreeStack(0);
+
+        expect(stackAfterAdd.length).to.equal(stackAfterRemoval.length - 1);
+        expect(await sortitionTree.stakeOf(0, juror4)).to.equal(150);
+      });
+    });
+  });
+
+  describe("Drawing Algorithm", function () {
+    beforeEach(async function () {
+      await sortitionTree.createTree(0, 2);
+    });
+
+    it("Should return zero address for empty tree", async function () {
+      const [drawnAddress, courtID] = await sortitionTree.draw(0, 1, 1, 12345);
+      expect(drawnAddress).to.equal(ethers.ZeroAddress);
+      expect(courtID).to.equal(0);
+    });
+
+    it("Should draw single juror from single-juror tree", async function () {
+      const juror = getTestAddress(0);
+      await sortitionTree.set(0, juror, 100);
+
+      // Multiple draws should always return the same juror
+      for (let i = 0; i < 5; i++) {
+        const [drawnAddress, courtID] = await sortitionTree.draw(0, 1, i, 12345 + i);
+        expect(drawnAddress.toLowerCase()).to.equal(juror.toLowerCase());
+        expect(courtID).to.equal(0);
+      }
+    });
+
+    it("Should draw deterministically with same inputs", async function () {
+      // Add multiple jurors
+      await sortitionTree.set(0, getTestAddress(0), 100);
+      await sortitionTree.set(0, getTestAddress(1), 200);
+      await sortitionTree.set(0, getTestAddress(2), 300);
+
+      const disputeID = 1;
+      const nonce = 2;
+      const randomNumber = 12345;
+
+      // Multiple calls with same parameters should return same result
+      const [address1] = await sortitionTree.draw(0, disputeID, nonce, randomNumber);
+      const [address2] = await sortitionTree.draw(0, disputeID, nonce, randomNumber);
+      const [address3] = await sortitionTree.draw(0, disputeID, nonce, randomNumber);
+
+      expect(address1).to.equal(address2);
+      expect(address2).to.equal(address3);
+    });
+
+    it("Should respect weighted probability distribution", async function () {
+      // Add jurors with very different stakes to test weighting
+      await sortitionTree.set(0, getTestAddress(0), 1); // Very low stake
+      await sortitionTree.set(0, getTestAddress(1), 1000); // Very high stake
+
+      let draws = { [getTestAddress(0).toLowerCase()]: 0, [getTestAddress(1).toLowerCase()]: 0 };
+
+      // Perform many draws with different random numbers
+      const numDraws = 100;
+      for (let i = 0; i < numDraws; i++) {
+        const [drawnAddress] = await sortitionTree.draw(0, 1, 1, i);
+        draws[drawnAddress.toLowerCase()]++;
+      }
+
+      // Juror with higher stake should be drawn more frequently
+      // With stakes of 1:1000, we expect roughly 0.1% vs 99.9% distribution
+      expect(draws[getTestAddress(1).toLowerCase()]).to.be.greaterThan(draws[getTestAddress(0).toLowerCase()]);
+      expect(draws[getTestAddress(1).toLowerCase()]).to.be.greaterThan(numDraws * 0.8); // At least 80% for high stake
+    });
+
+    it("Should handle edge case random numbers", async function () {
+      await sortitionTree.set(0, getTestAddress(0), 100);
+      await sortitionTree.set(0, getTestAddress(1), 200);
+
+      // Test with boundary random numbers
+      const testNumbers = [0, 1, ethers.MaxUint256];
+
+      for (const randomNumber of testNumbers) {
+        const [drawnAddress] = await sortitionTree.draw(0, 1, 1, randomNumber);
+        expect(drawnAddress).to.not.equal(ethers.ZeroAddress);
+
+        // Should be one of our jurors
+        const isValidJuror =
+          drawnAddress.toLowerCase() === getTestAddress(0).toLowerCase() ||
+          drawnAddress.toLowerCase() === getTestAddress(1).toLowerCase();
+        expect(isValidJuror).to.be.true;
+      }
+    });
+  });
+
+  describe("Multi-Court Scenarios", function () {
+    beforeEach(async function () {
+      // Create multiple courts with different K values
+      await sortitionTree.createTree(0, 2); // General Court
+      await sortitionTree.createTree(1, 3); // Tech Court
+      await sortitionTree.createTree(2, 2); // Legal Court
+    });
+
+    describe("Independent Court Operations", function () {
+      it("Should handle same juror staking in multiple courts", async function () {
+        const juror = getTestAddress(0);
+        const stakes = [100, 250, 75]; // Different stakes in different courts
+
+        // Set stakes in different courts
+        for (let courtID = 0; courtID < 3; courtID++) {
+          await sortitionTree.set(courtID, juror, stakes[courtID]);
+        }
+
+        // Verify stakes are independent
+        for (let courtID = 0; courtID < 3; courtID++) {
+          expect(await sortitionTree.stakeOf(courtID, juror)).to.equal(stakes[courtID]);
+          expect(await sortitionTree.getRootSum(courtID)).to.equal(stakes[courtID]);
+        }
+      });
+
+      it("Should maintain court isolation", async function () {
+        const juror1 = getTestAddress(0);
+        const juror2 = getTestAddress(1);
+
+        // Add different jurors to different courts
+        await sortitionTree.set(0, juror1, 100);
+        await sortitionTree.set(1, juror2, 200);
+
+        // Court 0 should only have juror1
+        expect(await sortitionTree.stakeOf(0, juror1)).to.equal(100);
+        expect(await sortitionTree.stakeOf(0, juror2)).to.equal(0);
+
+        // Court 1 should only have juror2
+        expect(await sortitionTree.stakeOf(1, juror1)).to.equal(0);
+        expect(await sortitionTree.stakeOf(1, juror2)).to.equal(200);
+      });
+
+      it("Should handle different tree structures independently", async function () {
+        const jurors = [getTestAddress(0), getTestAddress(1), getTestAddress(2), getTestAddress(3)];
+
+        // Add different numbers of jurors to each court
+        await sortitionTree.set(0, jurors[0], 100); // 1 juror in court 0
+
+        await sortitionTree.set(1, jurors[0], 150); // 2 jurors in court 1
+        await sortitionTree.set(1, jurors[1], 250);
+
+        await sortitionTree.set(2, jurors[0], 75); // 3 jurors in court 2
+        await sortitionTree.set(2, jurors[1], 125);
+        await sortitionTree.set(2, jurors[2], 175);
+
+        // Verify independent tree structures
+        expect(await sortitionTree.getRootSum(0)).to.equal(100);
+        expect(await sortitionTree.getRootSum(1)).to.equal(400);
+        expect(await sortitionTree.getRootSum(2)).to.equal(375);
+
+        // Verify each court has correct tree structure
+        const nodes0 = await sortitionTree.getTreeNodes(0);
+        const nodes1 = await sortitionTree.getTreeNodes(1);
+        const nodes2 = await sortitionTree.getTreeNodes(2);
+
+        expect(nodes0.length).to.be.lessThan(nodes2.length); // Fewer jurors = smaller tree
+        expect(nodes1.length).to.be.greaterThan(nodes0.length); // More jurors = larger tree
+      });
+    });
+
+    describe("Cross-Court Stake Updates", function () {
+      it("Should handle simultaneous updates across multiple courts", async function () {
+        const juror = getTestAddress(0);
+        const courtIDs = [0, 1, 2];
+        const initialStakes = [100, 200, 300];
+        const updatedStakes = [150, 250, 350];
+
+        // Set initial stakes
+        for (let i = 0; i < courtIDs.length; i++) {
+          await sortitionTree.set(courtIDs[i], juror, initialStakes[i]);
+        }
+
+        // Update all stakes
+        for (let i = 0; i < courtIDs.length; i++) {
+          await sortitionTree.set(courtIDs[i], juror, updatedStakes[i]);
+        }
+
+        // Verify all updates took effect
+        for (let i = 0; i < courtIDs.length; i++) {
+          expect(await sortitionTree.stakeOf(courtIDs[i], juror)).to.equal(updatedStakes[i]);
+        }
+      });
+
+      it("Should handle partial removals across courts", async function () {
+        const juror = getTestAddress(0);
+
+        // Add juror to all courts
+        await sortitionTree.set(0, juror, 100);
+        await sortitionTree.set(1, juror, 200);
+        await sortitionTree.set(2, juror, 300);
+
+        // Remove from middle court only
+        await sortitionTree.set(1, juror, 0);
+
+        // Verify partial removal
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(100);
+        expect(await sortitionTree.stakeOf(1, juror)).to.equal(0);
+        expect(await sortitionTree.stakeOf(2, juror)).to.equal(300);
+      });
+
+      it("Should use batch operations correctly", async function () {
+        const juror = getTestAddress(0);
+        const courtIDs = [0, 1, 2];
+        const stake = 500;
+
+        // Use batch operation to set stakes
+        await sortitionTree.setStakeInHierarchy(courtIDs, juror, stake);
+
+        // Verify all stakes were set
+        const stakes = await sortitionTree.getStakesAcrossCourts(juror, courtIDs);
+        for (const retrievedStake of stakes) {
+          expect(retrievedStake).to.equal(stake);
+        }
+      });
+    });
+
+    describe("Multi-Court Drawing", function () {
+      beforeEach(async function () {
+        // Setup jurors in different courts
+        await sortitionTree.set(0, getTestAddress(0), 100); // Court 0: 1 juror
+        await sortitionTree.set(0, getTestAddress(1), 200);
+
+        await sortitionTree.set(1, getTestAddress(1), 300); // Court 1: 2 jurors
+        await sortitionTree.set(1, getTestAddress(2), 400);
+
+        await sortitionTree.set(2, getTestAddress(0), 500); // Court 2: 1 juror only
+      });
+
+      it("Should draw correctly from different courts", async function () {
+        // Draw from each court
+        const [addr0] = await sortitionTree.draw(0, 1, 1, 12345);
+        const [addr1] = await sortitionTree.draw(1, 1, 1, 12345);
+        const [addr2] = await sortitionTree.draw(2, 1, 1, 12345);
+
+        // Should get valid addresses from each court
+        expect(addr0).to.not.equal(ethers.ZeroAddress);
+        expect(addr1).to.not.equal(ethers.ZeroAddress);
+        expect(addr2).to.not.equal(ethers.ZeroAddress);
+
+        // Court 2 should always return getTestAddress(0) since it's the only juror
+        expect(addr2.toLowerCase()).to.equal(getTestAddress(0).toLowerCase());
+      });
+
+      it("Should return correct court ID in draw results", async function () {
+        const [, courtID0] = await sortitionTree.draw(0, 1, 1, 12345);
+        const [, courtID1] = await sortitionTree.draw(1, 1, 1, 12345);
+        const [, courtID2] = await sortitionTree.draw(2, 1, 1, 12345);
+
+        // The returned court IDs should match the stake path IDs
+        // Since we're using the same court for staking and drawing, they should match
+        expect([0, 1]).to.include(Number(courtID0));
+        expect([1, 2]).to.include(Number(courtID1));
+        expect(Number(courtID2)).to.equal(2);
+      });
+
+      it("Should maintain independent probability distributions", async function () {
+        // Test drawing many times from court 0 where juror 1 has 2x stake of juror 0
+        let draws = { [getTestAddress(0).toLowerCase()]: 0, [getTestAddress(1).toLowerCase()]: 0 };
+
+        const numDraws = 50;
+        for (let i = 0; i < numDraws; i++) {
+          const [drawnAddress] = await sortitionTree.draw(0, 1, 1, i);
+          draws[drawnAddress.toLowerCase()]++;
+        }
+
+        // Juror 1 (200 stake) should be drawn more than juror 0 (100 stake)
+        expect(draws[getTestAddress(1).toLowerCase()]).to.be.greaterThan(draws[getTestAddress(0).toLowerCase()]);
+      });
+    });
+
+    describe("Complex Multi-Court Scenarios", function () {
+      it("Should handle realistic court hierarchy simulation", async function () {
+        // Simulate: General Court (0) ← Tech Court (1) ← Blockchain Court (2)
+        const courts = [0, 1, 2];
+        const jurors = [getTestAddress(0), getTestAddress(1), getTestAddress(2), getTestAddress(3)];
+
+        // General lawyers (stake in General Court only)
+        await sortitionTree.set(0, jurors[0], 100);
+        await sortitionTree.set(0, jurors[1], 150);
+
+        // Tech specialists (stake in both General and Tech)
+        await sortitionTree.set(0, jurors[2], 200);
+        await sortitionTree.set(1, jurors[2], 300);
+
+        // Blockchain experts (stake in all three)
+        await sortitionTree.set(0, jurors[3], 250);
+        await sortitionTree.set(1, jurors[3], 350);
+        await sortitionTree.set(2, jurors[3], 450);
+
+        // Verify hierarchy totals
+        expect(await sortitionTree.getRootSum(0)).to.equal(700); // All jurors
+        expect(await sortitionTree.getRootSum(1)).to.equal(650); // Tech specialists + experts
+        expect(await sortitionTree.getRootSum(2)).to.equal(450); // Blockchain experts only
+
+        // Test drawing from most specialized court (should only get experts)
+        const [blockchainExpert] = await sortitionTree.draw(2, 1, 1, 12345);
+        expect(blockchainExpert.toLowerCase()).to.equal(jurors[3].toLowerCase());
+      });
+
+      it("Should handle dynamic court operations", async function () {
+        const juror = getTestAddress(0);
+
+        // Juror starts in general court
+        await sortitionTree.set(0, juror, 100);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(100);
+
+        // Juror specializes in tech court
+        await sortitionTree.set(1, juror, 200);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(100);
+        expect(await sortitionTree.stakeOf(1, juror)).to.equal(200);
+
+        // Juror reduces general court involvement but increases tech specialization
+        await sortitionTree.set(0, juror, 50);
+        await sortitionTree.set(1, juror, 400);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(50);
+        expect(await sortitionTree.stakeOf(1, juror)).to.equal(400);
+
+        // Juror completely leaves general court
+        await sortitionTree.set(0, juror, 0);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(0);
+        expect(await sortitionTree.stakeOf(1, juror)).to.equal(400);
+      });
+
+      it("Should handle large multi-court operations efficiently", async function () {
+        const numCourts = 5;
+        const numJurors = 10;
+
+        // Create additional courts
+        for (let courtID = 3; courtID < numCourts; courtID++) {
+          await sortitionTree.createTree(courtID, 2);
+        }
+
+        // Add many jurors across many courts
+        for (let jurorIdx = 0; jurorIdx < numJurors; jurorIdx++) {
+          for (let courtID = 0; courtID < numCourts; courtID++) {
+            const stake = (jurorIdx + 1) * (courtID + 1) * 10; // Varied stakes
+            await sortitionTree.set(courtID, getTestAddress(jurorIdx), stake);
+          }
+        }
+
+        // Verify all operations completed successfully
+        for (let courtID = 0; courtID < numCourts; courtID++) {
+          const rootSum = await sortitionTree.getRootSum(courtID);
+          expect(rootSum).to.be.greaterThan(0);
+
+          // Should be able to draw from each court
+          const [drawnAddress] = await sortitionTree.draw(courtID, 1, 1, 12345 + courtID);
+          expect(drawnAddress).to.not.equal(ethers.ZeroAddress);
+        }
+      });
+    });
+  });
+
+  describe("Edge Cases & Error Conditions", function () {
+    it("Should handle operations on non-existent courts", async function () {
+      const juror = getTestAddress(0);
+
+      // Operations on non-existent court should behave predictably
+      expect(await sortitionTree.courtExists(999)).to.be.false;
+      expect(await sortitionTree.stakeOf(999, juror)).to.equal(0);
+
+      // Drawing from non-existent court should revert (no tree = no nodes array)
+      await expect(sortitionTree.draw(999, 1, 1, 12345)).to.be.reverted;
+    });
+
+    it("Should handle boundary values correctly", async function () {
+      await sortitionTree.createTree(0, 2);
+      const juror = getTestAddress(0);
+
+      // Test with maximum stake value
+      const maxStake = ethers.MaxUint256;
+
+      // This might fail due to gas limits, but should not revert due to overflow
+      // Note: In practice, stakes would be much smaller
+      try {
+        await sortitionTree.set(0, juror, maxStake);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(maxStake);
+      } catch (error) {
+        // Expected to fail due to gas limits, not due to overflow
+        expect(error).to.match(/gas/i);
+      }
+    });
+
+    it("Should maintain tree invariants under stress", async function () {
+      await sortitionTree.createTree(0, 3);
+
+      const operations = [];
+      const stakes = [100, 200, 300, 400, 500];
+      const jurors = stakes.map((_, i) => getTestAddress(i));
+
+      // Perform many random operations
+      for (let i = 0; i < 20; i++) {
+        const juror = jurors[i % jurors.length];
+        const stake = stakes[i % stakes.length];
+
+        await sortitionTree.set(0, juror, stake);
+        operations.push({ juror, stake });
+      }
+
+      // Verify tree integrity
+      let expectedTotal = 0;
+      const finalStakes = new Map();
+
+      // Calculate expected final state
+      for (const op of operations) {
+        const prevStake = finalStakes.get(op.juror) || 0;
+        expectedTotal = expectedTotal - prevStake + op.stake;
+        finalStakes.set(op.juror, op.stake);
+      }
+
+      // Verify actual state matches expected
+      expect(await sortitionTree.getRootSum(0)).to.equal(expectedTotal);
+
+      for (const [juror, expectedStake] of finalStakes) {
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(expectedStake);
+      }
+    });
+
+    it("Should handle rapid stake changes correctly", async function () {
+      await sortitionTree.createTree(0, 2);
+      const juror = getTestAddress(0);
+
+      // Rapid stake changes
+      const stakeSequence = [100, 0, 200, 300, 0, 150, 0, 500];
+
+      for (const stake of stakeSequence) {
+        await sortitionTree.set(0, juror, stake);
+        expect(await sortitionTree.stakeOf(0, juror)).to.equal(stake);
+        expect(await sortitionTree.getRootSum(0)).to.equal(stake);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Changes:
- More explicit boundary between the sortition trees and the sortition module.
- The tree key encoding doesn't leak anymore into the Core through the `createTree()` function, into the Dispute Kits through the `draw()` function.
- More readable handling of the tree key and courtID.
- Test coverage of the sortition trees

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `SortitionModule` to use `uint96` for court identifiers instead of `bytes32`, improving type safety and clarity. It also extracts the sortition sum trees logic into a dedicated library.

### Detailed summary
- Changed function parameters in `ISortitionModule` from `bytes32 _key` to `uint96 _courtID`.
- Updated `createTree` and `draw` functions to use `uint96` for court IDs.
- Refactored `SortitionSumTree` structure into a library `SortitionTrees`.
- Adjusted stake management functions to accommodate new types.
- Added tests for the new functionality and utilities in `SortitionTreesMock`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draw now returns the drawn juror and their originating subcourt.
  * New per‑court APIs to apply penalties/unstake and to view juror balances by court.

* **Refactor**
  * System-wide switch to numeric court IDs.
  * Sortition tree logic extracted to a shared library for consistent multi‑court handling.

* **Tests**
  * Comprehensive test suite and mocks validating tree, stake, draw, and multi‑court scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->