### PR TITLE
Proxy contracts reset of the version and initializers ahead of the migration

### DIFF
--- a/contracts/deploy/upgrade-all.ts
+++ b/contracts/deploy/upgrade-all.ts
@@ -98,11 +98,11 @@ const deployUpgradeAll: DeployFunction = async (hre: HardhatRuntimeEnvironment) 
   await upgrade(disputeKitShutter, "reinitialize", [wETH.address]);
   await upgrade(disputeKitGated, "reinitialize", [wETH.address]);
   await upgrade(disputeKitGatedShutter, "reinitialize", [wETH.address]);
-  await upgrade(disputeTemplateRegistry, "initialize2", []);
-  await upgrade(evidence, "initialize2", []);
+  await upgrade(disputeTemplateRegistry, "reinitialize", []);
+  await upgrade(evidence, "reinitialize", []);
   await upgrade(core, "reinitialize", [wETH.address]);
-  await upgrade(policyRegistry, "initialize2", []);
-  await upgrade(sortition, "initialize4", []);
+  await upgrade(policyRegistry, "reinitialize", []);
+  await upgrade(sortition, "reinitialize", []);
 };
 
 deployUpgradeAll.tags = ["UpgradeAll"];

--- a/contracts/src/arbitration/DisputeTemplateRegistry.sol
+++ b/contracts/src/arbitration/DisputeTemplateRegistry.sol
@@ -8,7 +8,7 @@ import "./interfaces/IDisputeTemplateRegistry.sol";
 /// @title Dispute Template Registry
 /// @dev A contract to maintain a registry of dispute templates.
 contract DisputeTemplateRegistry is IDisputeTemplateRegistry, UUPSProxiable, Initializable {
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -40,12 +40,8 @@ contract DisputeTemplateRegistry is IDisputeTemplateRegistry, UUPSProxiable, Ini
 
     /// @dev Initializer
     /// @param _owner Owner of the contract.
-    function initialize(address _owner) external reinitializer(1) {
+    function initialize(address _owner) external initializer {
         owner = _owner;
-    }
-
-    function initialize2() external reinitializer(2) {
-        // NOP
     }
 
     // ************************ //

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -8,7 +8,7 @@ import {KlerosCoreBase, IDisputeKit, ISortitionModule, IERC20} from "./KlerosCor
 /// Core arbitrator contract for Kleros v2.
 /// Note that this contract trusts the PNK token, the dispute kit and the sortition module contracts.
 contract KlerosCore is KlerosCoreBase {
-    string public constant override version = "0.10.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *            Constructor            * //
@@ -43,7 +43,7 @@ contract KlerosCore is KlerosCoreBase {
         bytes memory _sortitionExtraData,
         ISortitionModule _sortitionModuleAddress,
         address _wNative
-    ) external reinitializer(1) {
+    ) external initializer {
         __KlerosCoreBase_initialize(
             _owner,
             _guardian,
@@ -57,10 +57,6 @@ contract KlerosCore is KlerosCoreBase {
             _sortitionModuleAddress,
             _wNative
         );
-    }
-
-    function reinitialize(address _wNative) external reinitializer(6) {
-        wNative = _wNative;
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/KlerosCoreNeo.sol
+++ b/contracts/src/arbitration/KlerosCoreNeo.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 /// Core arbitrator contract for Kleros v2.
 /// Note that this contract trusts the PNK token, the dispute kit and the sortition module contracts.
 contract KlerosCoreNeo is KlerosCoreBase {
-    string public constant override version = "0.10.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -68,10 +68,6 @@ contract KlerosCoreNeo is KlerosCoreBase {
             _wNative
         );
         jurorNft = _jurorNft;
-    }
-
-    function reinitialize(address _wNative) external reinitializer(6) {
-        wNative = _wNative;
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/PolicyRegistry.sol
+++ b/contracts/src/arbitration/PolicyRegistry.sol
@@ -7,7 +7,7 @@ import "../proxy/Initializable.sol";
 /// @title PolicyRegistry
 /// @dev A contract to maintain a policy for each court.
 contract PolicyRegistry is UUPSProxiable, Initializable {
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *              Events               * //
@@ -47,12 +47,8 @@ contract PolicyRegistry is UUPSProxiable, Initializable {
 
     /// @dev Constructs the `PolicyRegistry` contract.
     /// @param _owner The owner's address.
-    function initialize(address _owner) external reinitializer(1) {
+    function initialize(address _owner) external initializer {
         owner = _owner;
-    }
-
-    function initialize2() external reinitializer(2) {
-        // NOP
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -7,7 +7,7 @@ import {SortitionModuleBase, KlerosCore, IRNG} from "./SortitionModuleBase.sol";
 /// @title SortitionModule
 /// @dev A factory of trees that keeps track of staked values for sortition.
 contract SortitionModule is SortitionModuleBase {
-    string public constant override version = "0.9.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *            Constructor            * //
@@ -30,12 +30,8 @@ contract SortitionModule is SortitionModuleBase {
         uint256 _minStakingTime,
         uint256 _maxDrawingTime,
         IRNG _rng
-    ) external reinitializer(1) {
+    ) external initializer {
         __SortitionModuleBase_initialize(_owner, _core, _minStakingTime, _maxDrawingTime, _rng);
-    }
-
-    function initialize4() external reinitializer(4) {
-        // NOP
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/SortitionModuleNeo.sol
+++ b/contracts/src/arbitration/SortitionModuleNeo.sol
@@ -7,7 +7,7 @@ import {SortitionModuleBase, KlerosCore, IRNG, StakingResult} from "./SortitionM
 /// @title SortitionModuleNeo
 /// @dev A factory of trees that keeps track of staked values for sortition.
 contract SortitionModuleNeo is SortitionModuleBase {
-    string public constant override version = "0.9.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -46,10 +46,6 @@ contract SortitionModuleNeo is SortitionModuleBase {
         __SortitionModuleBase_initialize(_owner, _core, _minStakingTime, _maxDrawingTime, _rng);
         maxStakePerJuror = _maxStakePerJuror;
         maxTotalStaked = _maxTotalStaked;
-    }
-
-    function initialize4() external reinitializer(4) {
-        // NOP
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
+++ b/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
@@ -13,7 +13,7 @@ import "../../libraries/Constants.sol";
 contract KlerosCoreRuler is IArbitratorV2, UUPSProxiable, Initializable {
     using SafeERC20 for IERC20;
 
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *         Enums / Structs           * //
@@ -175,11 +175,7 @@ contract KlerosCoreRuler is IArbitratorV2, UUPSProxiable, Initializable {
     /// @param _owner The owner's address.
     /// @param _pinakion The address of the token contract.
     /// @param _courtParameters Numeric parameters of General court (minStake, alpha, feeForJuror and jurorsForCourtJump respectively).
-    function initialize(
-        address _owner,
-        IERC20 _pinakion,
-        uint256[4] memory _courtParameters
-    ) external reinitializer(1) {
+    function initialize(address _owner, IERC20 _pinakion, uint256[4] memory _courtParameters) external initializer {
         owner = _owner;
         pinakion = _pinakion;
 
@@ -208,10 +204,6 @@ contract KlerosCoreRuler is IArbitratorV2, UUPSProxiable, Initializable {
             _courtParameters[3],
             court.timesPerPeriod
         );
-    }
-
-    function initialize2() external reinitializer(2) {
-        // NOP
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -11,7 +11,7 @@ import {DisputeKitClassicBase, KlerosCore} from "./DisputeKitClassicBase.sol";
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
 contract DisputeKitClassic is DisputeKitClassicBase {
-    string public constant override version = "0.13.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *            Constructor            * //
@@ -32,12 +32,8 @@ contract DisputeKitClassic is DisputeKitClassicBase {
         KlerosCore _core,
         address _wNative,
         uint256 _jumpDisputeKitID
-    ) external reinitializer(1) {
+    ) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative, _jumpDisputeKitID);
-    }
-
-    function reinitialize(uint256 _jumpDisputeKitID) external reinitializer(10) {
-        jumpDisputeKitID = _jumpDisputeKitID;
     }
 
     // ************************ //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
@@ -27,7 +27,7 @@ interface IBalanceHolderERC1155 {
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
 contract DisputeKitGated is DisputeKitClassicBase {
-    string public constant override version = "0.13.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *            Constructor            * //
@@ -48,12 +48,8 @@ contract DisputeKitGated is DisputeKitClassicBase {
         KlerosCore _core,
         address _wNative,
         uint256 _jumpDisputeKitID
-    ) external reinitializer(1) {
+    ) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative, _jumpDisputeKitID);
-    }
-
-    function reinitialize(uint256 _jumpDisputeKitID) external reinitializer(10) {
-        jumpDisputeKitID = _jumpDisputeKitID;
     }
 
     // ************************ //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
@@ -28,7 +28,7 @@ interface IBalanceHolderERC1155 {
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
 contract DisputeKitGatedShutter is DisputeKitClassicBase {
-    string public constant override version = "0.13.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -82,12 +82,8 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         KlerosCore _core,
         address _wNative,
         uint256 _jumpDisputeKitID
-    ) external reinitializer(1) {
+    ) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative, _jumpDisputeKitID);
-    }
-
-    function reinitialize(uint256 _jumpDisputeKitID) external reinitializer(10) {
-        jumpDisputeKitID = _jumpDisputeKitID;
     }
 
     // ************************ //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitShutter.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitShutter.sol
@@ -12,7 +12,7 @@ import {DisputeKitClassicBase, KlerosCore} from "./DisputeKitClassicBase.sol";
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
 contract DisputeKitShutter is DisputeKitClassicBase {
-    string public constant override version = "0.13.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -66,12 +66,8 @@ contract DisputeKitShutter is DisputeKitClassicBase {
         KlerosCore _core,
         address _wNative,
         uint256 _jumpDisputeKitID
-    ) external reinitializer(1) {
+    ) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative, _jumpDisputeKitID);
-    }
-
-    function reinitialize(uint256 _jumpDisputeKitID) external reinitializer(10) {
-        jumpDisputeKitID = _jumpDisputeKitID;
     }
 
     // ************************ //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -18,7 +18,7 @@ interface IProofOfHumanity {
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
 contract DisputeKitSybilResistant is DisputeKitClassicBase {
-    string public constant override version = "0.13.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -47,7 +47,7 @@ contract DisputeKitSybilResistant is DisputeKitClassicBase {
         IProofOfHumanity _poh,
         address _wNative,
         uint256 _jumpDisputeKitID
-    ) external reinitializer(1) {
+    ) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative, _jumpDisputeKitID);
         poh = _poh;
         singleDrawPerJuror = true;

--- a/contracts/src/arbitration/evidence/EvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/EvidenceModule.sol
@@ -9,7 +9,7 @@ import "../../proxy/Initializable.sol";
 
 /// @title Evidence Module
 contract EvidenceModule is IEvidence, Initializable, UUPSProxiable {
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
@@ -37,12 +37,8 @@ contract EvidenceModule is IEvidence, Initializable, UUPSProxiable {
 
     /// @dev Initializer.
     /// @param _owner The owner's address.
-    function initialize(address _owner) external reinitializer(1) {
+    function initialize(address _owner) external initializer {
         owner = _owner;
-    }
-
-    function initialize2() external reinitializer(2) {
-        // NOP
     }
 
     // ************************ //

--- a/contracts/src/arbitration/university/KlerosCoreUniversity.sol
+++ b/contracts/src/arbitration/university/KlerosCoreUniversity.sol
@@ -15,7 +15,7 @@ import "../../libraries/Constants.sol";
 contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
     using SafeERC20 for IERC20;
 
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *         Enums / Structs           * //
@@ -207,7 +207,7 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
         uint256[4] memory _courtParameters,
         uint256[4] memory _timesPerPeriod,
         ISortitionModuleUniversity _sortitionModuleAddress
-    ) external reinitializer(1) {
+    ) external initializer {
         owner = _owner;
         instructor = _instructor;
         pinakion = _pinakion;

--- a/contracts/src/arbitration/university/SortitionModuleUniversity.sol
+++ b/contracts/src/arbitration/university/SortitionModuleUniversity.sol
@@ -12,7 +12,7 @@ import "../../libraries/Constants.sol";
 /// @title SortitionModuleUniversity
 /// @dev An adapted version of the SortitionModule contract for educational purposes.
 contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable, Initializable {
-    string public constant override version = "0.8.0";
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *         Enums / Structs           * //
@@ -87,7 +87,7 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
 
     /// @dev Initializer (constructor equivalent for upgradable contracts).
     /// @param _core The KlerosCore.
-    function initialize(address _owner, KlerosCoreUniversity _core) external reinitializer(1) {
+    function initialize(address _owner, KlerosCoreUniversity _core) external initializer {
         owner = _owner;
         core = _core;
     }

--- a/contracts/src/gateway/ForeignGateway.sol
+++ b/contracts/src/gateway/ForeignGateway.sol
@@ -81,7 +81,7 @@ contract ForeignGateway is IForeignGateway, UUPSProxiable, Initializable {
         address _veaOutbox,
         uint256 _homeChainID,
         address _homeGateway
-    ) external reinitializer(1) {
+    ) external initializer {
         owner = _owner;
         veaOutbox = _veaOutbox;
         homeChainID = _homeChainID;

--- a/contracts/src/gateway/HomeGateway.sol
+++ b/contracts/src/gateway/HomeGateway.sol
@@ -72,7 +72,7 @@ contract HomeGateway is IHomeGateway, UUPSProxiable, Initializable {
         uint256 _foreignChainID,
         address _foreignGateway,
         IERC20 _feeToken
-    ) external reinitializer(1) {
+    ) external initializer {
         owner = _owner;
         arbitrator = _arbitrator;
         veaInbox = _veaInbox;

--- a/contracts/src/proxy/Initializable.sol
+++ b/contracts/src/proxy/Initializable.sol
@@ -93,7 +93,7 @@ abstract contract Initializable {
      * @dev A modifier that defines a protected initializer function that can be invoked at most once. In its scope,
      * `onlyInitializing` functions can be used to initialize parent contracts.
      *
-     * Similar to `reinitializer(1)`, except that functions marked with `initializer` can be nested in the context of a
+     * Similar to `initializer()`, except that functions marked with `initializer` can be nested in the context of a
      * constructor.
      *
      * Emits an {Initialized} event.

--- a/contracts/src/proxy/mock/by-inheritance/UpgradedByInheritance.sol
+++ b/contracts/src/proxy/mock/by-inheritance/UpgradedByInheritance.sol
@@ -20,7 +20,7 @@ contract UpgradedByInheritanceV1 is UUPSProxiable, Initializable {
         _disableInitializers();
     }
 
-    function initialize(address _owner) external virtual reinitializer(1) {
+    function initialize(address _owner) external virtual initializer {
         owner = _owner;
         counter = 1;
     }
@@ -61,7 +61,7 @@ contract UpgradedByInheritanceV3Bad is UpgradedByInheritanceV2 {
         _disableInitializers();
     }
 
-    function initializeV3() external reinitializer(1) {
+    function initializeV3() external initializer {
         // Wrong reinitializer version.
     }
 }

--- a/contracts/src/proxy/mock/by-rewrite/UpgradedByRewrite.sol
+++ b/contracts/src/proxy/mock/by-rewrite/UpgradedByRewrite.sol
@@ -23,7 +23,7 @@ contract UpgradedByRewrite is UUPSProxiable, Initializable {
         _disableInitializers();
     }
 
-    function initialize(address _owner) external virtual reinitializer(1) {
+    function initialize(address _owner) external virtual initializer {
         owner = _owner;
         counter = 1;
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the initialization methods in various smart contracts from `reinitializer` to `initializer`, alongside version updates to `2.0.0`. This change enhances contract upgradeability and improves the initialization process.

### Detailed summary
- Changed `reinitializer(1)` to `initializer` in multiple contracts.
- Updated version strings from previous versions to `2.0.0` in several contracts.
- Removed unnecessary `initialize2()` and `initialize4()` functions in some contracts.
- Updated initialization method signatures to include parameters where applicable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized one-time initialization across contracts; removed auxiliary reinitialize/initializeN entrypoints for a simpler, safer setup flow.
- Chores
  - Bumped public version identifiers to 2.0.0 across arbitration, dispute kits, gateways, and mock contracts.
  - Streamlined upgrade/deploy flow to align with the new initialization scheme.
- Documentation
  - Clarified initializer modifier description to reflect single-use initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->