### PR TITLE
feat: stateless fuzzing tests

### DIFF
--- a/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
+++ b/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
@@ -40,6 +40,8 @@ contract ArbitrableExample is IArbitrableV2 {
     mapping(uint256 => uint256) public externalIDtoLocalID; // Maps external (arbitrator side) dispute IDs to local dispute IDs.
     DisputeStruct[] public disputes; // Stores the disputes' info. disputes[disputeID].
 
+    uint256 public numberOfRulingOptions = 2;
+
     // ************************************* //
     // *        Function Modifiers         * //
     // ************************************* //
@@ -100,6 +102,10 @@ contract ArbitrableExample is IArbitrableV2 {
         templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
     }
 
+    function changeNumberOfRulingOptions(uint256 _numberOfRulingOptions) external onlyByOwner {
+        numberOfRulingOptions = _numberOfRulingOptions;
+    }
+
     // ************************************* //
     // *         State Modifiers           * //
     // ************************************* //
@@ -111,7 +117,6 @@ contract ArbitrableExample is IArbitrableV2 {
     function createDispute(string calldata _action) external payable returns (uint256 disputeID) {
         emit Action(_action);
 
-        uint256 numberOfRulingOptions = 2;
         uint256 localDisputeID = disputes.length;
         disputes.push(DisputeStruct({isRuled: false, ruling: 0, numberOfRulingOptions: numberOfRulingOptions}));
 
@@ -130,7 +135,6 @@ contract ArbitrableExample is IArbitrableV2 {
     function createDispute(string calldata _action, uint256 _feeInWeth) external returns (uint256 disputeID) {
         emit Action(_action);
 
-        uint256 numberOfRulingOptions = 2;
         uint256 localDisputeID = disputes.length;
         disputes.push(DisputeStruct({isRuled: false, ruling: 0, numberOfRulingOptions: numberOfRulingOptions}));
 

--- a/contracts/test/foundry/KlerosCore_Voting.t.sol
+++ b/contracts/test/foundry/KlerosCore_Voting.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
-import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import {KlerosCore, IArbitratorV2, IArbitrableV2} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitClassic, DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
 import {IDisputeKit} from "../../src/arbitration/interfaces/IDisputeKit.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
@@ -482,5 +482,60 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
         assertEq(totalVoted, 3, "totalVoted should be 3");
         assertEq(totalCommited, 0, "totalCommited should be 0");
         assertEq(choiceCount, 3, "choiceCount should be 3");
+    }
+
+    function testFuzz_castVote(uint256 numberOfOptions, uint256 choice1, uint256 choice2) public {
+        uint256 disputeID = 0;
+
+        arbitrable.changeNumberOfRulingOptions(numberOfOptions);
+
+        // Have only 2 options for 3 jurors to create a majority
+        vm.assume(choice1 <= numberOfOptions);
+        vm.assume(choice2 <= numberOfOptions);
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 2000);
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing phase
+
+        // Split the stakers' votes. The first staker will get VoteID 0 and the second will take the rest.
+        core.draw(disputeID, 1);
+
+        vm.warp(block.timestamp + maxDrawingTime);
+        sortitionModule.passPhase(); // Staking phase to stake the 2nd voter
+        vm.prank(staker2);
+        core.setStake(GENERAL_COURT, 20000);
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing phase
+
+        core.draw(disputeID, 2); // Assign leftover votes to staker2
+
+        vm.warp(block.timestamp + timesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+
+        uint256[] memory voteIDs = new uint256[](1);
+        voteIDs[0] = 0;
+        vm.prank(staker1);
+        disputeKit.castVote(disputeID, voteIDs, choice1, 0, "XYZ"); // Staker1 only got 1 vote because of low stake
+
+        voteIDs = new uint256[](2);
+        voteIDs[0] = 1;
+        voteIDs[1] = 2;
+        vm.prank(staker2);
+        disputeKit.castVote(disputeID, voteIDs, choice2, 0, "XYZ");
+        core.passPeriod(disputeID); // Appeal
+
+        vm.warp(block.timestamp + timesPerPeriod[3]);
+        core.passPeriod(disputeID); // Execution
+
+        vm.expectEmit(true, true, true, true);
+        emit IArbitrableV2.Ruling(IArbitratorV2(address(core)), disputeID, choice2);
+        core.executeRuling(disputeID);
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements to the `ArbitrableExample` contract by adding functionality to manage the number of ruling options in disputes and includes tests for various scenarios related to disputes, voting, and stakes in the Kleros arbitration system.

### Detailed summary
- Added `numberOfRulingOptions` variable to `ArbitrableExample`.
- Implemented `changeNumberOfRulingOptions` function to update ruling options.
- Removed local `numberOfRulingOptions` declarations in `createDispute` functions.
- Introduced fuzz tests for creating disputes, casting votes, and executing rulings.
- Enhanced existing tests to verify functionalities related to disputes and appeals.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ruling options are now configurable at runtime (default remains 2). Dispute creation and appeal flows consistently use the configured value. Governance can update the number of ruling options.

- Tests
  - Extensive fuzz tests added across appeals, disputes, drawing, execution, staking, and voting to validate variable ruling options, funding, iterations, and stake scenarios.
  - Improved assertion messages and coverage for end-to-end flows, balances, and juror state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->