### PR TITLE
Evidence event extra `_arbitrable` parameter

### DIFF
--- a/contracts/src/arbitration/evidence/EvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/EvidenceModule.sol
@@ -58,10 +58,12 @@ contract EvidenceModule is IEvidence, Initializable, UUPSProxiable {
     // ************************************* //
 
     /// @notice Submits evidence for a dispute.
+    /// @dev This function is intended for end users, not for arbitrable contracts which should emit their own events.
+    /// @param _arbitrable The arbitrable contract address.
     /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right evidence group ID.
     /// @param _evidence Stringified evidence object, example: `{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}`.
-    function submitEvidence(uint256 _externalDisputeID, string calldata _evidence) external {
-        emit Evidence(_externalDisputeID, msg.sender, _evidence);
+    function submitEvidence(address _arbitrable, uint256 _externalDisputeID, string calldata _evidence) external {
+        emit Evidence(_arbitrable, _externalDisputeID, msg.sender, _evidence);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
@@ -72,13 +72,15 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
 
     /// @notice To be raised when a moderated evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
     /// @param _arbitrator The arbitrator of the contract.
+    /// @param _arbitrable The arbitrable contract address.
     /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right evidence group ID.
     /// @param _party The address of the party submiting the evidence. Note that 0x0 refers to evidence not submitted by any party.
     /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
     event ModeratedEvidence(
         IArbitratorV2 indexed _arbitrator,
+        address indexed _arbitrable,
         uint256 indexed _externalDisputeID,
-        address indexed _party,
+        address _party,
         string _evidence
     );
 
@@ -190,9 +192,10 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
     // ************************************* //
 
     /// @notice Submits evidence.
+    /// @param _arbitrable The arbitrable contract address for this evidence.
     /// @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to. It's the submitter responsibility to submit the right evidence group ID.
     /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
-    function submitEvidence(uint256 _evidenceGroupID, string calldata _evidence) external payable {
+    function submitEvidence(address _arbitrable, uint256 _evidenceGroupID, string calldata _evidence) external payable {
         // Optimization opportunity: map evidenceID to an incremental index that can be safely assumed to be less than a small uint.
         bytes32 evidenceID = keccak256(abi.encodePacked(_evidenceGroupID, _evidence));
         EvidenceData storage evidenceData = evidences[evidenceID];
@@ -214,7 +217,7 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
         moderation.arbitratorDataID = arbitratorDataList.length - 1;
 
         // When evidence is submitted for a foreign arbitrable, the arbitrator field of Evidence is ignored.
-        emit ModeratedEvidence(arbitrator, _evidenceGroupID, msg.sender, _evidence);
+        emit ModeratedEvidence(arbitrator, _arbitrable, _evidenceGroupID, msg.sender, _evidence);
     }
 
     /// @notice Moderates an evidence submission. Requires the contester to at least double the accumulated stake of the oposing party.

--- a/contracts/src/arbitration/interfaces/IEvidence.sol
+++ b/contracts/src/arbitration/interfaces/IEvidence.sol
@@ -5,8 +5,15 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title IEvidence
 interface IEvidence {
     /// @notice To be raised when evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
+    /// @dev This event is intended for end users submitting evidence, not for arbitrable contracts.
+    /// @param _arbitrable The arbitrable contract address.
     /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right external dispute ID.
     /// @param _party The address of the party submitting the evidence.
     /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
-    event Evidence(uint256 indexed _externalDisputeID, address indexed _party, string _evidence);
+    event Evidence(
+        address indexed _arbitrable,
+        uint256 indexed _externalDisputeID,
+        address indexed _party,
+        string _evidence
+    );
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `submitEvidence` functionality in the Kleros arbitration system by adding an `_arbitrable` address parameter to related functions and events. This improves clarity and ensures that evidence submissions are correctly associated with their respective arbitrable contracts.

### Detailed summary
- Added `_arbitrable` parameter to `submitEvidence` in `EvidenceModule.sol` and `ModeratedEvidenceModule.sol`.
- Updated `Evidence` event in `IEvidence.sol` to include `_arbitrable`.
- Modified `ModeratedEvidence` event in `ModeratedEvidenceModule.sol` to include `_arbitrable`.
- Adjusted test cases in `index.ts` to reflect the new `_arbitrable` parameter in evidence submission.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Evidence and ModeratedEvidence events now include the arbitrable address for clearer dispute traceability.
- Refactor
  - Evidence submission now requires the arbitrable address as the first parameter; event argument order updated accordingly.
- Documentation
  - Updated guidance to reflect the new arbitrable parameter in evidence submission and events.
- Tests
  - Test scenarios updated to validate the new function signatures and event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->