### PR TITLE
Removal of externalDisputeID

### DIFF
--- a/contracts/src/arbitration/KlerosGovernor.sol
+++ b/contracts/src/arbitration/KlerosGovernor.sol
@@ -303,7 +303,7 @@ contract KlerosGovernor is IArbitrableV2 {
             // Check in case arbitration cost increased after the submission. It's unlikely that its increase won't be covered by the base deposit, but technically possible.
             session.sumDeposit = session.sumDeposit > arbitrationCost ? session.sumDeposit - arbitrationCost : 0;
             reservedETH = reservedETH > arbitrationCost ? reservedETH - arbitrationCost : 0;
-            emit DisputeRequest(arbitrator, session.disputeID, sessions.length - 1, templateId);
+            emit DisputeRequest(arbitrator, session.disputeID, templateId);
         }
     }
 

--- a/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
+++ b/contracts/src/arbitration/arbitrables/ArbitrableExample.sol
@@ -123,8 +123,7 @@ contract ArbitrableExample is IArbitrableV2 {
         disputeID = arbitrator.createDispute{value: msg.value}(numberOfRulingOptions, arbitratorExtraData);
         externalIDtoLocalID[disputeID] = localDisputeID;
 
-        uint256 externalDisputeID = uint256(keccak256(abi.encodePacked(_action)));
-        emit DisputeRequest(arbitrator, disputeID, externalDisputeID, templateId);
+        emit DisputeRequest(arbitrator, disputeID, templateId);
     }
 
     /// @notice Calls createDispute function of the specified arbitrator to create a dispute.
@@ -144,8 +143,7 @@ contract ArbitrableExample is IArbitrableV2 {
         disputeID = arbitrator.createDispute(numberOfRulingOptions, arbitratorExtraData, weth, _feeInWeth);
         externalIDtoLocalID[disputeID] = localDisputeID;
 
-        uint256 externalDisputeID = uint256(keccak256(abi.encodePacked(_action)));
-        emit DisputeRequest(arbitrator, disputeID, externalDisputeID, templateId);
+        emit DisputeRequest(arbitrator, disputeID, templateId);
     }
 
     /// @inheritdoc IArbitrableV2

--- a/contracts/src/arbitration/arbitrables/DisputeResolver.sol
+++ b/contracts/src/arbitration/arbitrables/DisputeResolver.sol
@@ -134,7 +134,7 @@ contract DisputeResolver is IArbitrableV2 {
         );
         arbitratorDisputeIDToLocalID[arbitratorDisputeID] = localDisputeID;
         uint256 templateId = templateRegistry.setDisputeTemplate("", _disputeTemplate, _disputeTemplateDataMappings);
-        emit DisputeRequest(arbitrator, arbitratorDisputeID, localDisputeID, templateId);
+        emit DisputeRequest(arbitrator, arbitratorDisputeID, templateId);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/devtools/DisputeResolverRuler.sol
+++ b/contracts/src/arbitration/devtools/DisputeResolverRuler.sol
@@ -46,7 +46,7 @@ contract DisputeResolverRuler is DisputeResolver {
         arbitratorDisputeID = IKlerosCoreRulerFragment(address(arbitrator)).getNextDisputeID();
         arbitratorDisputeIDToLocalID[arbitratorDisputeID] = localDisputeID;
         uint256 templateId = templateRegistry.setDisputeTemplate("", _disputeTemplate, _disputeTemplateDataMappings);
-        emit DisputeRequest(arbitrator, arbitratorDisputeID, localDisputeID, templateId);
+        emit DisputeRequest(arbitrator, arbitratorDisputeID, templateId);
 
         arbitrator.createDispute{value: msg.value}(_numberOfRulingOptions, _arbitratorExtraData);
     }

--- a/contracts/src/arbitration/evidence/EvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/EvidenceModule.sol
@@ -58,10 +58,10 @@ contract EvidenceModule is IEvidence, Initializable, UUPSProxiable {
     // ************************************* //
 
     /// @notice Submits evidence for a dispute.
-    /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right evidence group ID.
+    /// @param _arbitratorDisputeID The identifier of the dispute in the Arbitrator contract.
     /// @param _evidence Stringified evidence object, example: `{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}`.
-    function submitEvidence(uint256 _externalDisputeID, string calldata _evidence) external {
-        emit Evidence(_externalDisputeID, msg.sender, _evidence);
+    function submitEvidence(uint256 _arbitratorDisputeID, string calldata _evidence) external {
+        emit Evidence(_arbitratorDisputeID, msg.sender, _evidence);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
+++ b/contracts/src/arbitration/evidence/ModeratedEvidenceModule.sol
@@ -72,12 +72,12 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
 
     /// @notice To be raised when a moderated evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
     /// @param _arbitrator The arbitrator of the contract.
-    /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right evidence group ID.
+    /// @param _arbitratorDisputeID The identifier of the dispute in the Arbitrator contract.
     /// @param _party The address of the party submiting the evidence. Note that 0x0 refers to evidence not submitted by any party.
     /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
     event ModeratedEvidence(
         IArbitratorV2 indexed _arbitrator,
-        uint256 indexed _externalDisputeID,
+        uint256 indexed _arbitratorDisputeID,
         address indexed _party,
         string _evidence
     );
@@ -214,7 +214,7 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
         moderation.arbitratorDataID = arbitratorDataList.length - 1;
 
         // When evidence is submitted for a foreign arbitrable, the arbitrator field of Evidence is ignored.
-        emit ModeratedEvidence(arbitrator, _evidenceGroupID, msg.sender, _evidence);
+        emit ModeratedEvidence(arbitrator, evidenceData.disputeID, msg.sender, _evidence);
     }
 
     /// @notice Moderates an evidence submission. Requires the contester to at least double the accumulated stake of the oposing party.
@@ -265,12 +265,7 @@ contract ModeratedEvidenceModule is IArbitrableV2 {
             );
             disputeIDtoEvidenceID[evidenceData.disputeID] = _evidenceID;
 
-            emit DisputeRequest(
-                arbitrator,
-                evidenceData.disputeID,
-                uint256(_evidenceID),
-                arbitratorData.disputeTemplateId
-            );
+            emit DisputeRequest(arbitrator, evidenceData.disputeID, arbitratorData.disputeTemplateId);
             evidenceData.disputed = true;
             moderation.bondDeadline = 0;
             moderation.currentWinner = Party.None;

--- a/contracts/src/arbitration/interfaces/IArbitrableV2.sol
+++ b/contracts/src/arbitration/interfaces/IArbitrableV2.sol
@@ -17,14 +17,8 @@ interface IArbitrableV2 {
     /// @notice To be emitted when a dispute is created to link the correct template to the disputeID.
     /// @param _arbitrator The arbitrator of the contract.
     /// @param _arbitratorDisputeID The identifier of the dispute in the Arbitrator contract.
-    /// @param _externalDisputeID An identifier created outside Kleros by the protocol requesting arbitration.
     /// @param _templateId The identifier of the dispute template.
-    event DisputeRequest(
-        IArbitratorV2 indexed _arbitrator,
-        uint256 indexed _arbitratorDisputeID,
-        uint256 _externalDisputeID,
-        uint256 _templateId
-    );
+    event DisputeRequest(IArbitratorV2 indexed _arbitrator, uint256 indexed _arbitratorDisputeID, uint256 _templateId);
 
     /// @notice To be raised when a ruling is given.
     /// @param _arbitrator The arbitrator giving the ruling.

--- a/contracts/src/arbitration/interfaces/IEvidence.sol
+++ b/contracts/src/arbitration/interfaces/IEvidence.sol
@@ -5,8 +5,8 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title IEvidence
 interface IEvidence {
     /// @notice To be raised when evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
-    /// @param _externalDisputeID Unique identifier for this dispute outside Kleros. It's the submitter responsibility to submit the right external dispute ID.
+    /// @param _arbitratorDisputeID The identifier of the dispute in the Arbitrator contract.
     /// @param _party The address of the party submitting the evidence.
     /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
-    event Evidence(uint256 indexed _externalDisputeID, address indexed _party, string _evidence);
+    event Evidence(uint256 indexed _arbitratorDisputeID, address indexed _party, string _evidence);
 }

--- a/contracts/src/gateway/HomeGateway.sol
+++ b/contracts/src/gateway/HomeGateway.sol
@@ -151,7 +151,7 @@ contract HomeGateway is IHomeGateway, UUPSProxiable, Initializable {
         disputeHashtoID[disputeHash] = disputeID;
         relayedData.relayer = msg.sender;
 
-        emit DisputeRequest(arbitrator, disputeID, _params.externalDisputeID, _params.templateId);
+        emit DisputeRequest(arbitrator, disputeID, _params.templateId);
 
         emit CrossChainDisputeIncoming(
             arbitrator,
@@ -159,7 +159,6 @@ contract HomeGateway is IHomeGateway, UUPSProxiable, Initializable {
             _params.foreignArbitrable,
             _params.foreignDisputeID,
             disputeID,
-            _params.externalDisputeID,
             _params.templateId
         );
     }
@@ -192,7 +191,7 @@ contract HomeGateway is IHomeGateway, UUPSProxiable, Initializable {
         relayedData.relayer = msg.sender;
 
         // Not strictly necessary for functionality, only to satisfy IArbitrableV2
-        emit DisputeRequest(arbitrator, disputeID, _params.externalDisputeID, _params.templateId);
+        emit DisputeRequest(arbitrator, disputeID, _params.templateId);
 
         emit CrossChainDisputeIncoming(
             arbitrator,
@@ -200,7 +199,6 @@ contract HomeGateway is IHomeGateway, UUPSProxiable, Initializable {
             _params.foreignArbitrable,
             _params.foreignDisputeID,
             disputeID,
-            _params.externalDisputeID,
             _params.templateId
         );
     }

--- a/contracts/src/gateway/interfaces/IHomeGateway.sol
+++ b/contracts/src/gateway/interfaces/IHomeGateway.sol
@@ -18,14 +18,12 @@ interface IHomeGateway is IArbitrableV2, ISenderGateway {
     /// @param _arbitrable The address of the Arbitrable contract.
     /// @param _arbitrableDisputeID The identifier of the dispute in the Arbitrable contract.
     /// @param _arbitratorDisputeID The identifier of the dispute in the Arbitrator contract.
-    /// @param _externalDisputeID An identifier created outside Kleros by the protocol requesting arbitration.
     event CrossChainDisputeIncoming(
         IArbitratorV2 _arbitrator,
         uint256 _arbitrableChainId,
         address indexed _arbitrable,
         uint256 indexed _arbitrableDisputeID,
         uint256 indexed _arbitratorDisputeID,
-        uint256 _externalDisputeID,
         uint256 _templateId
     );
 
@@ -39,7 +37,6 @@ interface IHomeGateway is IArbitrableV2, ISenderGateway {
         uint256 foreignChainID;
         address foreignArbitrable;
         uint256 foreignDisputeID;
-        uint256 externalDisputeID;
         uint256 templateId;
         uint256 choices;
         bytes extraData;

--- a/contracts/test/arbitration/draw.ts
+++ b/contracts/test/arbitration/draw.ts
@@ -154,13 +154,12 @@ describe("Draw Benchmark", async () => {
     // Relayer tx
     await homeGateway
       .connect(await ethers.getSigner(relayer))
-      ["relayCreateDispute((bytes32,uint256,address,uint256,uint256,uint256,uint256,bytes))"](
+      ["relayCreateDispute((bytes32,uint256,address,uint256,uint256,uint256,bytes))"](
         {
           foreignBlockHash: lastBlock?.hash,
           foreignChainID: 31337,
           foreignArbitrable: arbitrable.target,
           foreignDisputeID: disputeId,
-          externalDisputeID: ethers.keccak256(ethers.toUtf8Bytes("future of france")),
           templateId: 0,
           choices: 2,
           extraData: `0x000000000000000000000000000000000000000000000000000000000000000${createDisputeCourtId}0000000000000000000000000000000000000000000000000000000000000003`,

--- a/contracts/test/arbitration/ruler.ts
+++ b/contracts/test/arbitration/ruler.ts
@@ -97,7 +97,7 @@ describe("KlerosCoreRuler", async () => {
       .and.to.emit(core, "JurorRewardPenalty")
       .withArgs(dev.address, disputeID, 0, 10000, 10000, 0, anyValue, ZeroAddress)
       .and.to.emit(resolver, "DisputeRequest")
-      .withArgs(core.target, disputeID, localDisputeID, templateId)
+      .withArgs(core.target, disputeID, templateId)
       .and.to.emit(resolver, "Ruling")
       .withArgs(core.target, disputeID, anyValue);
   });
@@ -121,7 +121,7 @@ describe("KlerosCoreRuler", async () => {
       .and.to.emit(core, "JurorRewardPenalty")
       .withArgs(dev.address, disputeID, 0, 10000, 10000, 0, anyValue, ZeroAddress)
       .and.to.emit(resolver, "DisputeRequest")
-      .withArgs(core.target, disputeID, localDisputeID, templateId)
+      .withArgs(core.target, disputeID, templateId)
       .and.to.emit(resolver, "Ruling")
       .withArgs(core.target, disputeID, 2);
   });
@@ -139,7 +139,7 @@ describe("KlerosCoreRuler", async () => {
       .to.emit(core, "DisputeCreation")
       .withArgs(disputeID, resolver.target)
       .and.to.emit(resolver, "DisputeRequest")
-      .withArgs(core.target, disputeID, localDisputeID, templateId);
+      .withArgs(core.target, disputeID, templateId);
 
     await expect(core.connect(deployer).executeRuling(disputeID, 3, true, true)).revertedWithCustomError(
       core,

--- a/contracts/test/evidence/index.ts
+++ b/contracts/test/evidence/index.ts
@@ -154,9 +154,9 @@ describe("Home Evidence contract", async () => {
       if (receipt === null) throw new Error("Receipt is null");
       const evidenceID = ethers.solidityPackedKeccak256(["uint", "string"], [1234, newEvidence]);
 
-      const [_arbitrator, _externalDisputeID, _party, _evidence] = getEmittedEvent("ModeratedEvidence", receipt).args;
+      const [_arbitrator, _disputeID, _party, _evidence] = getEmittedEvent("ModeratedEvidence", receipt).args;
       expect(_arbitrator).to.equal(arbitrator.target, "Wrong arbitrator.");
-      expect(_externalDisputeID).to.equal(1234, "Wrong external dispute ID.");
+      expect(_disputeID).to.equal(0, "Wrong dispute ID.");
       expect(_party).to.equal(user1.address, "Wrong submitter.");
       expect(_evidence).to.equal(newEvidence, "Wrong evidence message.");
 
@@ -261,14 +261,10 @@ describe("Home Evidence contract", async () => {
       });
       let receipt = await tx.wait();
       if (receipt === null) throw new Error("Receipt is null");
-      let [_arbitrator, _arbitrableDisputeID, _externalDisputeID, _templateId, _templateUri] = getEmittedEvent(
-        "DisputeRequest",
-        receipt
-      ).args;
+      let [_arbitrator, _disputeID, _templateId, _templateUri] = getEmittedEvent("DisputeRequest", receipt).args;
       expect(_arbitrator).to.equal(arbitrator.target, "Wrong arbitrator.");
-      expect(_arbitrableDisputeID).to.equal(0, "Wrong dispute ID.");
+      expect(_disputeID).to.equal(0, "Wrong dispute ID.");
       expect(_templateId).to.equal(1, "Wrong template ID.");
-      expect(_externalDisputeID).to.equal(evidenceID, "Wrong external dispute ID.");
 
       await expect(
         evidenceModule.connect(user2).moderate(evidenceID, Party.Moderator, {

--- a/contracts/test/integration/index.ts
+++ b/contracts/test/integration/index.ts
@@ -111,14 +111,7 @@ describe("Integration tests", async () => {
     await expect(tx)
       .to.emit(foreignGateway, "CrossChainDisputeOutgoing")
       .withArgs(anyValue, arbitrable.target, 1, 2, "0x00");
-    await expect(tx)
-      .to.emit(arbitrable, "DisputeRequest")
-      .withArgs(
-        foreignGateway.target,
-        1,
-        46619385602526556702049273755915206310773794210139929511467397410441395547901n,
-        0
-      );
+    await expect(tx).to.emit(arbitrable, "DisputeRequest").withArgs(foreignGateway.target, 1, 0);
     if (tx.blockNumber === null) throw new Error("tx.blockNumber is null");
     const lastBlock = await ethers.provider.getBlock(tx.blockNumber - 1);
     if (lastBlock === null) throw new Error("lastBlock is null");
@@ -132,21 +125,18 @@ describe("Integration tests", async () => {
     }
     // Relayer tx
     await expect(
-      homeGateway
-        .connect(relayer)
-        ["relayCreateDispute((bytes32,uint256,address,uint256,uint256,uint256,uint256,bytes))"](
-          {
-            foreignBlockHash: ethers.toBeHex(lastBlock.hash),
-            foreignChainID: 31337,
-            foreignArbitrable: arbitrable.target,
-            foreignDisputeID: disputeId,
-            externalDisputeID: ethers.keccak256(ethers.toUtf8Bytes("future of france")),
-            templateId: 0,
-            choices: 2,
-            extraData: "0x00",
-          },
-          { value: arbitrationCost }
-        )
+      homeGateway.connect(relayer)["relayCreateDispute((bytes32,uint256,address,uint256,uint256,uint256,bytes))"](
+        {
+          foreignBlockHash: ethers.toBeHex(lastBlock.hash),
+          foreignChainID: 31337,
+          foreignArbitrable: arbitrable.target,
+          foreignDisputeID: disputeId,
+          templateId: 0,
+          choices: 2,
+          extraData: "0x00",
+        },
+        { value: arbitrationCost }
+      )
     ).to.emit(homeGateway, "DisputeRequest");
 
     await network.provider.send("evm_increaseTime", [2000]); // Wait for minStakingTime


### PR DESCRIPTION
Resolves #2168 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `DisputeRequest` event by removing the `_externalDisputeID` parameter across multiple contracts, improving code clarity and consistency while retaining the essential functionality.

### Detailed summary
- Removed `_externalDisputeID` from `DisputeRequest` in `KlerosGovernor.sol`, `DisputeResolver.sol`, `DisputeResolverRuler.sol`, `ArbitrableExample.sol`, and `HomeGateway.sol`.
- Updated event signatures in `IArbitrableV2.sol` and `IEvidence.sol` to reflect the removal of `_externalDisputeID`.
- Adjusted function parameters in `submitEvidence` to use `_arbitratorDisputeID` instead of `_externalDisputeID`.
- Modified tests in `draw.ts`, `ruler.ts`, and `index.ts` to align with the new event structure and removed references to `_externalDisputeID`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Ruling event to arbitrable interfaces for clearer outcome tracking.
- Refactor
  - Streamlined dispute-related events by removing local/external dispute IDs and standardizing on arbitrator dispute ID.
  - Simplified gateway dispute creation parameters (fewer arguments) and aligned event payloads accordingly.
- Documentation
  - Updated parameter names and comments to reflect the new dispute ID conventions.
- Tests
  - Adjusted test suites to match updated event shapes and simplified dispute creation inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->