### PR TITLE
feat(KC): allow to pass commit period quicker

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -708,8 +708,10 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             if (round.drawnJurors.length != round.nbVotes) revert DisputeStillDrawing();
             dispute.period = court.hiddenVotes ? Period.commit : Period.vote;
         } else if (dispute.period == Period.commit) {
-            // Note that we do not want to pass to Voting period if all the commits are cast because it breaks the Shutter auto-reveal currently.
-            if (block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)]) {
+            if (
+                block.timestamp - dispute.lastPeriodChange < court.timesPerPeriod[uint256(dispute.period)] &&
+                !disputeKits[round.disputeKitID].areCommitsAllCast(_disputeID)
+            ) {
                 revert CommitPeriodNotPassed();
             }
             dispute.period = Period.vote;

--- a/contracts/test/foundry/KlerosCore_Voting.t.sol
+++ b/contracts/test/foundry/KlerosCore_Voting.t.sol
@@ -94,6 +94,10 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
         voteIDs[0] = 1;
         voteIDs[1] = 2;
 
+        // Shouldn't allow to switch period yet.
+        vm.expectRevert(KlerosCore.CommitPeriodNotPassed.selector);
+        core.passPeriod(disputeID);
+
         vm.prank(staker1);
         vm.expectEmit(true, true, true, true);
         emit DisputeKitClassicBase.CommitCast(disputeID, staker1, voteIDs, commit);
@@ -109,7 +113,8 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
         }
 
         // Check reveal in the next period
-        vm.warp(block.timestamp + timesPerPeriod[1]);
+        // Should allow to switch period since all commits are cast.
+        //vm.warp(block.timestamp + timesPerPeriod[1]);
         core.passPeriod(disputeID);
 
         // Check the require with the wrong choice and then with the wrong salt


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the period transition logic in the `KlerosCore` contract to prevent switching to the voting period until all commits are cast. It also updates the test cases to reflect this new logic.

### Detailed summary
- Modified the condition for transitioning from `Period.commit` to `Period.vote` to include a check for all commits being cast.
- Added a revert statement `CommitPeriodNotPassed()` if the transition conditions are not met.
- Updated tests to expect a revert when trying to pass the period before all commits are cast.
- Adjusted comments in the test to clarify the expected behavior regarding period transitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced commit period validation to ensure all commits are cast before advancing to the voting period, preventing premature period transitions during the arbitration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->