### PR TITLE
Update keeperBotShutter.ts: Allow - characters in justification field when decoding messages

### DIFF
--- a/contracts/scripts/keeperBotShutter.ts
+++ b/contracts/scripts/keeperBotShutter.ts
@@ -35,10 +35,12 @@ const logger = loggerFactory.createLogger(loggerOptions);
 const decode = (message: string) => {
   const SEPARATOR = "-";
   const parts = message.split(SEPARATOR);
-  if (parts.length !== 3) {
+  if (parts.length < 3) {
     throw Error(`Malformed decrypted message (${message})`);
   }
-  const [choice, salt, justification] = parts;
+  const [choice, salt, ...rest] = parts;
+  const justification = rest.join(SEPARATOR);
+  
   return {
     choice: BigInt(choice),
     salt,


### PR DESCRIPTION
Previously, the implementation assumed that the decrypted message would always split into exactly three parts:

choice-salt-justification

This caused decoding to fail with Malformed decrypted message when the justification itself contained -, since message.split("-") produced more than three segments.

The new logic:

* Requires parts.length >= 3 instead of parts.length === 3
* Except for the first and second segments, all remaining segments (re-joined with -) as justification

This preserves the existing format while making the decoder robust to justifications that include the separator which can be used in texts.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the way the `message` is parsed in the `keeperBotShutter.ts` file. It changes the condition for validating the number of parts and adjusts how the `justification` is extracted from the `parts` array.

### Detailed summary
- Changed the validation condition from checking for exactly 3 parts to checking for fewer than 3 parts.
- Updated the destructuring of `parts` to capture all remaining elements into `rest`.
- Constructed `justification` by joining the `rest` array with the `SEPARATOR`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message parsing to correctly handle messages with multiple separators, allowing proper reconstruction of multi-part content. The decoder now robustly processes complex message structures while preserving existing field integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->