### PR TITLE
fix(subgraph): evidence-crash

### DIFF
--- a/subgraph/core/src/EvidenceModule.ts
+++ b/subgraph/core/src/EvidenceModule.ts
@@ -29,6 +29,7 @@ export function handleEvidenceEvent(event: EvidenceEvent): void {
   evidence.sender = userId;
   evidence.senderAddress = userId;
   evidence.evidenceIndex = numberOfEvidences.toString();
+  evidence.dispute = dispute.id;
   ensureUser(userId);
 
   let jsonObjValueAndSuccess = json.try_fromString(event.params._evidence);

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "drtVersion": "0.14.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `version` of the `@kleros/kleros-v2-subgraph` package and adds a new property to the `evidence` object in the `EvidenceModule.ts` file to include the `dispute` ID.

### Detailed summary
- Updated `version` in `subgraph/package.json` from `0.19.1` to `0.19.2`.
- Added `evidence.dispute = dispute.id;` in `subgraph/core/src/EvidenceModule.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed evidence tracking to properly link evidence records with their related disputes.

* **Chores**
  * Version bump to 0.19.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->