### PR TITLE
chore: translation bug in attachment pages

### DIFF
--- a/web/src/components/DisputePreview/Policies.tsx
+++ b/web/src/components/DisputePreview/Policies.tsx
@@ -78,7 +78,7 @@ export const Policies: React.FC<IPolicies> = ({ disputePolicyURI, courtId, attac
       <StyledP>{t("misc.policy_documents")}</StyledP>
       {!isUndefined(attachment) && !isUndefined(attachment.uri) ? (
         <StyledInternalLink
-          to={`/attachment/?disputeId=${id}&title=${t("misc.case_policy")}&url=${getIpfsUrl(attachment.uri)}`}
+          to={`/attachment/?disputeId=${id}&title=misc.case_policy&url=${getIpfsUrl(attachment.uri)}`}
         >
           <StyledPaperclipIcon />
           {attachment.label ?? t("misc.attachment")}
@@ -86,7 +86,7 @@ export const Policies: React.FC<IPolicies> = ({ disputePolicyURI, courtId, attac
       ) : null}
       {isUndefined(disputePolicyURI) ? null : (
         <StyledInternalLink
-          to={`/attachment/?disputeId=${id}&title=${t("misc.dispute_policy")}&url=${getIpfsUrl(disputePolicyURI)}`}
+          to={`/attachment/?disputeId=${id}&title=misc.dispute_policy&url=${getIpfsUrl(disputePolicyURI)}`}
         >
           <StyledPolicyIcon />
           {t("misc.dispute_policy")}

--- a/web/src/components/EvidenceCard.tsx
+++ b/web/src/components/EvidenceCard.tsx
@@ -242,9 +242,7 @@ const EvidenceCard: React.FC<IEvidenceCard> = ({
         </BottomLeftContent>
         {fileURI && fileURI !== "-" ? (
           <FileLinkContainer>
-            <StyledInternalLink
-              to={`/attachment/?disputeId=${id}&title=${t("misc.evidence_file")}&url=${getIpfsUrl(fileURI)}`}
-            >
+            <StyledInternalLink to={`/attachment/?disputeId=${id}&title=misc.evidence_file&url=${getIpfsUrl(fileURI)}`}>
               <AttachmentIcon />
               <AttachedFileText />
             </StyledInternalLink>

--- a/web/src/pages/AttachmentDisplay/Header.tsx
+++ b/web/src/pages/AttachmentDisplay/Header.tsx
@@ -70,14 +70,14 @@ const Header: React.FC<{ title: string }> = ({ title }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const disputeId = searchParams.get("disputeId");
-  const attachmentTitle = searchParams.get("title");
+  const titleKey = searchParams.get("title");
 
   const handleReturn = () => {
-    if (attachmentTitle === "Evidence File") {
+    if (titleKey === "misc.evidence_file") {
       navigate(`/cases/${disputeId}/evidence`);
-    } else if (attachmentTitle === "Case Policy" || attachmentTitle === "Dispute Policy") {
+    } else if (titleKey === "misc.case_policy" || titleKey === "misc.dispute_policy") {
       navigate(`/cases/${disputeId}/overview`);
-    } else if (attachmentTitle === "Policy File") {
+    } else if (titleKey === "misc.policy_file") {
       navigate(`/resolver/policy`);
     } else {
       navigate("/");

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -56,7 +56,8 @@ const AttachmentDisplay: React.FC = () => {
   const [searchParams] = useSearchParams();
 
   const url = searchParams.get("url");
-  const title = searchParams.get("title") ?? t("misc.attachment");
+  const titleKey = searchParams.get("title");
+  const title = titleKey ? t(titleKey) : t("misc.attachment");
   return (
     <Container>
       <AttachmentContainer>

--- a/web/src/pages/Resolver/Policy/index.tsx
+++ b/web/src/pages/Resolver/Policy/index.tsx
@@ -113,7 +113,7 @@ const Policy: React.FC = () => {
         msg={`${t("misc.you_can_attach_additional")}\n${getFileUploaderMsg(Roles.Policy, roleRestrictions)}`}
       />
       {!isUndefined(disputeData.policyURI) ? (
-        <StyledInternalLink to={`/attachment/?title=${t("misc.policy_file")}&url=${getIpfsUrl(disputeData.policyURI)}`}>
+        <StyledInternalLink to={`/attachment/?title=misc.policy_file&url=${getIpfsUrl(disputeData.policyURI)}`}>
           <StyledPolicyIcon />
           {t("misc.inspect_uploaded_policy")}
         </StyledInternalLink>


### PR DESCRIPTION
the translation was embedded in the url directly so didn't change on 2nd language change when in the same page

it's actually an edge case and its unlikely any normal user would encounter it anyways

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the way titles are retrieved and used in URL parameters across multiple components. It changes the title retrieval from using the translation function directly to using a key, improving consistency and clarity in the code.

### Detailed summary
- Changed title retrieval in `AttachmentDisplay/index.tsx` to use a key.
- Updated URLs in `EvidenceCard.tsx`, `Policy/index.tsx`, and `Policies.tsx` to use title keys instead of translation functions.
- Modified navigation logic in `Header.tsx` to check against title keys instead of direct title values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved attachment title localization handling for evidence files and policy documents
  * Fixed fallback behavior for missing attachment titles in the attachment display page

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->