### PR TITLE
chore: atlas query update

### DIFF
--- a/web/src/pages/Courts/CourtDetails/StakingHistoryByCourt/DisplayStakes/index.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakingHistoryByCourt/DisplayStakes/index.tsx
@@ -103,7 +103,7 @@ const DisplayStakes: React.FC = () => {
   }, [searchValue, courtId]);
 
   useEffect(() => {
-    const allItems = data?.userStakingEvents?.items ?? [];
+    const allItems = data?.userStakingEventsV2?.items ?? [];
 
     const chunk = allItems.map((item) => {
       const itemCourtId = item.item.args._courtID;

--- a/web/src/pages/Profile/Stakes/StakingHistory.tsx
+++ b/web/src/pages/Profile/Stakes/StakingHistory.tsx
@@ -55,10 +55,10 @@ const StakingHistory: React.FC<IStakingHistory> = ({ searchParamAddress }) => {
   );
 
   const { data: courtTreeData, isLoading: isLoadingCourtTree } = useCourtTree();
-  const totalNumberStakingEvents = stakingHistoryData?.userStakingEvents?.count ?? 0;
+  const totalNumberStakingEvents = stakingHistoryData?.userStakingEventsV2?.count ?? 0;
   const totalPages = useMemo(() => Math.ceil(totalNumberStakingEvents / eventsPerPage), [totalNumberStakingEvents]);
 
-  const stakingEvents = stakingHistoryData?.userStakingEvents?.items ?? [];
+  const stakingEvents = stakingHistoryData?.userStakingEventsV2?.items ?? [];
 
   const handlePageChange = (newPage: number) => {
     navigate(`/profile/stakes/${newPage}?address=${searchParamAddress}`);

--- a/web/src/utils/fetchStakingEventsByCourt.ts
+++ b/web/src/utils/fetchStakingEventsByCourt.ts
@@ -16,7 +16,7 @@ export type StakingEventItem = {
 };
 
 export type StakingEventsByCourtResponse = {
-  userStakingEvents: {
+  userStakingEventsV2: {
     items: Array<{ item: StakingEventItem }>;
     count: number;
   };
@@ -29,7 +29,7 @@ const query = `
     $contract: ContractInput!
     $pagination: PaginationArgs
   ) {
-    userStakingEvents(
+    userStakingEventsV2(
       partialAddress: $partialAddress
       courtIDs: $courtIDs
       contract: $contract


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the staking events data structure from `userStakingEvents` to `userStakingEventsV2` across multiple files, ensuring that the application retrieves and processes the latest staking events correctly.

### Detailed summary
- Changed `userStakingEvents` to `userStakingEventsV2` in `web/src/pages/Courts/CourtDetails/StakingHistoryByCourt/DisplayStakes/index.tsx`.
- Updated the type definition in `web/src/utils/fetchStakingEventsByCourt.ts`.
- Modified total staking events count in `web/src/pages/Profile/Stakes/StakingHistory.tsx`.
- Adjusted staking events retrieval in `web/src/pages/Profile/Stakes/StakingHistory.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staking history data retrieval to use the latest data source version across user profiles and court-specific displays, ensuring consistent access to staking event information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->