### PR TITLE
fix(web): stake bug

### DIFF
--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawButton.tsx
@@ -136,18 +136,15 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
       if (signal.aborted) return;
       const isWithdraw = action === ActionType.withdraw;
       const requestData = config?.request ?? setStakeConfig?.request;
+      const commonArgs = [amount, theme, t] as const;
 
       if (requestData && publicClient) {
         updatePopupState(
           signal,
           getStakeSteps(
             isWithdraw ? StakeSteps.WithdrawInitiate : StakeSteps.StakeInitiate,
-            amount,
-            theme,
-            approvalHash,
-            undefined,
-            undefined,
-            t
+            ...commonArgs,
+            approvalHash
           )
         );
 
@@ -158,12 +155,9 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
               signal,
               getStakeSteps(
                 isWithdraw ? StakeSteps.WithdrawPending : StakeSteps.StakePending,
-                amount,
-                theme,
+                ...commonArgs,
                 approvalHash,
-                hash,
-                undefined,
-                t
+                hash
               )
             );
             await publicClient.waitForTransactionReceipt({ hash, confirmations: 2 }).then((res: TransactionReceipt) => {
@@ -174,12 +168,9 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
                   signal,
                   getStakeSteps(
                     isWithdraw ? StakeSteps.WithdrawConfirmed : StakeSteps.StakeConfirmed,
-                    amount,
-                    theme,
+                    ...commonArgs,
                     approvalHash,
-                    hash,
-                    undefined,
-                    t
+                    hash
                   )
                 );
                 setIsSuccess(true);
@@ -188,12 +179,9 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
                   signal,
                   getStakeSteps(
                     isWithdraw ? StakeSteps.WithdrawFailed : StakeSteps.StakeFailed,
-                    amount,
-                    theme,
+                    ...commonArgs,
                     approvalHash,
-                    hash,
-                    undefined,
-                    t
+                    hash
                   )
                 );
             });
@@ -203,12 +191,10 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
               signal,
               getStakeSteps(
                 isWithdraw ? StakeSteps.WithdrawFailed : StakeSteps.StakeFailed,
-                amount,
-                theme,
+                ...commonArgs,
                 approvalHash,
                 undefined,
-                err,
-                t
+                err
               )
             );
           });
@@ -217,12 +203,10 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
           signal,
           getStakeSteps(
             StakeSteps.StakeFailed,
-            amount,
-            theme,
+            ...commonArgs,
             approvalHash,
             undefined,
-            new Error("Simulation Failed. Please restart the process."),
-            t
+            new Error("Simulation Failed. Please restart the process.")
           )
         );
       }
@@ -234,20 +218,15 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
     setIsPopupOpen(true);
     controllerRef.current = new AbortController();
     const signal = controllerRef.current.signal;
+    const commonArgs = [amount, theme, t] as const;
 
     if (isAllowance && increaseAllowanceConfig && publicClient) {
-      updatePopupState(
-        signal,
-        getStakeSteps(StakeSteps.ApproveInitiate, amount, theme, undefined, undefined, undefined, t)
-      );
+      updatePopupState(signal, getStakeSteps(StakeSteps.ApproveInitiate, ...commonArgs));
 
       increaseAllowance(increaseAllowanceConfig.request)
         .then(async (hash) => {
           if (signal.aborted) return;
-          updatePopupState(
-            signal,
-            getStakeSteps(StakeSteps.ApprovePending, amount, theme, hash, undefined, undefined, t)
-          );
+          updatePopupState(signal, getStakeSteps(StakeSteps.ApprovePending, ...commonArgs, hash));
 
           await publicClient
             .waitForTransactionReceipt({ hash, confirmations: 2 })
@@ -264,29 +243,20 @@ const StakeWithdrawButton: React.FC<IActionButton> = ({
                     signal,
                     getStakeSteps(
                       StakeSteps.ApproveFailed,
-                      amount,
-                      theme,
+                      ...commonArgs,
                       hash,
                       undefined,
-                      new Error("Something went wrong. Please restart the process."),
-                      t
+                      new Error("Something went wrong. Please restart the process.")
                     )
                   );
                 else {
                   handleStake(signal, refetchData.data, hash);
                 }
-              } else
-                updatePopupState(
-                  signal,
-                  getStakeSteps(StakeSteps.ApproveFailed, amount, theme, hash, undefined, undefined, t)
-                );
+              } else updatePopupState(signal, getStakeSteps(StakeSteps.ApproveFailed, ...commonArgs, hash));
             });
         })
         .catch((err) => {
-          updatePopupState(
-            signal,
-            getStakeSteps(StakeSteps.ApproveFailed, amount, theme, undefined, undefined, err, t)
-          );
+          updatePopupState(signal, getStakeSteps(StakeSteps.ApproveFailed, ...commonArgs, undefined, undefined, err));
         });
     } else {
       handleStake(signal);

--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/stakeSteps.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/stakeSteps.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import styled, { DefaultTheme } from "styled-components";
 
-import { useTranslation } from "react-i18next";
-
 import { _TimelineItem1, StateProp } from "@kleros/ui-components-library";
 
 import CheckIcon from "svgs/icons/check-circle-outline.svg";
@@ -135,25 +133,46 @@ export const getStakeSteps = (
   theme: DefaultTheme,
   approvalHash?: `0x${string}`,
   stakeHash?: `0x${string}`,
-  error?: any
+  error?: any,
+  t?: (key: string) => string
 ): [_TimelineItem1, ..._TimelineItem1[]] => {
-  const { t } = useTranslation();
+  const translate = t ?? ((key: string) => key);
   switch (stepType) {
     case StakeSteps.ApproveInitiate:
-      return createApprovalSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, error, t);
+      return createApprovalSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, error, translate);
 
     case StakeSteps.ApprovePending:
-      return createApprovalSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, error, t);
+      return createApprovalSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, error, translate);
     case StakeSteps.ApproveFailed:
-      return createApprovalSteps(theme, "refused", "active", amount, approvalHash, error, t);
+      return createApprovalSteps(theme, "refused", "active", amount, approvalHash, error, translate);
     case StakeSteps.StakeInitiate:
-      return createStakeSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, stakeHash, error, true, t);
+      return createStakeSteps(
+        theme,
+        theme.secondaryPurple,
+        "loading",
+        amount,
+        approvalHash,
+        stakeHash,
+        error,
+        true,
+        translate
+      );
     case StakeSteps.StakePending:
-      return createStakeSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, stakeHash, error, true, t);
+      return createStakeSteps(
+        theme,
+        theme.secondaryPurple,
+        "active",
+        amount,
+        approvalHash,
+        stakeHash,
+        error,
+        true,
+        translate
+      );
     case StakeSteps.StakeFailed:
-      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, true, t);
+      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, true, translate);
     case StakeSteps.StakeConfirmed:
-      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, true, t);
+      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, true, translate);
     case StakeSteps.WithdrawInitiate:
       return createStakeSteps(
         theme,
@@ -164,13 +183,23 @@ export const getStakeSteps = (
         stakeHash,
         error,
         false,
-        t
+        translate
       );
     case StakeSteps.WithdrawPending:
-      return createStakeSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, stakeHash, error, false, t);
+      return createStakeSteps(
+        theme,
+        theme.secondaryPurple,
+        "active",
+        amount,
+        approvalHash,
+        stakeHash,
+        error,
+        false,
+        translate
+      );
     case StakeSteps.WithdrawConfirmed:
-      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, false, t);
+      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, false, translate);
     default:
-      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, false, t);
+      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, false, translate);
   }
 };

--- a/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/stakeSteps.tsx
+++ b/web/src/pages/Courts/CourtDetails/StakePanel/StakeWithdrawPopup/stakeSteps.tsx
@@ -131,48 +131,27 @@ export const getStakeSteps = (
   stepType: StakeSteps,
   amount: string,
   theme: DefaultTheme,
+  t: (key: string) => string,
   approvalHash?: `0x${string}`,
   stakeHash?: `0x${string}`,
-  error?: any,
-  t?: (key: string) => string
+  error?: any
 ): [_TimelineItem1, ..._TimelineItem1[]] => {
-  const translate = t ?? ((key: string) => key);
   switch (stepType) {
     case StakeSteps.ApproveInitiate:
-      return createApprovalSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, error, translate);
+      return createApprovalSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, error, t);
 
     case StakeSteps.ApprovePending:
-      return createApprovalSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, error, translate);
+      return createApprovalSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, error, t);
     case StakeSteps.ApproveFailed:
-      return createApprovalSteps(theme, "refused", "active", amount, approvalHash, error, translate);
+      return createApprovalSteps(theme, "refused", "active", amount, approvalHash, error, t);
     case StakeSteps.StakeInitiate:
-      return createStakeSteps(
-        theme,
-        theme.secondaryPurple,
-        "loading",
-        amount,
-        approvalHash,
-        stakeHash,
-        error,
-        true,
-        translate
-      );
+      return createStakeSteps(theme, theme.secondaryPurple, "loading", amount, approvalHash, stakeHash, error, true, t);
     case StakeSteps.StakePending:
-      return createStakeSteps(
-        theme,
-        theme.secondaryPurple,
-        "active",
-        amount,
-        approvalHash,
-        stakeHash,
-        error,
-        true,
-        translate
-      );
+      return createStakeSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, stakeHash, error, true, t);
     case StakeSteps.StakeFailed:
-      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, true, translate);
+      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, true, t);
     case StakeSteps.StakeConfirmed:
-      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, true, translate);
+      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, true, t);
     case StakeSteps.WithdrawInitiate:
       return createStakeSteps(
         theme,
@@ -183,23 +162,13 @@ export const getStakeSteps = (
         stakeHash,
         error,
         false,
-        translate
+        t
       );
     case StakeSteps.WithdrawPending:
-      return createStakeSteps(
-        theme,
-        theme.secondaryPurple,
-        "active",
-        amount,
-        approvalHash,
-        stakeHash,
-        error,
-        false,
-        translate
-      );
+      return createStakeSteps(theme, theme.secondaryPurple, "active", amount, approvalHash, stakeHash, error, false, t);
     case StakeSteps.WithdrawConfirmed:
-      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, false, translate);
+      return createStakeSteps(theme, "accepted", "active", amount, approvalHash, stakeHash, error, false, t);
     default:
-      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, false, translate);
+      return createStakeSteps(theme, "refused", "active", amount, approvalHash, stakeHash, error, false, t);
   }
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `StakeWithdrawPopup` and `StakeWithdrawButton` components to integrate a translation function, enhancing localization support for the user interface.

### Detailed summary
- Removed the use of `useTranslation` hook from `getStakeSteps`.
- Added a translation function parameter `t` to `getStakeSteps`.
- Updated `commonArgs` in `StakeWithdrawButton` to include the translation function `t`.
- Adjusted the `updatePopupState` calls to use the updated `commonArgs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked stake/withdraw step handling to pass the translation function through step generation so step text updates correctly with language changes.
* **Bug Fixes**
  * Improved propagation of approval/stake hashes and error details so progress, success, and failure states display more reliably.
* **No User-Visible Change**
  * Public interfaces and overall visible behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->