### PR TITLE
Arbitration pausing emergency mechanism

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -107,6 +107,9 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     Dispute[] public disputes; // The disputes.
     mapping(IERC20 => bool) public acceptedFeeTokens; // True if the token is accepted.
     bool public paused; // Whether asset withdrawals are paused.
+    bool public arbitrationPaused; // Whether arbitration period transitions are paused.
+    uint256 public arbitrationPauseGracePeriodStart; // Timestamp when the grace period started.
+    uint256 public arbitrationPauseGracePeriodEnd; // Timestamp after which period transitions can resume.
     address public wNative; // The wrapped native token for safeSend().
     mapping(address => bool) public arbitrableWhitelist; // Arbitrable whitelist.
     bool public arbitrableWhitelistEnabled; // Whether the arbitrable whitelist is enabled.
@@ -254,6 +257,13 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @notice Emitted when this contract is unpaused.
     event Unpaused();
 
+    /// @notice Emitted when arbitration period transitions are paused.
+    event ArbitrationPaused();
+
+    /// @notice Emitted when arbitration period transitions are unpaused.
+    /// @param _gracePeriodEnd Timestamp after which period transitions can resume.
+    event ArbitrationUnpaused(uint256 _gracePeriodEnd);
+
     // ************************************* //
     // *        Function Modifiers         * //
     // ************************************* //
@@ -387,6 +397,23 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     function unpause() external onlyByOwner whenPaused {
         paused = false;
         emit Unpaused();
+    }
+
+    /// @notice Pause arbitration period transitions. Can only be done by guardian or owner.
+    function pauseArbitration() external onlyByGuardianOrOwner {
+        if (arbitrationPaused) revert WhenArbitrationNotPausedOnly();
+        arbitrationPaused = true;
+        emit ArbitrationPaused();
+    }
+
+    /// @notice Unpause arbitration period transitions with a grace window. Can only be done by owner.
+    /// @param _gracePeriod Duration in seconds of the grace period.
+    function unpauseArbitration(uint256 _gracePeriod) external onlyByOwner {
+        if (!arbitrationPaused) revert WhenArbitrationPausedOnly();
+        arbitrationPaused = false;
+        arbitrationPauseGracePeriodStart = block.timestamp;
+        arbitrationPauseGracePeriodEnd = block.timestamp + _gracePeriod;
+        emit ArbitrationUnpaused(arbitrationPauseGracePeriodEnd);
     }
 
     /// @notice Allows the owner to call anything on behalf of the contract.
@@ -695,9 +722,9 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @notice Passes the period of a specified dispute.
     /// @param _disputeID The ID of the dispute.
     function passPeriod(uint256 _disputeID) external {
+        if (arbitrationPaused || block.timestamp <= arbitrationPauseGracePeriodEnd)
+            revert WhenArbitrationNotPausedOnly();
         Dispute storage dispute = disputes[_disputeID];
-        Court storage court = courts[dispute.courtID];
-
         uint256 currentRound = dispute.rounds.length - 1;
         Round storage round = dispute.rounds[currentRound];
         if (dispute.period == Period.evidence) {
@@ -747,6 +774,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _iterations The number of iterations to run.
     /// @return nbDrawnJurors The total number of jurors drawn in the round.
     function draw(uint256 _disputeID, uint256 _iterations) external returns (uint256 nbDrawnJurors) {
+        if (arbitrationPaused) revert WhenArbitrationNotPausedOnly();
         Dispute storage dispute = disputes[_disputeID];
         uint256 currentRound = dispute.rounds.length - 1;
         Round storage round = dispute.rounds[currentRound];
@@ -1066,6 +1094,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @notice Executes a specified dispute's ruling.
     /// @param _disputeID The ID of the dispute.
     function executeRuling(uint256 _disputeID) external {
+        if (arbitrationPaused) revert WhenArbitrationNotPausedOnly();
         Dispute storage dispute = disputes[_disputeID];
         if (dispute.period != Period.execution) revert NotExecutionPeriod();
 
@@ -1130,6 +1159,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         if (dispute.period == Period.appeal) {
             start = dispute.lastPeriodChange;
             end = dispute.lastPeriodChange + round.timesPerPeriod[uint256(Period.appeal)];
+            if (end < arbitrationPauseGracePeriodEnd) {
+                // Currently in unpause grace period, adjust the start and end times.
+                start = arbitrationPauseGracePeriodStart;
+                end = arbitrationPauseGracePeriodEnd;
+            }
         } else {
             start = 0;
             end = 0;
@@ -1477,5 +1511,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     error TransferFailed();
     error WhenNotPausedOnly();
     error WhenPausedOnly();
+    error WhenArbitrationNotPausedOnly();
+    error WhenArbitrationPausedOnly();
     error StakingZeroWhenNoStake();
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -158,6 +158,11 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
         _;
     }
 
+    modifier whenArbitrationNotPaused() {
+        if (core.arbitrationPaused()) revert WhenArbitrationNotPausedOnly();
+        _;
+    }
+
     // ************************************* //
     // *            Constructor            * //
     // ************************************* //
@@ -301,7 +306,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
         uint256 _coreDisputeID,
         uint256[] calldata _voteIDs,
         bytes32 _commit
-    ) internal isActive(_coreDisputeID) {
+    ) internal whenArbitrationNotPaused isActive(_coreDisputeID) {
         (, , KlerosCore.Period period, , , ) = core.disputes(_coreDisputeID);
         if (period != KlerosCore.Period.commit) revert NotCommitPeriod();
         if (_voteIDs.length == 0) revert EmptyVoteIDs();
@@ -348,7 +353,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
         uint256 _salt,
         string memory _justification,
         address _juror
-    ) internal isActive(_coreDisputeID) {
+    ) internal whenArbitrationNotPaused isActive(_coreDisputeID) {
         (, , KlerosCore.Period period, , , ) = core.disputes(_coreDisputeID);
         if (period != KlerosCore.Period.vote) revert NotVotePeriod();
         if (_voteIDs.length == 0) revert EmptyVoteIDs();
@@ -398,7 +403,10 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     /// Note that the surplus deposit will be reimbursed.
     /// @param _coreDisputeID Index of the dispute in Kleros Core.
     /// @param _choice A choice that receives funding.
-    function fundAppeal(uint256 _coreDisputeID, uint256 _choice) external payable isActive(_coreDisputeID) {
+    function fundAppeal(
+        uint256 _coreDisputeID,
+        uint256 _choice
+    ) external payable whenArbitrationNotPaused isActive(_coreDisputeID) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         if (_choice > dispute.numberOfChoices) revert ChoiceOutOfBounds();
 
@@ -455,8 +463,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
             } else {
                 // Don't subtract 1 from length since both round arrays haven't been updated yet.
                 dispute.coreRoundIDToLocal[coreRoundID + 1] = dispute.rounds.length;
-
-                Round storage newRound = dispute.rounds.push();
+                dispute.rounds.push();
             }
             core.appeal{value: appealCost}(_coreDisputeID, dispute.numberOfChoices, dispute.extraData);
         }
@@ -840,4 +847,5 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     error AppealFeeIsAlreadyPaid();
     error DisputeNotResolved();
     error CoreIsPaused();
+    error WhenArbitrationNotPausedOnly();
 }

--- a/contracts/test/foundry/KlerosCore_Governance.t.sol
+++ b/contracts/test/foundry/KlerosCore_Governance.t.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.24;
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {IArbitratorV2} from "../../src/arbitration/KlerosCore.sol";
+import {DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassicBase.sol";
 import {DisputeKitSybilResistant} from "../../src/arbitration/dispute-kits/DisputeKitSybilResistant.sol";
+import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
 import {SortitionModuleMock} from "../../src/test/SortitionModuleMock.sol";
 import {PNK} from "../../src/token/PNK.sol";
 import "../../src/libraries/Constants.sol";
@@ -45,6 +47,255 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
         emit KlerosCore.Unpaused();
         core.unpause();
         assertEq(core.paused(), false, "Wrong paused value");
+    }
+
+    function test_pauseArbitration() public {
+        vm.expectRevert(KlerosCore.GuardianOrOwnerOnly.selector);
+        vm.prank(other);
+        core.pauseArbitration();
+
+        vm.prank(guardian);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.ArbitrationPaused();
+        core.pauseArbitration();
+        assertEq(core.arbitrationPaused(), true, "Wrong arbitrationPaused value");
+
+        vm.prank(owner);
+        vm.expectRevert(KlerosCore.WhenArbitrationNotPausedOnly.selector);
+        core.pauseArbitration();
+    }
+
+    function test_unpauseArbitration() public {
+        uint256 grace = 3600;
+
+        vm.expectRevert(KlerosCore.OwnerOnly.selector);
+        vm.prank(other);
+        core.unpauseArbitration(grace);
+
+        vm.expectRevert(KlerosCore.WhenArbitrationPausedOnly.selector);
+        vm.prank(owner);
+        core.unpauseArbitration(grace);
+
+        vm.prank(owner);
+        core.pauseArbitration();
+
+        uint256 expectedGraceEnd = block.timestamp + grace;
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.ArbitrationUnpaused(expectedGraceEnd);
+        core.unpauseArbitration(grace);
+
+        assertEq(core.arbitrationPaused(), false, "Wrong arbitrationPaused value");
+        assertEq(core.arbitrationPauseGracePeriodEnd(), expectedGraceEnd, "Wrong arbitrationPauseGracePeriodEnd");
+    }
+
+    function test_arbitrationGraceBlocksPassPeriodButNotActions() public {
+        uint256 disputeID = 0;
+        uint256 grace = 3600;
+
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        vm.prank(guardian);
+        core.pauseArbitration();
+        vm.prank(owner);
+        core.unpauseArbitration(grace);
+
+        vm.expectRevert(KlerosCore.WhenArbitrationNotPausedOnly.selector);
+        core.passPeriod(disputeID);
+
+        vm.expectRevert(SortitionModule.NotDrawingPhase.selector);
+        core.draw(disputeID, 1);
+
+        uint256[] memory voteIDs = new uint256[](1);
+        voteIDs[0] = 0;
+
+        vm.prank(staker1);
+        vm.expectRevert(DisputeKitClassicBase.NotCommitPeriod.selector);
+        disputeKit.castCommit(disputeID, voteIDs, bytes32(uint256(1)));
+
+        vm.prank(staker1);
+        vm.expectRevert(DisputeKitClassicBase.NotVotePeriod.selector);
+        disputeKit.castVote(disputeID, voteIDs, 1, 0, "XYZ");
+
+        vm.prank(crowdfunder1);
+        vm.expectRevert(DisputeKitClassicBase.NotAppealPeriod.selector);
+        disputeKit.fundAppeal(disputeID, 1);
+    }
+
+    function test_arbitrationPausedBlocksActions() public {
+        uint256 disputeID = 0;
+
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        vm.prank(guardian);
+        core.pauseArbitration();
+
+        vm.expectRevert(KlerosCore.WhenArbitrationNotPausedOnly.selector);
+        core.draw(disputeID, 1);
+
+        uint256[] memory voteIDs = new uint256[](1);
+        voteIDs[0] = 0;
+
+        vm.prank(staker1);
+        vm.expectRevert(DisputeKitClassicBase.WhenArbitrationNotPausedOnly.selector);
+        disputeKit.castCommit(disputeID, voteIDs, bytes32(uint256(1)));
+
+        vm.prank(staker1);
+        vm.expectRevert(DisputeKitClassicBase.WhenArbitrationNotPausedOnly.selector);
+        disputeKit.castVote(disputeID, voteIDs, 1, 0, "XYZ");
+
+        vm.prank(crowdfunder1);
+        vm.expectRevert(DisputeKitClassicBase.WhenArbitrationNotPausedOnly.selector);
+        disputeKit.fundAppeal(disputeID, 1);
+
+        vm.expectRevert(DisputeKitClassicBase.WhenArbitrationNotPausedOnly.selector);
+        core.executeRuling(disputeID);
+    }
+
+    function test_arbitrationGraceExpires() public {
+        uint256 disputeID = 0;
+        uint256 grace = 3600;
+
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        vm.prank(guardian);
+        core.pauseArbitration();
+        vm.prank(owner);
+        core.unpauseArbitration(grace);
+
+        vm.expectRevert(KlerosCore.WhenArbitrationNotPausedOnly.selector);
+        core.passPeriod(disputeID);
+
+        vm.warp(core.arbitrationPauseGracePeriodEnd() + 1);
+        vm.expectRevert(KlerosCore.DisputeStillDrawing.selector);
+        core.passPeriod(disputeID);
+    }
+
+    function _loserCutoff(uint256 appealStart, uint256 appealEnd) internal pure returns (uint256) {
+        return appealStart + (appealEnd - appealStart) / 2;
+    }
+
+    function _createDisputeAndAdvanceToAppeal() internal returns (uint256 disputeID) {
+        disputeID = 0;
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 10000);
+        vm.prank(staker2);
+        core.setStake(GENERAL_COURT, 10000);
+
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing
+
+        core.draw(disputeID, DEFAULT_NB_OF_JURORS);
+
+        vm.warp(block.timestamp + timesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+
+        KlerosCore.Round memory round = core.getRoundInfo(disputeID, 0);
+        uint256 countStaker1;
+        uint256 countStaker2;
+        for (uint256 i = 0; i < round.drawnJurors.length; i++) {
+            if (round.drawnJurors[i] == staker1) countStaker1++;
+            if (round.drawnJurors[i] == staker2) countStaker2++;
+        }
+
+        if (countStaker1 > 0) {
+            uint256[] memory voteIDsStaker1 = new uint256[](countStaker1);
+            uint256 idx;
+            for (uint256 i = 0; i < round.drawnJurors.length; i++) {
+                if (round.drawnJurors[i] == staker1) {
+                    voteIDsStaker1[idx] = i;
+                    idx++;
+                }
+            }
+            vm.prank(staker1);
+            disputeKit.castVote(disputeID, voteIDsStaker1, 1, 0, "XYZ");
+        }
+
+        if (countStaker2 > 0) {
+            uint256[] memory voteIDsStaker2 = new uint256[](countStaker2);
+            uint256 idx;
+            for (uint256 i = 0; i < round.drawnJurors.length; i++) {
+                if (round.drawnJurors[i] == staker2) {
+                    voteIDsStaker2[idx] = i;
+                    idx++;
+                }
+            }
+            vm.prank(staker2);
+            // Vote the same as staker1 to avoid a potential tie in `currentRuling()`.
+            disputeKit.castVote(disputeID, voteIDsStaker2, 1, 0, "XYZ");
+        }
+
+        core.passPeriod(disputeID); // Appeal
+    }
+
+    function test_appealPeriodExtendedByGrace() public {
+        uint256 disputeID = _createDisputeAndAdvanceToAppeal();
+        (, uint256 baseEnd) = core.appealPeriod(disputeID);
+
+        uint256 grace = 3600;
+        uint256 expectedGraceEnd = block.timestamp + grace;
+        assertGt(expectedGraceEnd, baseEnd, "Grace end should exceed base end");
+
+        vm.prank(guardian);
+        core.pauseArbitration();
+        vm.prank(owner);
+        core.unpauseArbitration(grace);
+
+        (, uint256 end) = core.appealPeriod(disputeID);
+        assertEq(end, expectedGraceEnd, "Appeal end should extend to grace end");
+    }
+
+    function test_fundAppealAfterBaseEndDuringGrace() public {
+        vm.warp(1717171717); // Set the current block timestamp to a realistic epoch time to avoid under-flows
+        uint256 disputeID = _createDisputeAndAdvanceToAppeal();
+
+        (uint256 start, uint256 baseEnd) = core.appealPeriod(disputeID);
+        uint256 baseLoserCutoff = _loserCutoff(start, baseEnd);
+        uint256 grace = 1 days;
+        uint256 pauseDuration = 3 days;
+        uint256 expectedGraceEnd = block.timestamp + pauseDuration + grace;
+
+        vm.prank(guardian);
+        core.pauseArbitration();
+        vm.warp(block.timestamp + pauseDuration);
+        vm.prank(owner);
+        core.unpauseArbitration(grace);
+
+        (, uint256 newEnd) = core.appealPeriod(disputeID);
+        assertEq(newEnd, expectedGraceEnd, "Appeal end should extend to grace end");
+
+        uint256 newLoserCutoff = _loserCutoff(start + pauseDuration, newEnd);
+        assertEq(newLoserCutoff, start + pauseDuration + grace / 2, "Loser cutoff should extend by grace/2");
+
+        (uint256 ruling, , ) = core.currentRuling(disputeID);
+        uint256 loserChoice = ruling == 1 ? 2 : 1;
+
+        // Warp to the middle of the loser's appeal period.
+        vm.warp(block.timestamp + grace / 4);
+        assertGt(block.timestamp, baseLoserCutoff, "Warp should be after original loser cutoff");
+        assertLt(block.timestamp, newLoserCutoff, "Warp should stay within extended loser window");
+
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 1}(disputeID, loserChoice);
+
+        // Warp to the middle of the winner's appeal period.
+        vm.warp(block.timestamp + grace / 2);
+
+        vm.prank(crowdfunder1);
+        vm.expectRevert(DisputeKitClassicBase.NotAppealPeriodForLoser.selector);
+        disputeKit.fundAppeal{value: 1}(disputeID, loserChoice);
+
+        vm.prank(crowdfunder2);
+        disputeKit.fundAppeal{value: 1}(disputeID, ruling);
     }
 
     function test_executeOwnerProposal() public {


### PR DESCRIPTION
There is an existing pausing mechanism focused on stopping the flow of value (PNK/ETH), and it deliberately did not attempt to pause the arbitration process. This PR adds a distinct arbitration‑specific pausing mechanism.

## Summary
- Added an arbitration grace window that temporarily blocks `passPeriod()` while allowing jurors and parties to continue actions (draw, commit, vote, fund appeal) after unpausing.
- Gated draw/vote/commit/appeal on `arbitrationPaused` only, so these actions are allowed during grace but still blocked during a full arbitration pause.

## Rationale
The grace period is designed to protect jurors and parties when arbitration is paused. Without a grace window, users who were blocked from acting (voting, committing, appealing) could be penalized once the pause is lifted because the period time has already elapsed. By delaying period transitions while still allowing actions after unpause, participants get a fair opportunity to complete their required steps, reducing unfair slashing for jurors and lost appeal opportunities for parties.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new modifier `whenArbitrationNotPaused` to manage arbitration state in the `KlerosCore` and `DisputeKitClassicBase` contracts, allowing operations to be paused or resumed. It also adds related events, errors, and tests to ensure proper functionality.

### Detailed summary
- Added `whenArbitrationNotPaused` modifier in `DisputeKitClassicBase`.
- Updated function signatures in `DisputeKitClassicBase` to use the new modifier.
- Introduced `arbitrationPaused` state variable in `KlerosCore`.
- Added events: `ArbitrationPaused` and `ArbitrationUnpaused`.
- Implemented `pauseArbitration` and `unpauseArbitration` functions in `KlerosCore`.
- Added error handling for paused arbitration.
- Updated tests for arbitration pause functionality in `KlerosCore_GovernanceTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arbitration pause/unpause controls with a configurable grace period; pausing blocks arbitration actions, adjusts appeal windows and cutoff timing, and emits public signals on pause/unpause. Dispute-handling paths now prevent commits/votes and appeal funding while paused.

* **Tests**
  * Added governance tests validating pause/unpause flows, grace-period effects on appeal timing and cutoffs, blocked actions during pause, and owner/guardian control paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->