### PR TITLE
Unstake ineligible jurors I-02

### DIFF
--- a/contracts/deploy/utils/klerosCoreHelper.ts
+++ b/contracts/deploy/utils/klerosCoreHelper.ts
@@ -16,7 +16,7 @@ export const changeCurrencyRate = async (
     await tx.wait();
   }
   const rate = await ratesConverter.currencyRates(erc20);
-  if (rate.rateInEth !== toBigInt(rateInEth) || rate.rateDecimals !== rateDecimals) {
+  if (rate.rateInEth !== toBigInt(rateInEth) || rate.rateDecimals !== toBigInt(rateDecimals)) {
     console.log(`core.changeCurrencyRates(${erc20}, ${rateInEth}, ${rateDecimals})`);
     const tx = await ratesConverter.changeCurrencyRates(erc20, rateInEth, rateDecimals);
     await tx.wait();

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -13,6 +13,7 @@ import {SafeERC20} from "../libraries/SafeERC20.sol";
 import {SafeSend} from "../libraries/SafeSend.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {EnumerableSet} from "../libraries/EnumerableSet.sol";
 import "../libraries/Constants.sol";
 
 /// @title KlerosCore
@@ -21,6 +22,7 @@ import "../libraries/Constants.sol";
 contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     using SafeERC20 for IERC20;
     using SafeSend for address payable;
+    using EnumerableSet for EnumerableSet.UintSet;
 
     string public constant override version = "2.0.0";
 
@@ -45,7 +47,6 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 feeForJuror; // Arbitration fee paid per juror.
         uint256 jurorsForCourtJump; // The appeal after the one that reaches this number of jurors will go to the parent court if any.
         uint256[4] timesPerPeriod; // The time allotted to each dispute period in the form `timesPerPeriod[period]`.
-        mapping(uint256 disputeKitId => bool) supportedDisputeKits; // True if DK with this ID is supported by the court. Note that each court must support classic dispute kit.
         uint256[10] __gap; // Reserved slots for future upgrades.
     }
 
@@ -103,6 +104,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     address public jurorProsecutionModule; // The module for juror's prosecution.
     ISortitionModule public sortitionModule; // Sortition module for drawing.
     Court[] public courts; // The courts.
+    mapping(uint96 courtID => EnumerableSet.UintSet) private _supportedDisputeKits; // True if DK with this ID is supported by the court. Note that each court must support classic dispute kit.
     IDisputeKit[] public disputeKits; // Array of dispute kits.
     Dispute[] public disputes; // The disputes.
     mapping(IERC20 => bool) public acceptedFeeTokens; // True if the token is accepted.
@@ -480,7 +482,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _jurorsForCourtJump The `jurorsForCourtJump` property value of the court.
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the court.
     /// @param _sortitionExtraData Extra data for sortition module.
-    /// @param _supportedDisputeKits Indexes of dispute kits that this court will support.
+    /// @param __supportedDisputeKits Indexes of dispute kits that this court will support.
     function createCourt(
         uint96 _parent,
         bool _hiddenVotes,
@@ -490,23 +492,23 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 _jurorsForCourtJump,
         uint256[4] memory _timesPerPeriod,
         bytes memory _sortitionExtraData,
-        uint256[] memory _supportedDisputeKits
+        uint256[] memory __supportedDisputeKits
     ) external onlyByOwner {
         if (courts[_parent].minStake > _minStake) revert MinStakeLowerThanParentCourt();
-        if (_supportedDisputeKits.length == 0) revert UnsupportedDisputeKit();
+        if (__supportedDisputeKits.length == 0) revert UnsupportedDisputeKit();
         if (_parent == FORKING_COURT) revert InvalidForkingCourtAsParent();
 
         uint96 courtID = uint96(courts.length);
         Court storage court = courts.push();
 
-        for (uint256 i = 0; i < _supportedDisputeKits.length; i++) {
-            if (_supportedDisputeKits[i] == NULL_DISPUTE_KIT || _supportedDisputeKits[i] >= disputeKits.length) {
+        for (uint256 i = 0; i < __supportedDisputeKits.length; i++) {
+            if (__supportedDisputeKits[i] == NULL_DISPUTE_KIT || __supportedDisputeKits[i] >= disputeKits.length) {
                 revert WrongDisputeKitIndex();
             }
-            _enableDisputeKit(uint96(courtID), _supportedDisputeKits[i], true);
+            _enableDisputeKit(uint96(courtID), __supportedDisputeKits[i], true);
         }
         // Check that Classic DK support was added.
-        if (!court.supportedDisputeKits[DISPUTE_KIT_CLASSIC]) revert MustSupportDisputeKitClassic();
+        if (!_supportedDisputeKits[courtID].contains(DISPUTE_KIT_CLASSIC)) revert MustSupportDisputeKitClassic();
 
         court.parent = _parent;
         court.children = new uint256[](0);
@@ -530,7 +532,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             _feeForJuror,
             _jurorsForCourtJump,
             _timesPerPeriod,
-            _supportedDisputeKits
+            __supportedDisputeKits
         );
     }
 
@@ -688,7 +690,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     ) internal returns (uint256 disputeID) {
         if (arbitrableWhitelistEnabled && !arbitrableWhitelist[msg.sender]) revert ArbitrableNotWhitelisted();
         (uint96 courtID, , uint256 disputeKitID) = _extraDataToCourtIDMinJurorsDisputeKit(_extraData);
-        if (!courts[courtID].supportedDisputeKits[disputeKitID]) revert DisputeKitNotSupportedByCourt();
+        if (!_supportedDisputeKits[courtID].contains(disputeKitID)) revert DisputeKitNotSupportedByCourt();
 
         disputeID = disputes.length;
         Dispute storage dispute = disputes.push();
@@ -1110,6 +1112,26 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         }
     }
 
+    /// @notice Forces unstaking of those jurors who have been ineligible by any of the supported dispute kits for a given court.
+    /// @param _courtID The ID of the court for forced unstaking.
+    /// @param _jurors The addresses of the jurors.
+    function forcedUnstakeIneligibleJurors(uint96 _courtID, address[] calldata _jurors) external {
+        // Note that we are requiring *at least one* dispute kit to have marked the juror as ineligible.
+        // But we could imagine requiring *all* of the dispute kits to have marked the juror as ineligible in alternate implementation.
+        uint256[] memory supportedDisputeKits = _supportedDisputeKits[_courtID].values();
+        for (uint256 i = 0; i < supportedDisputeKits.length; i++) {
+            IDisputeKit disputeKit = disputeKits[supportedDisputeKits[i]];
+            for (uint256 j = 0; j < _jurors.length; j++) {
+                address juror = _jurors[j];
+                if (disputeKit.ineligibleJurors(juror) > 10) {
+                    // TODO: make this a governance parameter?!
+                    sortitionModule.forcedUnstake(juror, _courtID);
+                    return;
+                }
+            }
+        }
+    }
+
     // ************************************* //
     // *           Public Views            * //
     // ************************************* //
@@ -1217,7 +1239,14 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _disputeKitID The ID of the dispute kit to check the support for.
     /// @return Whether the dispute kit is supported or not.
     function isSupported(uint96 _courtID, uint256 _disputeKitID) external view returns (bool) {
-        return courts[_courtID].supportedDisputeKits[_disputeKitID];
+        return _supportedDisputeKits[_courtID].contains(_disputeKitID);
+    }
+
+    /// @notice Gets the supported dispute kits IDs for a given court.
+    /// @param _courtID The ID of the court to get the supported dispute kits for.
+    /// @return The supported dispute kits IDs for the given court.
+    function getSupportedDisputeKits(uint96 _courtID) external view returns (uint256[] memory) {
+        return _supportedDisputeKits[_courtID].values();
     }
 
     /// @notice Gets the timesPerPeriod array for a given court.
@@ -1327,7 +1356,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             newRoundNbVotes = (_round.nbVotes * 2) + 1;
         }
         // Ensure compatibility between the next round's court and dispute kit.
-        if (!courts[newCourtID].supportedDisputeKits[newDisputeKitID]) {
+        if (!_supportedDisputeKits[newCourtID].contains(newDisputeKitID)) {
             // Falling back to `DisputeKitClassic` which is always supported and with default nbVotes increase.
             newDisputeKitID = DISPUTE_KIT_CLASSIC;
             newRoundNbVotes = (_round.nbVotes * 2) + 1;
@@ -1367,7 +1396,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _disputeKitID The ID of the dispute kit to toggle the support for.
     /// @param _enable Whether to enable or disable the support. Note that classic dispute kit should always be enabled.
     function _enableDisputeKit(uint96 _courtID, uint256 _disputeKitID, bool _enable) internal {
-        courts[_courtID].supportedDisputeKits[_disputeKitID] = _enable;
+        if (_enable) {
+            _supportedDisputeKits[_courtID].add(_disputeKitID);
+        } else {
+            _supportedDisputeKits[_courtID].remove(_disputeKitID);
+        }
         emit DisputeKitEnabled(_courtID, _disputeKitID, _enable);
     }
 

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -86,6 +86,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     mapping(uint96 currentCourtID => NextRoundSettings) public courtIDToNextRoundSettings; // The settings for the next round.
     bool public singleDrawPerJuror; // Whether each juror can only draw once per round, false by default.
     address public wNative; // The wrapped native token for safeSend().
+    mapping(address juror => uint256 ineligibleDraws) public ineligibleJurors; // The count of ineligible draws for the juror.
 
     uint256[50] private __gap; // Reserved slots for future upgrades.
 
@@ -137,6 +138,12 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     /// @param _courtID The ID of the court that the settings are changed for.
     /// @param _nextRoundSettings The settings for the next round.
     event NextRoundSettingsChanged(uint96 indexed _courtID, NextRoundSettings _nextRoundSettings);
+
+    /// @notice To be emitted when a juror is marked as ineligible.
+    /// @param _juror The address of the juror.
+    /// @param _courtID The ID of the court that the juror is ineligible for.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    event JurorIneligible(address indexed _juror, uint96 indexed _courtID, uint256 indexed _coreDisputeID);
 
     // ************************************* //
     // *              Modifiers            * //
@@ -281,12 +288,18 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
             return (drawnAddress, fromSubcourtID);
         }
 
-        if (_postDrawCheck(round, _coreDisputeID, drawnAddress, _roundNbVotes)) {
+        (bool success, bool ineligible) = _postDrawCheck(round, _coreDisputeID, drawnAddress, _roundNbVotes);
+        if (success) {
             Vote storage vote = round.votes.push();
             vote.account = drawnAddress;
             round.alreadyDrawn[drawnAddress] = true;
         } else {
             drawnAddress = address(0);
+        }
+        if (!ineligible && courtID == fromSubcourtID) {
+            // Only mark the juror as ineligible if they are directly in `courtID` rather than in a child court.
+            ineligibleJurors[drawnAddress] += 1;
+            emit JurorIneligible(drawnAddress, courtID, _coreDisputeID);
         }
     }
 
@@ -808,20 +821,21 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
     ///
     /// @param _coreDisputeID ID of the dispute in the core contract.
     /// @param _juror Chosen address.
-    /// @return Whether the address passes the check or not.
+    /// @return success Whether the address passes the check or not.
+    /// @return ineligible Whether the address is marked as ineligible and candidate for later forced unstaking.
     function _postDrawCheck(
         Round storage /*_round*/,
         uint256 _coreDisputeID,
         address _juror,
         uint256 /*_roundNbVotes*/
-    ) internal view virtual returns (bool) {
+    ) internal view virtual returns (bool, bool) {
         if (singleDrawPerJuror) {
             uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
             Dispute storage dispute = disputes[localDisputeID];
             Round storage round = dispute.rounds[dispute.rounds.length - 1];
-            return !round.alreadyDrawn[_juror];
+            return (!round.alreadyDrawn[_juror], false);
         } else {
-            return true;
+            return (true, false);
         }
     }
 

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
@@ -131,8 +131,9 @@ contract DisputeKitGated is DisputeKitClassicBase {
         uint256 _coreDisputeID,
         address _juror,
         uint256 _roundNbVotes
-    ) internal view override returns (bool) {
-        if (!super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes)) return false;
+    ) internal view override returns (bool success, bool ineligible) {
+        (success, ineligible) = super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes);
+        if (!success) return (success, ineligible);
 
         // Get the local dispute and extract token info from extraData
         uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
@@ -140,14 +141,16 @@ contract DisputeKitGated is DisputeKitClassicBase {
         (address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
         // If no token gate is specified, allow all jurors
-        if (tokenGate == NO_TOKEN_GATE) return true;
+        if (tokenGate == NO_TOKEN_GATE) return (true, false);
 
         // Check juror's token balance
         if (isERC1155) {
-            return IBalanceHolderERC1155(tokenGate).balanceOf(_juror, tokenId) > 0;
+            success = IBalanceHolderERC1155(tokenGate).balanceOf(_juror, tokenId) > 0;
         } else {
-            return IBalanceHolder(tokenGate).balanceOf(_juror) > 0;
+            success = IBalanceHolder(tokenGate).balanceOf(_juror) > 0;
         }
+        // Mark the juror as ineligible if they don't hold the token.
+        if (!success) ineligible = true;
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol
@@ -115,7 +115,7 @@ contract DisputeKitGatedArgentinaConsumerProtection is DisputeKitClassicBase {
         uint256 _coreDisputeID,
         address _juror,
         uint256 _roundNbVotes
-    ) internal view override returns (bool) {
+    ) internal view override returns (bool success, bool ineligible) {
         if (IBalanceHolder(accreditedConsumerProtectionLawyerToken).balanceOf(_juror) == 0) {
             // The juror is not a consumer protection lawyer.
             uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
@@ -127,11 +127,11 @@ contract DisputeKitGatedArgentinaConsumerProtection is DisputeKitClassicBase {
             ) {
                 // This is the last draw iteration and we still have not drawn a consumer protection lawyer.
                 // Reject this draw so that another iteration can try again later.
-                return false;
+                return (false, false);
             }
             if (IBalanceHolder(accreditedProfessionalToken).balanceOf(_juror) == 0) {
-                // The juror does not hold either of the tokens.
-                return false;
+                // The juror does not hold either of the tokens, mark them as ineligible.
+                return (false, true);
             }
         }
         return super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes);

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
@@ -258,8 +258,9 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         uint256 _coreDisputeID,
         address _juror,
         uint256 _roundNbVotes
-    ) internal view override returns (bool) {
-        if (!super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes)) return false;
+    ) internal view override returns (bool success, bool ineligible) {
+        (success, ineligible) = super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes);
+        if (!success) return (success, ineligible);
 
         // Get the local dispute and extract token info from extraData
         uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
@@ -267,14 +268,16 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         (address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
         // If no token gate is specified, allow all jurors
-        if (tokenGate == NO_TOKEN_GATE) return true;
+        if (tokenGate == NO_TOKEN_GATE) return (true, false);
 
         // Check juror's token balance
         if (isERC1155) {
-            return IBalanceHolderERC1155(tokenGate).balanceOf(_juror, tokenId) > 0;
+            success = IBalanceHolderERC1155(tokenGate).balanceOf(_juror, tokenId) > 0;
         } else {
-            return IBalanceHolder(tokenGate).balanceOf(_juror) > 0;
+            success = IBalanceHolder(tokenGate).balanceOf(_juror) > 0;
         }
+        // Mark the juror as ineligible if they don't hold the token.
+        if (!success) ineligible = true;
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -73,7 +73,11 @@ contract DisputeKitSybilResistant is DisputeKitClassicBase {
         uint256 _coreDisputeID,
         address _juror,
         uint256 _roundNbVotes
-    ) internal view override returns (bool) {
-        return super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes) && poh.isHuman(_juror);
+    ) internal view override returns (bool success, bool ineligible) {
+        (success, ineligible) = super._postDrawCheck(_round, _coreDisputeID, _juror, _roundNbVotes);
+        if (!success) return (success, ineligible);
+
+        // Mark the juror as ineligible if they are not a human.
+        if (!poh.isHuman(_juror)) return (false, true);
     }
 }

--- a/contracts/src/arbitration/interfaces/IDisputeKit.sol
+++ b/contracts/src/arbitration/interfaces/IDisputeKit.sol
@@ -197,4 +197,9 @@ interface IDisputeKit {
         uint256 _coreRoundID,
         uint256 _voteID
     ) external view returns (address account, bytes32 commit, uint256 choice, bool voted);
+
+    /// @notice Returns the number of ineligible draws for a given juror.
+    /// @param _juror The address of the juror.
+    /// @return ineligibleDraws The number of ineligible draws for the juror.
+    function ineligibleJurors(address _juror) external view returns (uint256 ineligibleDraws);
 }

--- a/contracts/src/libraries/EnumerableSet.sol
+++ b/contracts/src/libraries/EnumerableSet.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+// This file is slightly modified from the original to keep only the minimum necessary: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.5.0/contracts/utils/structs/EnumerableSet.sol
+// OpenZeppelin Contracts (last updated v5.5.0) (utils/structs/EnumerableSet.sol)
+// This file was procedurally generated from scripts/generate/templates/EnumerableSet.js.
+
+pragma solidity ^0.8.24;
+
+/**
+ * @dev Library for managing
+ * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
+ * types.
+ *
+ * Sets have the following properties:
+ *
+ * - Elements are added, removed, and checked for existence in constant time
+ * (O(1)).
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ * - Set can be cleared (all elements removed) in O(n).
+ *
+ * ```solidity
+ * contract Example {
+ *     // Add the library methods
+ *     using EnumerableSet for EnumerableSet.AddressSet;
+ *
+ *     // Declare a set state variable
+ *     EnumerableSet.AddressSet private mySet;
+ * }
+ * ```
+ *
+ * The following types are supported:
+ *
+ * - `uint256` (`UintSet`) since v3.3.0
+ *
+ * [WARNING]
+ * ====
+ * Trying to delete such a structure from storage will likely result in data corruption, rendering the structure
+ * unusable.
+ * See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
+ *
+ * In order to clean an EnumerableSet, you can either remove all elements one by one or create a fresh instance using an
+ * array of EnumerableSet.
+ * ====
+ */
+library EnumerableSet {
+    // To implement this library for multiple types with as little code
+    // repetition as possible, we write it in terms of a generic Set type with
+    // bytes32 values.
+    // The Set implementation uses private functions, and user-facing
+    // implementations (such as AddressSet) are just wrappers around the
+    // underlying Set.
+    // This means that we can only create new EnumerableSets for types that fit
+    // in bytes32.
+
+    struct Set {
+        // Storage of set values
+        bytes32[] _values;
+        // Position is the index of the value in the `values` array plus 1.
+        // Position 0 is used to mean a value is not in the set.
+        mapping(bytes32 value => uint256) _positions;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function _add(Set storage set, bytes32 value) private returns (bool) {
+        if (!_contains(set, value)) {
+            set._values.push(value);
+            // The value is stored at length-1, but we add 1 to all indexes
+            // and use 0 as a sentinel value
+            set._positions[value] = set._values.length;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function _remove(Set storage set, bytes32 value) private returns (bool) {
+        // We cache the value's position to prevent multiple reads from the same storage slot
+        uint256 position = set._positions[value];
+
+        if (position != 0) {
+            // Equivalent to contains(set, value)
+            // To delete an element from the _values array in O(1), we swap the element to delete with the last one in
+            // the array, and then remove the last element (sometimes called as 'swap and pop').
+            // This modifies the order of the array, as noted in {at}.
+
+            uint256 valueIndex = position - 1;
+            uint256 lastIndex = set._values.length - 1;
+
+            if (valueIndex != lastIndex) {
+                bytes32 lastValue = set._values[lastIndex];
+
+                // Move the lastValue to the index where the value to delete is
+                set._values[valueIndex] = lastValue;
+                // Update the tracked position of the lastValue (that was just moved)
+                set._positions[lastValue] = position;
+            }
+
+            // Delete the slot where the moved value was stored
+            set._values.pop();
+
+            // Delete the tracked position for the deleted slot
+            delete set._positions[value];
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: This function has an unbounded cost that scales with set size. Developers should keep in mind that
+     * using it may render the function uncallable if the set grows to the point where clearing it consumes too much
+     * gas to fit in a block.
+     */
+    function _clear(Set storage set) private {
+        uint256 len = _length(set);
+        for (uint256 i = 0; i < len; ++i) {
+            delete set._positions[set._values[i]];
+        }
+        delete set._values;
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function _contains(Set storage set, bytes32 value) private view returns (bool) {
+        return set._positions[value] != 0;
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function _length(Set storage set) private view returns (uint256) {
+        return set._values.length;
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function _at(Set storage set, uint256 index) private view returns (bytes32) {
+        return set._values[index];
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function _values(Set storage set) private view returns (bytes32[] memory) {
+        return set._values;
+    }
+
+    // UintSet
+
+    struct UintSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(UintSet storage set, uint256 value) internal returns (bool) {
+        return _add(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(UintSet storage set, uint256 value) internal returns (bool) {
+        return _remove(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes all the values from a set. O(n).
+     *
+     * WARNING: Developers should keep in mind that this function has an unbounded cost and using it may render the
+     * function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+     */
+    function clear(UintSet storage set) internal {
+        _clear(set._inner);
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(UintSet storage set, uint256 value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(UintSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+        return uint256(_at(set._inner, index));
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(UintSet storage set) internal view returns (uint256[] memory) {
+        bytes32[] memory store = _values(set._inner);
+        uint256[] memory result;
+
+        assembly ("memory-safe") {
+            result := store
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the juror eligibility checks in the arbitration contracts by introducing mechanisms to track ineligible jurors and improving the handling of dispute kits in the KlerosCore contract.

### Detailed summary
- Added `ineligibleJurors` function in `IDisputeKit` to return ineligible draws for a juror.
- Modified `_postDrawCheck` in various dispute kits to return success and ineligible status.
- Introduced `JurorIneligible` event in `DisputeKitClassicBase`.
- Updated `KlerosCore` to manage supported dispute kits using `EnumerableSet`.
- Implemented `forcedUnstakeIneligibleJurors` function in `KlerosCore` to handle jurors marked ineligible.
- Adjusted function signatures and internal logic to accommodate new eligibility checks and event emissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `forcedUnstakeIneligibleJurors()` function to forcibly unstake jurors deemed ineligible by any supported dispute kit for a court.
  * Added `getSupportedDisputeKits()` function to query supported dispute kits for a specific court.
  * Enhanced juror ineligibility tracking across dispute kits with new event emissions.

* **Updated Features**
  * Improved `isSupported()` function for more efficient dispute kit compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->