### PR TITLE
Gated token whitelist by court

### DIFF
--- a/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
-
+import {GENERAL_COURT} from "../../libraries/Constants.sol";
 interface IBalanceHolder {
     /// @notice Returns the number of tokens in `owner` account.
     /// @dev Compatible with ERC-20 and ERC-721.
@@ -36,7 +36,17 @@ contract DisputeKitGated is DisputeKitClassicBase {
     // *             Storage               * //
     // ************************************* //
 
-    mapping(address token => bool supported) public supportedTokens; // Whether the token is supported or not.
+    mapping(uint96 courtID => mapping(address token => bool supported)) public supportedTokens; // Whether the token is supported or not in a court
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @dev Emitted when the supported tokens for a court are changed.
+    /// @param _courtID The ID of the court.
+    /// @param _token The address of the token.
+    /// @param _supported Whether the token is supported or not.
+    event SupportedTokensChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
 
     // ************************************* //
     // *            Constructor            * //
@@ -53,7 +63,7 @@ contract DisputeKitGated is DisputeKitClassicBase {
     /// @param _wNative The wrapped native token address, typically wETH.
     function initialize(address _owner, KlerosCore _core, address _wNative) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative);
-        supportedTokens[NO_TOKEN_GATE] = true; // Allows disputes without token gating
+        supportedTokens[GENERAL_COURT][NO_TOKEN_GATE] = true; // Allow disputes without token gating in the General Court
     }
 
     // ************************ //
@@ -67,11 +77,13 @@ contract DisputeKitGated is DisputeKitClassicBase {
     }
 
     /// @notice Changes the supported tokens.
-    /// @param _tokens The tokens to support.
+    /// @param _courtID The ID of the court.
+    /// @param _tokens The tokens to support in the given court.
     /// @param _supported Whether the tokens are supported or not.
-    function changeSupportedTokens(address[] memory _tokens, bool _supported) external onlyByOwner {
+    function changeSupportedTokens(uint96 _courtID, address[] memory _tokens, bool _supported) external onlyByOwner {
         for (uint256 i = 0; i < _tokens.length; i++) {
-            supportedTokens[_tokens[i]] = _supported;
+            supportedTokens[_courtID][_tokens[i]] = _supported;
+            emit SupportedTokensChanged(_courtID, _tokens[i], _supported);
         }
     }
 
@@ -87,8 +99,8 @@ contract DisputeKitGated is DisputeKitClassicBase {
         bytes calldata _extraData,
         uint256 _nbVotes
     ) public override {
-        (address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
-        if (!supportedTokens[tokenGate]) revert TokenNotSupported(tokenGate);
+        (uint96 courtID, address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
+        if (!supportedTokens[courtID][tokenGate]) revert TokenNotSupported(courtID, tokenGate);
 
         // super.createDispute() ensures access control onlyByCore.
         super.createDispute(_coreDisputeID, _coreRoundID, _numberOfChoices, _extraData, _nbVotes);
@@ -105,17 +117,20 @@ contract DisputeKitGated is DisputeKitClassicBase {
     /// - bytes 64-95: uint256 disputeKitID, not used here
     /// - bytes 96-127: uint256 packedTokenGateAndFlag (address tokenGate in bits 0-159, bool isERC1155 in bit 160)
     /// - bytes 128-159: uint256 tokenId
+    /// @return courtID The ID of the court.
     /// @return tokenGate The address of the token contract used for gating access.
     /// @return isERC1155 True if the token is an ERC-1155, false for ERC-20/ERC-721.
     /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-20/ERC-721).
     function _extraDataToTokenInfo(
         bytes memory _extraData
-    ) internal pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
+    ) internal pure returns (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) {
         // Need at least 160 bytes to safely read the parameters
-        if (_extraData.length < 160) return (address(0), false, 0);
+        if (_extraData.length < 160) return (0, address(0), false, 0);
 
         assembly {
             // solium-disable-line security/no-inline-assembly
+            courtID := mload(add(_extraData, 0x20))
+
             let packedTokenGateIsERC1155 := mload(add(_extraData, 0x80)) // 4th parameter at offset 128
             tokenId := mload(add(_extraData, 0xA0)) // 5th parameter at offset 160 (moved up)
 
@@ -137,7 +152,7 @@ contract DisputeKitGated is DisputeKitClassicBase {
         // Get the local dispute and extract token info from extraData
         uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
         Dispute storage dispute = disputes[localDisputeID];
-        (address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
+        (, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
         // If no token gate is specified, allow all jurors
         if (tokenGate == NO_TOKEN_GATE) return true;
@@ -154,5 +169,5 @@ contract DisputeKitGated is DisputeKitClassicBase {
     // *              Errors               * //
     // ************************************* //
 
-    error TokenNotSupported(address tokenGate);
+    error TokenNotSupported(uint96 courtID, address tokenGate);
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
-
+import {GENERAL_COURT} from "../../libraries/Constants.sol";
 interface IBalanceHolder {
     /// @notice Returns the number of tokens in `owner` account.
     /// @dev Compatible with ERC-20 and ERC-721.
@@ -37,7 +37,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     // *             Storage               * //
     // ************************************* //
 
-    mapping(address token => bool supported) public supportedTokens; // Whether the token is supported or not.
+    mapping(uint96 courtID => mapping(address token => bool supported)) public supportedTokens; // Whether the token is supported or not in a court
     mapping(uint256 localDisputeID => mapping(uint256 localRoundID => mapping(uint256 voteID => bytes32 justificationCommitment)))
         public justificationCommitments;
 
@@ -50,6 +50,12 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     // ************************************* //
     // *              Events               * //
     // ************************************* //
+
+    /// @dev Emitted when the supported tokens for a court are changed.
+    /// @param _courtID The ID of the court.
+    /// @param _token The address of the token.
+    /// @param _supported Whether the token is supported or not.
+    event SupportedTokensChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
 
     /// @dev Emitted when a vote is cast.
     /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
@@ -82,7 +88,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     /// @param _wNative The wrapped native token address, typically wETH.
     function initialize(address _owner, KlerosCore _core, address _wNative) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative);
-        supportedTokens[NO_TOKEN_GATE] = true; // Allows disputes without token gating
+        supportedTokens[GENERAL_COURT][NO_TOKEN_GATE] = true; // Allow disputes without token gating in the General Court
     }
 
     // ************************ //
@@ -96,11 +102,13 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     }
 
     /// @notice Changes the supported tokens.
-    /// @param _tokens The tokens to support.
+    /// @param _courtID The ID of the court.
+    /// @param _tokens The tokens to support in the given court.
     /// @param _supported Whether the tokens are supported or not.
-    function changeSupportedTokens(address[] memory _tokens, bool _supported) external onlyByOwner {
+    function changeSupportedTokens(uint96 _courtID, address[] memory _tokens, bool _supported) external onlyByOwner {
         for (uint256 i = 0; i < _tokens.length; i++) {
-            supportedTokens[_tokens[i]] = _supported;
+            supportedTokens[_courtID][_tokens[i]] = _supported;
+            emit SupportedTokensChanged(_courtID, _tokens[i], _supported);
         }
     }
 
@@ -116,8 +124,8 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         bytes calldata _extraData,
         uint256 _nbVotes
     ) public override {
-        (address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
-        if (!supportedTokens[tokenGate]) revert TokenNotSupported(tokenGate);
+        (uint96 courtID, address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
+        if (!supportedTokens[courtID][tokenGate]) revert TokenNotSupported(courtID, tokenGate);
 
         // super.createDispute() ensures access control onlyByCore.
         super.createDispute(_coreDisputeID, _coreRoundID, _numberOfChoices, _extraData, _nbVotes);
@@ -232,17 +240,20 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     /// - bytes 64-95: uint256 disputeKitID, not used here
     /// - bytes 96-127: uint256 packedTokenGateAndFlag (address tokenGate in bits 0-159, bool isERC1155 in bit 160)
     /// - bytes 128-159: uint256 tokenId
+    /// @return courtID The ID of the court.
     /// @return tokenGate The address of the token contract used for gating access.
     /// @return isERC1155 True if the token is an ERC-1155, false for ERC-20/ERC-721.
     /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-20/ERC-721).
     function _extraDataToTokenInfo(
         bytes memory _extraData
-    ) internal pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
+    ) internal pure returns (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) {
         // Need at least 160 bytes to safely read the parameters
-        if (_extraData.length < 160) return (address(0), false, 0);
+        if (_extraData.length < 160) return (0, address(0), false, 0);
 
         assembly {
             // solium-disable-line security/no-inline-assembly
+            courtID := mload(add(_extraData, 0x20))
+
             let packedTokenGateIsERC1155 := mload(add(_extraData, 0x80)) // 4th parameter at offset 128
             tokenId := mload(add(_extraData, 0xA0)) // 5th parameter at offset 160 (moved up)
 
@@ -264,7 +275,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         // Get the local dispute and extract token info from extraData
         uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
         Dispute storage dispute = disputes[localDisputeID];
-        (address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
+        (, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
         // If no token gate is specified, allow all jurors
         if (tokenGate == NO_TOKEN_GATE) return true;
@@ -281,7 +292,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     // *              Errors               * //
     // ************************************* //
 
-    error TokenNotSupported(address tokenGate);
+    error TokenNotSupported(uint96 courtID, address tokenGate);
     error EmptyJustificationCommit();
     error JustificationCommitmentMismatch();
 }

--- a/contracts/src/test/DisputeKitGatedMock.sol
+++ b/contracts/src/test/DisputeKitGatedMock.sol
@@ -10,6 +10,6 @@ contract DisputeKitGatedMock is DisputeKitGated {
     function extraDataToTokenInfo(
         bytes memory _extraData
     ) public pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
-        (tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
+        (, tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
     }
 }

--- a/contracts/src/test/DisputeKitGatedShutterMock.sol
+++ b/contracts/src/test/DisputeKitGatedShutterMock.sol
@@ -10,6 +10,6 @@ contract DisputeKitGatedShutterMock is DisputeKitGatedShutter {
     function extraDataToTokenInfo(
         bytes memory _extraData
     ) public pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
-        (tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
+        (, tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
     }
 }

--- a/contracts/test/arbitration/helpers/dispute-kit-gated-common.ts
+++ b/contracts/test/arbitration/helpers/dispute-kit-gated-common.ts
@@ -77,10 +77,11 @@ export const encodeExtraData = (
 export const whitelistTokens = async (
   context: TokenGatedTestContext,
   tokens: (string | Addressable)[],
-  supported: boolean = true
+  supported: boolean = true,
+  courtId: BigNumberish = Courts.GENERAL
 ) => {
   const tokenAddresses = tokens.map((token) => (typeof token === "string" ? token : token.toString()));
-  return context.disputeKit.changeSupportedTokens(tokenAddresses, supported);
+  return context.disputeKit.changeSupportedTokens(courtId, tokenAddresses, supported);
 };
 
 // Helper function to create a dispute with the specified token gate
@@ -88,9 +89,10 @@ export const createDisputeWithToken = async (
   context: TokenGatedTestContext,
   token: string | Addressable,
   isERC1155: boolean = false,
-  tokenId: BigNumberish = 0
+  tokenId: BigNumberish = 0,
+  courtId: BigNumberish = Courts.GENERAL
 ) => {
-  const extraData = encodeExtraData(Courts.GENERAL, 3, context.gatedDisputeKitID, token, isERC1155, tokenId);
+  const extraData = encodeExtraData(courtId, 3, context.gatedDisputeKitID, token, isERC1155, tokenId);
   const arbitrationCost = await context.core["arbitrationCost(bytes)"](extraData);
   return context.core["createDispute(uint256,bytes)"](2, extraData, { value: arbitrationCost });
 };
@@ -99,10 +101,11 @@ export const createDisputeWithToken = async (
 export const expectTokenSupported = async (
   context: TokenGatedTestContext,
   token: string | Addressable,
-  supported: boolean
+  supported: boolean,
+  courtId: BigNumberish = Courts.GENERAL
 ) => {
   const tokenAddress = typeof token === "string" ? token : token.toString();
-  expect(await context.disputeKit.supportedTokens(tokenAddress)).to.equal(supported);
+  expect(await context.disputeKit.supportedTokens(courtId, tokenAddress)).to.equal(supported);
 };
 
 // Helper function to stake and draw jurors
@@ -300,6 +303,32 @@ export function testTokenWhitelistManagement(context: () => TokenGatedTestContex
         await whitelistTokens(ctx, [ctx.dai.target], false);
         await expectTokenSupported(ctx, ctx.dai.target, false);
       });
+
+      it("Should not affect other courts when whitelisting tokens", async () => {
+        const ctx = context();
+
+        // Setup already whitelists DAI in GENERAL only.
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.GENERAL);
+        await expectTokenSupported(ctx, ctx.dai.target, false, Courts.FORKING);
+
+        // Whitelist in FORKING should not affect GENERAL.
+        await whitelistTokens(ctx, [ctx.dai.target], true, Courts.FORKING);
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.FORKING);
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.GENERAL);
+      });
+
+      it("Should keep court-specific state isolated across add/remove operations", async () => {
+        const ctx = context();
+
+        // Whitelist DAI in both courts, then remove only in GENERAL.
+        await whitelistTokens(ctx, [ctx.dai.target], true, Courts.FORKING);
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.GENERAL);
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.FORKING);
+
+        await whitelistTokens(ctx, [ctx.dai.target], false, Courts.GENERAL);
+        await expectTokenSupported(ctx, ctx.dai.target, false, Courts.GENERAL);
+        await expectTokenSupported(ctx, ctx.dai.target, true, Courts.FORKING);
+      });
     });
   });
 }
@@ -308,7 +337,8 @@ export function testAccessControl(context: () => TokenGatedTestContext) {
   describe("Access Control", async () => {
     it("Should revert when non-owner tries to change supported tokens", async () => {
       const ctx = context();
-      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens([ctx.dai.target], true)).to.be.reverted;
+      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens(Courts.GENERAL, [ctx.dai.target], true)).to
+        .be.reverted;
     });
 
     it("Should revert when non-owner tries to remove supported tokens", async () => {
@@ -317,7 +347,8 @@ export function testAccessControl(context: () => TokenGatedTestContext) {
       await whitelistTokens(ctx, [ctx.dai.target], true);
 
       // Then try to remove as non-owner
-      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens([ctx.dai.target], false)).to.be.reverted;
+      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens(Courts.GENERAL, [ctx.dai.target], false)).to
+        .be.reverted;
     });
   });
 }
@@ -330,7 +361,23 @@ export function testUnsupportedTokenErrors(context: () => TokenGatedTestContext)
 
       await expect(createDisputeWithToken(ctx, ctx.dai.target))
         .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
-        .withArgs(ctx.dai.target);
+        .withArgs(Courts.GENERAL, ctx.dai.target);
+    });
+
+    it("Should check token support using the courtID encoded in extraData", async () => {
+      const ctx = context();
+
+      // Enable the dispute kit in FORKING court so dispute creation reaches DK logic.
+      const deployerSigner = await ethers.getSigner(ctx.deployer);
+      await ctx.core.connect(deployerSigner).enableDisputeKits(Courts.FORKING, [ctx.gatedDisputeKitID], true);
+
+      // DAI is supported in GENERAL from setup, but not in FORKING by default.
+      await expectTokenSupported(ctx, ctx.dai.target, true, Courts.GENERAL);
+      await expectTokenSupported(ctx, ctx.dai.target, false, Courts.FORKING);
+
+      await expect(createDisputeWithToken(ctx, ctx.dai.target, false, 0, Courts.FORKING))
+        .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
+        .withArgs(Courts.FORKING, ctx.dai.target);
     });
 
     it("Should revert with TokenNotSupported when creating dispute with unsupported ERC721", async () => {
@@ -339,7 +386,7 @@ export function testUnsupportedTokenErrors(context: () => TokenGatedTestContext)
 
       await expect(createDisputeWithToken(ctx, ctx.nft721.target))
         .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
-        .withArgs(ctx.nft721.target);
+        .withArgs(Courts.GENERAL, ctx.nft721.target);
     });
 
     it("Should revert with TokenNotSupported when creating dispute with unsupported ERC1155", async () => {
@@ -348,7 +395,7 @@ export function testUnsupportedTokenErrors(context: () => TokenGatedTestContext)
 
       await expect(createDisputeWithToken(ctx, ctx.nft1155.target, true, ctx.TOKEN_ID))
         .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
-        .withArgs(ctx.nft1155.target);
+        .withArgs(Courts.GENERAL, ctx.nft1155.target);
     });
 
     it("Should allow dispute creation after token is whitelisted", async () => {
@@ -597,7 +644,7 @@ export function testWhitelistIntegration(context: () => TokenGatedTestContext) {
       // Try to create another dispute (should fail)
       await expect(createDisputeWithToken(ctx, ctx.dai.target))
         .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
-        .withArgs(ctx.dai.target);
+        .withArgs(Courts.GENERAL, ctx.dai.target);
     });
 
     it("Should maintain whitelist state correctly across multiple operations", async () => {
@@ -629,6 +676,28 @@ export function testNoTokenGateAddress(context: () => TokenGatedTestContext) {
     it("Should verify that address(0) is supported by default", async () => {
       const ctx = context();
       await expectTokenSupported(ctx, ethers.ZeroAddress, true);
+    });
+
+    it("Should verify that address(0) is court-scoped (GENERAL only by default)", async () => {
+      const ctx = context();
+      await expectTokenSupported(ctx, ethers.ZeroAddress, true, Courts.GENERAL);
+      await expectTokenSupported(ctx, ethers.ZeroAddress, false, Courts.FORKING);
+    });
+
+    it("Should require explicit support for address(0) outside GENERAL", async () => {
+      const ctx = context();
+
+      // Enable the dispute kit in FORKING court so dispute creation reaches DK logic.
+      const deployerSigner = await ethers.getSigner(ctx.deployer);
+      await ctx.core.connect(deployerSigner).enableDisputeKits(Courts.FORKING, [ctx.gatedDisputeKitID], true);
+
+      // Dispute without token gating should revert in FORKING unless whitelisted there.
+      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0, Courts.FORKING))
+        .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
+        .withArgs(Courts.FORKING, ethers.ZeroAddress);
+
+      await whitelistTokens(ctx, [ethers.ZeroAddress], true, Courts.FORKING);
+      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0, Courts.FORKING)).to.not.be.reverted;
     });
 
     it("Should allow dispute creation with address(0) as tokenGate", async () => {

--- a/contracts/test/arbitration/helpers/dispute-kit-shutter-common.ts
+++ b/contracts/test/arbitration/helpers/dispute-kit-shutter-common.ts
@@ -273,7 +273,7 @@ export async function setupShutterTest(config: ShutterTestConfig): Promise<Shutt
     // If gated, whitelist DAI token
     if (config.isGated) {
       const gatedKit = disputeKit as DisputeKitGatedShutterMock;
-      await gatedKit.changeSupportedTokens([dai.target], true);
+      await gatedKit.changeSupportedTokens(Courts.GENERAL, [dai.target], true);
     }
   } else {
     throw new Error(`Unknown contract name: ${config.contractName}`);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `DisputeKitGated` and `DisputeKitGatedShutter` contracts to support court-specific token gating. It introduces a new mapping structure for supported tokens by court and updates related functions, events, and error handling.

### Detailed summary
- Updated `supportedTokens` mapping to be court-specific.
- Added `SupportedTokensChanged` event for token support changes.
- Modified `changeSupportedTokens` function to accept a court ID.
- Adjusted `_extraDataToTokenInfo` function to return a court ID.
- Enhanced error handling for unsupported tokens to include court ID.
- Updated tests to reflect changes in token support logic by court.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token gating is now scoped per court, allowing different courts to support different tokens independently.
  * Added event to track token support changes.

* **Tests**
  * Updated test utilities to support per-court token configuration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->