### PR TITLE
Staking eligibility enforced per court

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -7,6 +7,7 @@ import {IArbitratorV2} from "./interfaces/IArbitratorV2.sol";
 import {IDisputeKit} from "./interfaces/IDisputeKit.sol";
 import {ISortitionModule} from "./interfaces/ISortitionModule.sol";
 import {IRatesConverter} from "./interfaces/IRatesConverter.sol";
+import {ICourtEligibility} from "./interfaces/ICourtEligibility.sol";
 import {Initializable} from "../proxy/Initializable.sol";
 import {UUPSProxiable} from "../proxy/UUPSProxiable.sol";
 import {SafeERC20} from "../libraries/SafeERC20.sol";
@@ -46,6 +47,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 jurorsForCourtJump; // The appeal after the one that reaches this number of jurors will go to the parent court if any.
         uint256[4] timesPerPeriod; // The time allotted to each dispute period in the form `timesPerPeriod[period]`.
         mapping(uint256 disputeKitId => bool) supportedDisputeKits; // True if DK with this ID is supported by the court. Note that each court must support classic dispute kit.
+        ICourtEligibility eligibility; // The eligibility predicate for the court.
         uint256[10] __gap; // Reserved slots for future upgrades.
     }
 
@@ -152,6 +154,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _jurorsForCourtJump The `jurorsForCourtJump` property value of the court.
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the court.
     /// @param _supportedDisputeKits Indexes of dispute kits that this court will support.
+    /// @param _eligibility The eligibility predicate for the court.
     event CourtCreated(
         uint96 indexed _courtID,
         uint96 indexed _parent,
@@ -161,7 +164,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 _feeForJuror,
         uint256 _jurorsForCourtJump,
         uint256[4] _timesPerPeriod,
-        uint256[] _supportedDisputeKits
+        uint256[] _supportedDisputeKits,
+        ICourtEligibility _eligibility
     );
 
     /// @notice Emitted when court's parameters are changed.
@@ -172,6 +176,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _feeForJuror The `feeForJuror` property value of the court.
     /// @param _jurorsForCourtJump The `jurorsForCourtJump` property value of the court.
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the court.
+    /// @param _eligibility The eligibility predicate for the court.
     event CourtModified(
         uint96 indexed _courtID,
         bool _hiddenVotes,
@@ -179,7 +184,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 _alpha,
         uint256 _feeForJuror,
         uint256 _jurorsForCourtJump,
-        uint256[4] _timesPerPeriod
+        uint256[4] _timesPerPeriod,
+        ICourtEligibility _eligibility
     );
 
     /// @notice Emitted when a dispute kit is created.
@@ -372,7 +378,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             _courtParameters[2],
             _courtParameters[3],
             _timesPerPeriod,
-            supportedDisputeKits
+            supportedDisputeKits,
+            ICourtEligibility(address(0))
         );
         _enableDisputeKit(GENERAL_COURT, DISPUTE_KIT_CLASSIC, true);
     }
@@ -481,6 +488,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the court.
     /// @param _sortitionExtraData Extra data for sortition module.
     /// @param _supportedDisputeKits Indexes of dispute kits that this court will support.
+    /// @param _eligibility The eligibility predicate for the court.
     function createCourt(
         uint96 _parent,
         bool _hiddenVotes,
@@ -490,7 +498,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 _jurorsForCourtJump,
         uint256[4] memory _timesPerPeriod,
         bytes memory _sortitionExtraData,
-        uint256[] memory _supportedDisputeKits
+        uint256[] memory _supportedDisputeKits,
+        ICourtEligibility _eligibility
     ) external onlyByOwner {
         if (courts[_parent].minStake > _minStake) revert MinStakeLowerThanParentCourt();
         if (_supportedDisputeKits.length == 0) revert UnsupportedDisputeKit();
@@ -516,6 +525,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         court.feeForJuror = _feeForJuror;
         court.jurorsForCourtJump = _jurorsForCourtJump;
         court.timesPerPeriod = _timesPerPeriod;
+        court.eligibility = _eligibility;
 
         sortitionModule.createTree(courtID, _sortitionExtraData);
 
@@ -530,7 +540,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             _feeForJuror,
             _jurorsForCourtJump,
             _timesPerPeriod,
-            _supportedDisputeKits
+            _supportedDisputeKits,
+            _eligibility
         );
     }
 
@@ -542,6 +553,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _feeForJuror The `feeForJuror` property value of the court.
     /// @param _jurorsForCourtJump The `jurorsForCourtJump` property value of the court.
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the court.
+    /// @param _eligibility The eligibility predicate for the court.
     function changeCourtParameters(
         uint96 _courtID,
         bool _hiddenVotes,
@@ -549,7 +561,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256 _alpha,
         uint256 _feeForJuror,
         uint256 _jurorsForCourtJump,
-        uint256[4] memory _timesPerPeriod
+        uint256[4] memory _timesPerPeriod,
+        ICourtEligibility _eligibility
     ) external onlyByOwner {
         Court storage court = courts[_courtID];
         if (_courtID != GENERAL_COURT && courts[court.parent].minStake > _minStake) {
@@ -566,6 +579,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         court.feeForJuror = _feeForJuror;
         court.jurorsForCourtJump = _jurorsForCourtJump;
         court.timesPerPeriod = _timesPerPeriod;
+        court.eligibility = _eligibility;
         emit CourtModified(
             _courtID,
             _hiddenVotes,
@@ -573,7 +587,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             _alpha,
             _feeForJuror,
             _jurorsForCourtJump,
-            _timesPerPeriod
+            _timesPerPeriod,
+            _eligibility
         );
     }
 
@@ -1397,7 +1412,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             _account,
             _courtID,
             _newStake,
-            _noDelay
+            _noDelay,
+            courts[_courtID].eligibility
         );
         if (stakingResult != StakingResult.Successful && stakingResult != StakingResult.Delayed) {
             _stakingFailed(_onError, stakingResult);
@@ -1433,6 +1449,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         if (_result == StakingResult.CannotStakeZeroWhenNoStake) revert StakingZeroWhenNoStake();
         if (_result == StakingResult.CannotStakeMoreThanMaxStakePerJuror) revert StakingMoreThanMaxStakePerJuror();
         if (_result == StakingResult.CannotStakeMoreThanMaxTotalStaked) revert StakingMoreThanMaxTotalStaked();
+        if (_result == StakingResult.NotEligibleForStaking) revert NotEligibleForStaking();
     }
 
     /// @notice Gets a court ID, the minimum number of jurors and an ID of a dispute kit from a specified extra data bytes array.

--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import {KlerosCore} from "./KlerosCore.sol";
 import {ISortitionModule} from "./interfaces/ISortitionModule.sol";
+import {ICourtEligibility} from "./interfaces/ICourtEligibility.sol";
 import {Initializable} from "../proxy/Initializable.sol";
 import {UUPSProxiable} from "../proxy/UUPSProxiable.sol";
 import {SortitionTrees, TreeKey, CourtID} from "../libraries/SortitionTrees.sol";
@@ -263,16 +264,24 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
         address _account,
         uint96 _courtID,
         uint256 _newStake,
-        bool _noDelay
+        bool _noDelay,
+        ICourtEligibility _eligibility
     ) external override onlyByCore returns (uint256 pnkDeposit, uint256 pnkWithdrawal, StakingResult stakingResult) {
-        (pnkDeposit, pnkWithdrawal, stakingResult) = _validateStake(_account, _courtID, _newStake, _noDelay);
+        (pnkDeposit, pnkWithdrawal, stakingResult) = _validateStake(
+            _account,
+            _courtID,
+            _newStake,
+            _noDelay,
+            _eligibility
+        );
     }
 
     function _validateStake(
         address _account,
         uint96 _courtID,
         uint256 _newStake,
-        bool _noDelay
+        bool _noDelay,
+        ICourtEligibility _eligibility
     ) internal returns (uint256 pnkDeposit, uint256 pnkWithdrawal, StakingResult stakingResult) {
         Juror storage juror = jurors[_account];
         uint256 currentStake = _stakeOf(_account, _courtID);
@@ -289,6 +298,10 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
         }
 
         if (stakeIncrease) {
+            // Check if the juror is eligible to stake in the court.
+            if (_eligibility != ICourtEligibility(address(0)) && !_eligibility.isEligible(_account, _courtID)) {
+                return (0, 0, StakingResult.NotEligibleForStaking);
+            }
             // Check if the stake increase is within the limits.
             if (juror.stakedPnk + stakeChange > maxStakePerJuror || currentStake + stakeChange > maxStakePerJuror) {
                 return (0, 0, StakingResult.CannotStakeMoreThanMaxStakePerJuror);
@@ -422,7 +435,7 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
             if (currentCourtID == GENERAL_COURT) {
                 finished = true;
             } else {
-                (currentCourtID, , , , , ) = core.courts(currentCourtID); // Get the parent court.
+                (currentCourtID, , , , , , ) = core.courts(currentCourtID); // Get the parent court.
             }
         }
         emit StakeSet(_account, _courtID, _newStake, juror.stakedPnk);

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassicBase.sol
@@ -651,7 +651,7 @@ abstract contract DisputeKitClassicBase is IDisputeKit, Initializable, UUPSProxi
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
 
         (uint96 courtID, , , , , ) = core.disputes(_coreDisputeID);
-        (, bool hiddenVotes, , , , ) = core.courts(courtID);
+        (, bool hiddenVotes, , , , , ) = core.courts(courtID);
         uint256 expectedTotalVoted = hiddenVotes ? round.totalCommitted : round.votes.length;
 
         return round.totalVoted == expectedTotalVoted;

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGated.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
-import {GENERAL_COURT} from "../../libraries/Constants.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 interface IBalanceHolder {
     /// @notice Returns the number of tokens in `owner` account.
-    /// @dev Compatible with ERC-20 and ERC-721.
+    /// @dev Compatible with ERC-721.
     /// @param owner The address of the owner.
     /// @return balance The number of tokens in `owner` account.
     function balanceOf(address owner) external view returns (uint256 balance);
@@ -23,20 +25,24 @@ interface IBalanceHolderERC1155 {
 
 /// @title DisputeKitGated
 /// @notice Dispute kit implementation adapted from DisputeKitClassic
-/// - a drawing system: proportional to staked PNK with a non-zero balance of `tokenGate` where `tokenGate` is an ERC20, ERC721 or ERC1155
+/// - a drawing system: proportional to staked PNK with a non-zero balance of `tokenGate` where `tokenGate` is ERC721 or ERC1155
 /// - a vote aggregation system: plurality,
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
-contract DisputeKitGated is DisputeKitClassicBase {
-    string public constant override version = "2.0.0";
+contract DisputeKitGated is DisputeKitClassicBase, ICourtEligibility {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
 
-    address private constant NO_TOKEN_GATE = address(0);
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
     // ************************************* //
 
-    mapping(uint96 courtID => mapping(address token => bool supported)) public supportedTokens; // Whether the token is supported or not in a court
+    mapping(uint96 courtID => EnumerableSet.AddressSet) internal supportedErc721Tokens; // Supported ERC-721 token gates.
+    mapping(uint96 courtID => EnumerableSet.AddressSet) internal supportedErc1155Tokens; // Supported ERC-1155 token gates.
+    mapping(uint96 courtID => mapping(address token => EnumerableSet.UintSet tokenIDs))
+        internal supportedErc1155TokenIds; // Supported ERC-1155 tokenIds for a particular ERC-1155 token contract.
 
     // ************************************* //
     // *              Events               * //
@@ -46,7 +52,19 @@ contract DisputeKitGated is DisputeKitClassicBase {
     /// @param _courtID The ID of the court.
     /// @param _token The address of the token.
     /// @param _supported Whether the token is supported or not.
-    event SupportedTokensChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
+    event SupportedErc721TokenChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
+
+    /// @dev Emitted when supported ERC-1155 tokenIds for a token are changed.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract.
+    /// @param _tokenId The ERC-1155 tokenId.
+    /// @param _supported Whether the tokenId is supported or not.
+    event SupportedErc1155TokenIdChanged(
+        uint96 indexed _courtID,
+        address indexed _token,
+        uint256 indexed _tokenId,
+        bool _supported
+    );
 
     // ************************************* //
     // *            Constructor            * //
@@ -63,7 +81,6 @@ contract DisputeKitGated is DisputeKitClassicBase {
     /// @param _wNative The wrapped native token address, typically wETH.
     function initialize(address _owner, KlerosCore _core, address _wNative) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative);
-        supportedTokens[GENERAL_COURT][NO_TOKEN_GATE] = true; // Allow disputes without token gating in the General Court
     }
 
     // ************************ //
@@ -76,14 +93,49 @@ contract DisputeKitGated is DisputeKitClassicBase {
         // NOP
     }
 
-    /// @notice Changes the supported tokens.
+    /// @notice Changes the supported ERC-721 tokens.
     /// @param _courtID The ID of the court.
     /// @param _tokens The tokens to support in the given court.
     /// @param _supported Whether the tokens are supported or not.
-    function changeSupportedTokens(uint96 _courtID, address[] memory _tokens, bool _supported) external onlyByOwner {
+    function changeSupportedErc721Tokens(
+        uint96 _courtID,
+        address[] memory _tokens,
+        bool _supported
+    ) external onlyByOwner {
         for (uint256 i = 0; i < _tokens.length; i++) {
-            supportedTokens[_courtID][_tokens[i]] = _supported;
-            emit SupportedTokensChanged(_courtID, _tokens[i], _supported);
+            if (_tokens[i] == address(0)) revert TokenGateRequired();
+            if (_supported) {
+                supportedErc721Tokens[_courtID].add(_tokens[i]);
+            } else {
+                supportedErc721Tokens[_courtID].remove(_tokens[i]);
+            }
+            emit SupportedErc721TokenChanged(_courtID, _tokens[i], _supported);
+        }
+    }
+
+    /// @notice Changes supported ERC-1155 tokenIds for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract.
+    /// @param _tokenIds The ERC-1155 tokenIds to add/remove.
+    /// @param _supported Whether the tokenIds are supported or not.
+    function changeSupportedErc1155TokenIds(
+        uint96 _courtID,
+        address _token,
+        uint256[] memory _tokenIds,
+        bool _supported
+    ) external onlyByOwner {
+        if (_token == address(0)) revert TokenGateRequired();
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            if (_supported) {
+                supportedErc1155TokenIds[_courtID][_token].add(_tokenIds[i]);
+                supportedErc1155Tokens[_courtID].add(_token);
+            } else {
+                supportedErc1155TokenIds[_courtID][_token].remove(_tokenIds[i]);
+                if (supportedErc1155TokenIds[_courtID][_token].length() == 0) {
+                    supportedErc1155Tokens[_courtID].remove(_token);
+                }
+            }
+            emit SupportedErc1155TokenIdChanged(_courtID, _token, _tokenIds[i], _supported);
         }
     }
 
@@ -92,6 +144,7 @@ contract DisputeKitGated is DisputeKitClassicBase {
     // ************************************* //
 
     /// @inheritdoc DisputeKitClassicBase
+    /// @notice A token gate must be specified in the `extraData`, otherwise the transaction reverts.
     function createDispute(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
@@ -99,11 +152,115 @@ contract DisputeKitGated is DisputeKitClassicBase {
         bytes calldata _extraData,
         uint256 _nbVotes
     ) public override {
-        (uint96 courtID, address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
-        if (!supportedTokens[courtID][tokenGate]) revert TokenNotSupported(courtID, tokenGate);
+        (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(_extraData);
+
+        // DisputeKitGated must always be token-gated.
+        if (tokenGate == address(0)) revert TokenGateRequired();
+
+        if (isERC1155) {
+            if (!supportedErc1155TokenIds[courtID][tokenGate].contains(tokenId))
+                revert TokenNotSupported(courtID, tokenGate);
+        } else {
+            if (!supportedErc721Tokens[courtID].contains(tokenGate)) revert TokenNotSupported(courtID, tokenGate);
+        }
 
         // super.createDispute() ensures access control onlyByCore.
         super.createDispute(_coreDisputeID, _coreRoundID, _numberOfChoices, _extraData, _nbVotes);
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @inheritdoc ICourtEligibility
+    /// @dev Complexity: O(n + m) where `n` is the number of supported ERC-721 tokens and `m` is the number of supported ERC-1155 tokens.
+    function isEligible(address _juror, uint96 _courtID) external view override returns (bool) {
+        uint256 erc721Length = supportedErc721Tokens[_courtID].length();
+        for (uint256 i = 0; i < erc721Length; i++) {
+            address token = supportedErc721Tokens[_courtID].at(i);
+            if (token == address(0)) continue;
+            if (IBalanceHolder(token).balanceOf(_juror) > 0) return true;
+        }
+
+        uint256 erc1155Length = supportedErc1155Tokens[_courtID].length();
+        for (uint256 i = 0; i < erc1155Length; i++) {
+            address token = supportedErc1155Tokens[_courtID].at(i);
+            if (token == address(0)) continue;
+            EnumerableSet.UintSet storage tokenIds = supportedErc1155TokenIds[_courtID][token];
+            uint256 tokenIdsLength = tokenIds.length();
+            for (uint256 j = 0; j < tokenIdsLength; j++) {
+                uint256 tokenId = tokenIds.at(j);
+                if (IBalanceHolderERC1155(token).balanceOf(_juror, tokenId) > 0) return true;
+            }
+        }
+        return false;
+    }
+
+    /// @notice Checks if an ERC-721 token is supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @param _token The address of the token.
+    /// @return Whether the token is supported or not.
+    function isErc721TokenSupported(uint96 _courtID, address _token) external view returns (bool) {
+        return supportedErc721Tokens[_courtID].contains(_token);
+    }
+
+    /// @notice Returns the number of ERC-721 tokens supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @return The number of ERC-721 tokens supported in the court.
+    function supportedErc721TokensLength(uint96 _courtID) external view returns (uint256) {
+        return supportedErc721Tokens[_courtID].length();
+    }
+
+    /// @notice Returns the ERC-721 token at the given index.
+    /// @param _courtID The ID of the court.
+    /// @param _index The index of the token.
+    /// @return The ERC-721 token at the given index.
+    function supportedErc721TokensAt(uint96 _courtID, uint256 _index) external view returns (address) {
+        return supportedErc721Tokens[_courtID].at(_index);
+    }
+
+    /// @notice Checks if an ERC-1155 `(token, tokenId)` is supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @param _tokenId The ERC-1155 tokenId.
+    function isErc1155TokenIdSupported(uint96 _courtID, address _token, uint256 _tokenId) external view returns (bool) {
+        return supportedErc1155TokenIds[_courtID][_token].contains(_tokenId);
+    }
+
+    /// @notice Returns the number of ERC-1155 tokenIds supported for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @return The number of ERC-1155 tokenIds supported for the given token contract.
+    function supportedErc1155TokenIdsLength(uint96 _courtID, address _token) external view returns (uint256) {
+        return supportedErc1155TokenIds[_courtID][_token].length();
+    }
+
+    /// @notice Returns the ERC-1155 tokenId at the given index for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @param _index The index of the tokenId.
+    /// @return The ERC-1155 tokenId at the given index for the given token contract.
+    function supportedErc1155TokenIdsAt(
+        uint96 _courtID,
+        address _token,
+        uint256 _index
+    ) external view returns (uint256) {
+        return supportedErc1155TokenIds[_courtID][_token].at(_index);
+    }
+
+    /// @notice Returns the number of ERC-1155 tokens supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @return The number of ERC-1155 tokens supported in the court.
+    function supportedErc1155TokensLength(uint96 _courtID) external view returns (uint256) {
+        return supportedErc1155Tokens[_courtID].length();
+    }
+
+    /// @notice Returns the ERC-1155 token at the given index.
+    /// @param _courtID The ID of the court.
+    /// @param _index The index of the token.
+    /// @return The ERC-1155 token at the given index.
+    function supportedErc1155TokensAt(uint96 _courtID, uint256 _index) external view returns (address) {
+        return supportedErc1155Tokens[_courtID].at(_index);
     }
 
     // ************************************* //
@@ -119,8 +276,8 @@ contract DisputeKitGated is DisputeKitClassicBase {
     /// - bytes 128-159: uint256 tokenId
     /// @return courtID The ID of the court.
     /// @return tokenGate The address of the token contract used for gating access.
-    /// @return isERC1155 True if the token is an ERC-1155, false for ERC-20/ERC-721.
-    /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-20/ERC-721).
+    /// @return isERC1155 True if the token is an ERC-1155, false for ERC-721.
+    /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-721).
     function _extraDataToTokenInfo(
         bytes memory _extraData
     ) internal pure returns (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) {
@@ -154,8 +311,7 @@ contract DisputeKitGated is DisputeKitClassicBase {
         Dispute storage dispute = disputes[localDisputeID];
         (, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
-        // If no token gate is specified, allow all jurors
-        if (tokenGate == NO_TOKEN_GATE) return true;
+        if (tokenGate == address(0)) return false; // Token gate must be specified.
 
         // Check juror's token balance
         if (isERC1155) {
@@ -170,4 +326,5 @@ contract DisputeKitGated is DisputeKitClassicBase {
     // ************************************* //
 
     error TokenNotSupported(uint96 courtID, address tokenGate);
+    error TokenGateRequired();
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
 
 interface IBalanceHolder {
     /// @notice Returns the number of tokens in `owner` account.
@@ -20,7 +21,7 @@ interface IBalanceHolder {
 /// - a vote aggregation system: plurality,
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
-contract DisputeKitGatedArgentinaConsumerProtection is DisputeKitClassicBase {
+contract DisputeKitGatedArgentinaConsumerProtection is DisputeKitClassicBase, ICourtEligibility {
     string public constant override version = "2.0.0";
 
     // ************************************* //
@@ -103,6 +104,17 @@ contract DisputeKitGatedArgentinaConsumerProtection is DisputeKitClassicBase {
             drawnConsumerProtectionLawyer[localDisputeID][localRoundID] = true;
         }
         return (drawnAddress, fromSubcourtID);
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @inheritdoc ICourtEligibility
+    function isEligible(address _juror, uint96 /* _courtID */) external view override returns (bool) {
+        return
+            IBalanceHolder(accreditedConsumerProtectionLawyerToken).balanceOf(_juror) > 0 ||
+            IBalanceHolder(accreditedProfessionalToken).balanceOf(_juror) > 0;
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
-import {GENERAL_COURT} from "../../libraries/Constants.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 interface IBalanceHolder {
     /// @notice Returns the number of tokens in `owner` account.
-    /// @dev Compatible with ERC-20 and ERC-721.
+    /// @dev Compatible with ERC-721.
     /// @param owner The address of the owner.
     /// @return balance The number of tokens in `owner` account.
     function balanceOf(address owner) external view returns (uint256 balance);
@@ -24,20 +26,24 @@ interface IBalanceHolderERC1155 {
 /// @title DisputeKitGatedShutter
 /// @notice Added functionality: shielded voting.
 /// Dispute kit implementation adapted from DisputeKitClassic
-/// - a drawing system: proportional to staked PNK with a non-zero balance of `tokenGate` where `tokenGate` is an ERC20, ERC721 or ERC1155
+/// - a drawing system: proportional to staked PNK with a non-zero balance of `tokenGate` where `tokenGate` is ERC721 or ERC1155
 /// - a vote aggregation system: plurality,
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
-contract DisputeKitGatedShutter is DisputeKitClassicBase {
-    string public constant override version = "2.0.0";
+contract DisputeKitGatedShutter is DisputeKitClassicBase, ICourtEligibility {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
 
-    address private constant NO_TOKEN_GATE = address(0);
+    string public constant override version = "2.0.0";
 
     // ************************************* //
     // *             Storage               * //
     // ************************************* //
 
-    mapping(uint96 courtID => mapping(address token => bool supported)) public supportedTokens; // Whether the token is supported or not in a court
+    mapping(uint96 courtID => EnumerableSet.AddressSet) internal supportedErc721Tokens; // Supported ERC-721 token gates.
+    mapping(uint96 courtID => EnumerableSet.AddressSet) internal supportedErc1155Tokens; // Supported ERC-1155 token gates.
+    mapping(uint96 courtID => mapping(address token => EnumerableSet.UintSet tokenIDs))
+        internal supportedErc1155TokenIds; // Supported ERC-1155 tokenIds for a particular ERC-1155 token contract.
     mapping(uint256 localDisputeID => mapping(uint256 localRoundID => mapping(uint256 voteID => bytes32 justificationCommitment)))
         public justificationCommitments;
 
@@ -55,7 +61,19 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     /// @param _courtID The ID of the court.
     /// @param _token The address of the token.
     /// @param _supported Whether the token is supported or not.
-    event SupportedTokensChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
+    event SupportedErc721TokenChanged(uint96 indexed _courtID, address indexed _token, bool _supported);
+
+    /// @dev Emitted when supported ERC-1155 tokenIds for a token are changed.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract.
+    /// @param _tokenId The ERC-1155 tokenId.
+    /// @param _supported Whether the tokenId is supported or not.
+    event SupportedErc1155TokenIdChanged(
+        uint96 indexed _courtID,
+        address indexed _token,
+        uint256 indexed _tokenId,
+        bool _supported
+    );
 
     /// @dev Emitted when a vote is cast.
     /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
@@ -88,7 +106,6 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     /// @param _wNative The wrapped native token address, typically wETH.
     function initialize(address _owner, KlerosCore _core, address _wNative) external initializer {
         __DisputeKitClassicBase_initialize(_owner, _core, _wNative);
-        supportedTokens[GENERAL_COURT][NO_TOKEN_GATE] = true; // Allow disputes without token gating in the General Court
     }
 
     // ************************ //
@@ -101,14 +118,49 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         // NOP
     }
 
-    /// @notice Changes the supported tokens.
+    /// @notice Changes the supported ERC-721 tokens.
     /// @param _courtID The ID of the court.
     /// @param _tokens The tokens to support in the given court.
     /// @param _supported Whether the tokens are supported or not.
-    function changeSupportedTokens(uint96 _courtID, address[] memory _tokens, bool _supported) external onlyByOwner {
+    function changeSupportedErc721Tokens(
+        uint96 _courtID,
+        address[] memory _tokens,
+        bool _supported
+    ) external onlyByOwner {
         for (uint256 i = 0; i < _tokens.length; i++) {
-            supportedTokens[_courtID][_tokens[i]] = _supported;
-            emit SupportedTokensChanged(_courtID, _tokens[i], _supported);
+            if (_tokens[i] == address(0)) revert TokenGateRequired();
+            if (_supported) {
+                supportedErc721Tokens[_courtID].add(_tokens[i]);
+            } else {
+                supportedErc721Tokens[_courtID].remove(_tokens[i]);
+            }
+            emit SupportedErc721TokenChanged(_courtID, _tokens[i], _supported);
+        }
+    }
+
+    /// @notice Changes supported ERC-1155 tokenIds for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract.
+    /// @param _tokenIds The ERC-1155 tokenIds to add/remove.
+    /// @param _supported Whether the tokenIds are supported or not.
+    function changeSupportedErc1155TokenIds(
+        uint96 _courtID,
+        address _token,
+        uint256[] memory _tokenIds,
+        bool _supported
+    ) external onlyByOwner {
+        if (_token == address(0)) revert TokenGateRequired();
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            if (_supported) {
+                supportedErc1155TokenIds[_courtID][_token].add(_tokenIds[i]);
+                supportedErc1155Tokens[_courtID].add(_token);
+            } else {
+                supportedErc1155TokenIds[_courtID][_token].remove(_tokenIds[i]);
+                if (supportedErc1155TokenIds[_courtID][_token].length() == 0) {
+                    supportedErc1155Tokens[_courtID].remove(_token);
+                }
+            }
+            emit SupportedErc1155TokenIdChanged(_courtID, _token, _tokenIds[i], _supported);
         }
     }
 
@@ -117,6 +169,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     // ************************************* //
 
     /// @inheritdoc DisputeKitClassicBase
+    /// @notice A token gate must be specified in the `extraData`, otherwise the transaction reverts.
     function createDispute(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
@@ -124,8 +177,17 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         bytes calldata _extraData,
         uint256 _nbVotes
     ) public override {
-        (uint96 courtID, address tokenGate, , ) = _extraDataToTokenInfo(_extraData);
-        if (!supportedTokens[courtID][tokenGate]) revert TokenNotSupported(courtID, tokenGate);
+        (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(_extraData);
+
+        // DisputeKitGated must always be token-gated.
+        if (tokenGate == address(0)) revert TokenGateRequired();
+
+        if (isERC1155) {
+            if (!supportedErc1155TokenIds[courtID][tokenGate].contains(tokenId))
+                revert TokenNotSupported(courtID, tokenGate);
+        } else {
+            if (!supportedErc721Tokens[courtID].contains(tokenGate)) revert TokenNotSupported(courtID, tokenGate);
+        }
 
         // super.createDispute() ensures access control onlyByCore.
         super.createDispute(_coreDisputeID, _coreRoundID, _numberOfChoices, _extraData, _nbVotes);
@@ -208,6 +270,97 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         return keccak256(abi.encode(_salt, keccak256(bytes(_justification))));
     }
 
+    /// @inheritdoc ICourtEligibility
+    /// @dev Complexity: O(n + m) where `n` is the number of supported ERC-721 tokens and `m` is the number of supported ERC-1155 tokens.
+    function isEligible(address _juror, uint96 _courtID) external view override returns (bool) {
+        uint256 erc721Length = supportedErc721Tokens[_courtID].length();
+        for (uint256 i = 0; i < erc721Length; i++) {
+            address token = supportedErc721Tokens[_courtID].at(i);
+            if (token == address(0)) continue;
+            if (IBalanceHolder(token).balanceOf(_juror) > 0) return true;
+        }
+
+        uint256 erc1155Length = supportedErc1155Tokens[_courtID].length();
+        for (uint256 i = 0; i < erc1155Length; i++) {
+            address token = supportedErc1155Tokens[_courtID].at(i);
+            if (token == address(0)) continue;
+            EnumerableSet.UintSet storage tokenIds = supportedErc1155TokenIds[_courtID][token];
+            uint256 tokenIdsLength = tokenIds.length();
+            for (uint256 j = 0; j < tokenIdsLength; j++) {
+                uint256 tokenId = tokenIds.at(j);
+                if (IBalanceHolderERC1155(token).balanceOf(_juror, tokenId) > 0) return true;
+            }
+        }
+        return false;
+    }
+
+    /// @notice Checks if an ERC-721 token is supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @param _token The address of the token.
+    /// @return Whether the token is supported or not.
+    function isErc721TokenSupported(uint96 _courtID, address _token) external view returns (bool) {
+        return supportedErc721Tokens[_courtID].contains(_token);
+    }
+
+    /// @notice Returns the number of ERC-721 tokens supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @return The number of ERC-721 tokens supported in the court.
+    function supportedErc721TokensLength(uint96 _courtID) external view returns (uint256) {
+        return supportedErc721Tokens[_courtID].length();
+    }
+
+    /// @notice Returns the ERC-721 token at the given index.
+    /// @param _courtID The ID of the court.
+    /// @param _index The index of the token.
+    /// @return The ERC-721 token at the given index.
+    function supportedErc721TokensAt(uint96 _courtID, uint256 _index) external view returns (address) {
+        return supportedErc721Tokens[_courtID].at(_index);
+    }
+
+    /// @notice Checks if an ERC-1155 `(token, tokenId)` is supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @param _tokenId The ERC-1155 tokenId.
+    function isErc1155TokenIdSupported(uint96 _courtID, address _token, uint256 _tokenId) external view returns (bool) {
+        return supportedErc1155TokenIds[_courtID][_token].contains(_tokenId);
+    }
+
+    /// @notice Returns the number of ERC-1155 tokenIds supported for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @return The number of ERC-1155 tokenIds supported for the given token contract.
+    function supportedErc1155TokenIdsLength(uint96 _courtID, address _token) external view returns (uint256) {
+        return supportedErc1155TokenIds[_courtID][_token].length();
+    }
+
+    /// @notice Returns the ERC-1155 tokenId at the given index for a given token contract.
+    /// @param _courtID The ID of the court.
+    /// @param _token The ERC-1155 token contract address.
+    /// @param _index The index of the tokenId.
+    /// @return The ERC-1155 tokenId at the given index for the given token contract.
+    function supportedErc1155TokenIdsAt(
+        uint96 _courtID,
+        address _token,
+        uint256 _index
+    ) external view returns (uint256) {
+        return supportedErc1155TokenIds[_courtID][_token].at(_index);
+    }
+
+    /// @notice Returns the number of ERC-1155 tokens supported in a court.
+    /// @param _courtID The ID of the court.
+    /// @return The number of ERC-1155 tokens supported in the court.
+    function supportedErc1155TokensLength(uint96 _courtID) external view returns (uint256) {
+        return supportedErc1155Tokens[_courtID].length();
+    }
+
+    /// @notice Returns the ERC-1155 token at the given index.
+    /// @param _courtID The ID of the court.
+    /// @param _index The index of the token.
+    /// @return The ERC-1155 token at the given index.
+    function supportedErc1155TokensAt(uint96 _courtID, uint256 _index) external view returns (address) {
+        return supportedErc1155Tokens[_courtID].at(_index);
+    }
+
     // ************************************* //
     // *            Internal               * //
     // ************************************* //
@@ -242,8 +395,8 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     /// - bytes 128-159: uint256 tokenId
     /// @return courtID The ID of the court.
     /// @return tokenGate The address of the token contract used for gating access.
-    /// @return isERC1155 True if the token is an ERC-1155, false for ERC-20/ERC-721.
-    /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-20/ERC-721).
+    /// @return isERC1155 True if the token is an ERC-1155, false for ERC-721.
+    /// @return tokenId The token ID for ERC-1155 tokens (ignored for ERC-721).
     function _extraDataToTokenInfo(
         bytes memory _extraData
     ) internal pure returns (uint96 courtID, address tokenGate, bool isERC1155, uint256 tokenId) {
@@ -277,8 +430,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
         Dispute storage dispute = disputes[localDisputeID];
         (, address tokenGate, bool isERC1155, uint256 tokenId) = _extraDataToTokenInfo(dispute.extraData);
 
-        // If no token gate is specified, allow all jurors
-        if (tokenGate == NO_TOKEN_GATE) return true;
+        if (tokenGate == address(0)) return false; // Token gate must be specified.
 
         // Check juror's token balance
         if (isERC1155) {
@@ -293,6 +445,7 @@ contract DisputeKitGatedShutter is DisputeKitClassicBase {
     // ************************************* //
 
     error TokenNotSupported(uint96 courtID, address tokenGate);
+    error TokenGateRequired();
     error EmptyJustificationCommit();
     error JustificationCommitmentMismatch();
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import {DisputeKitClassicBase} from "./DisputeKitClassicBase.sol";
 import {KlerosCore} from "../KlerosCore.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
 
 interface IProofOfHumanity {
     /// @notice Check whether the account corresponds to a claimed humanity.
@@ -19,7 +20,7 @@ interface IProofOfHumanity {
 /// - a vote aggregation system: plurality,
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.
-contract DisputeKitSybilResistant is DisputeKitClassicBase {
+contract DisputeKitSybilResistant is DisputeKitClassicBase, ICourtEligibility {
     string public constant override version = "2.0.0";
 
     // ************************************* //
@@ -61,6 +62,15 @@ contract DisputeKitSybilResistant is DisputeKitClassicBase {
     ///      Only the owner can perform upgrades (`onlyByOwner`)
     function _authorizeUpgrade(address) internal view override onlyByOwner {
         // NOP
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @inheritdoc ICourtEligibility
+    function isEligible(address _juror, uint96 /* _courtID */) external view override returns (bool) {
+        return poh.isHuman(_juror);
     }
 
     // ************************************* //

--- a/contracts/src/arbitration/interfaces/ICourtEligibility.sol
+++ b/contracts/src/arbitration/interfaces/ICourtEligibility.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0 <0.9.0;
+
+/// @title ICourtEligibility
+/// @notice Interface for the court eligibility predicate.
+interface ICourtEligibility {
+    /// @notice Checks if the juror is eligible to stake or to vote in the court.
+    /// @param _juror The address of the juror.
+    /// @param _courtID The ID of the court.
+    /// @return True if the juror is eligible, false otherwise.
+    function isEligible(address _juror, uint96 _courtID) external view returns (bool);
+}

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../../libraries/Constants.sol";
+import {ICourtEligibility} from "./ICourtEligibility.sol";
 
 /// @title ISortitionModule
 /// @notice Interface for the SortitionModule contract.
@@ -47,6 +48,7 @@ interface ISortitionModule {
     /// @param _courtID The ID of the court.
     /// @param _newStake The new stake.
     /// @param _noDelay True if the stake change should not be delayed.
+    /// @param _eligibility The eligibility predicate for the court.
     /// @return pnkDeposit The amount of PNK to be deposited.
     /// @return pnkWithdrawal The amount of PNK to be withdrawn.
     /// @return stakingResult The result of the staking operation.
@@ -54,7 +56,8 @@ interface ISortitionModule {
         address _account,
         uint96 _courtID,
         uint256 _newStake,
-        bool _noDelay
+        bool _noDelay,
+        ICourtEligibility _eligibility
     ) external returns (uint256 pnkDeposit, uint256 pnkWithdrawal, StakingResult stakingResult);
 
     /// @notice Update the state of the stakes, called by KC at the end of setStake flow.

--- a/contracts/src/arbitration/university/KlerosCoreUniversity.sol
+++ b/contracts/src/arbitration/university/KlerosCoreUniversity.sol
@@ -6,6 +6,7 @@ import {IArbitrableV2} from "../interfaces/IArbitrableV2.sol";
 import {IArbitratorV2} from "../interfaces/IArbitratorV2.sol";
 import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
 import {IRatesConverter} from "../interfaces/IRatesConverter.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
 import {ISortitionModuleUniversity} from "./ISortitionModuleUniversity.sol";
 import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
 import {Initializable} from "../../proxy/Initializable.sol";
@@ -1096,7 +1097,8 @@ contract KlerosCoreUniversity is IArbitratorV2, UUPSProxiable, Initializable {
             _account,
             _courtID,
             _newStake,
-            _noDelay
+            _noDelay,
+            ICourtEligibility(address(0))
         );
         if (stakingResult != StakingResult.Successful) {
             _stakingFailed(_onError, stakingResult);

--- a/contracts/src/arbitration/university/SortitionModuleUniversity.sol
+++ b/contracts/src/arbitration/university/SortitionModuleUniversity.sol
@@ -6,6 +6,7 @@ import {KlerosCoreUniversity} from "./KlerosCoreUniversity.sol";
 import {ISortitionModuleUniversity} from "./ISortitionModuleUniversity.sol";
 import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
 import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
+import {ICourtEligibility} from "../interfaces/ICourtEligibility.sol";
 import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
 import {Initializable} from "../../proxy/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -145,7 +146,8 @@ contract SortitionModuleUniversity is ISortitionModuleUniversity, UUPSProxiable,
         address _account,
         uint96 _courtID,
         uint256 _newStake,
-        bool /*_noDelay*/
+        bool /*_noDelay*/,
+        ICourtEligibility /*_eligibility*/
     )
         external
         view

--- a/contracts/src/libraries/Constants.sol
+++ b/contracts/src/libraries/Constants.sol
@@ -38,5 +38,6 @@ enum StakingResult {
     CannotStakeLessThanMinStake,
     CannotStakeMoreThanMaxStakePerJuror,
     CannotStakeMoreThanMaxTotalStaked,
+    NotEligibleForStaking,
     CannotStakeZeroWhenNoStake
 }

--- a/contracts/src/test/DisputeKitGatedMock.sol
+++ b/contracts/src/test/DisputeKitGatedMock.sol
@@ -3,13 +3,28 @@
 pragma solidity ^0.8.24;
 
 import {DisputeKitGated} from "../arbitration/dispute-kits/DisputeKitGated.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title DisputeKitGatedMock
 /// DisputeKitGated with view functions to use in the tests.
 contract DisputeKitGatedMock is DisputeKitGated {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     function extraDataToTokenInfo(
         bytes memory _extraData
     ) public pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
         (, tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
+    }
+
+    /// @notice TEST ONLY: bypasses governance validation.
+    /// @dev May violate invariants. For example, `address(0)` is normally forbidden as a token gate.
+    function unsafeAddSupportedErc721Token(uint96 _courtID, address _token) external onlyByOwner {
+        supportedErc721Tokens[_courtID].add(_token);
+    }
+
+    /// @notice TEST ONLY: bypasses governance validation.
+    /// @dev May violate invariants. For example, `address(0)` is normally forbidden as a token gate.
+    function unsafeAddSupportedErc1155Token(uint96 _courtID, address _token) external onlyByOwner {
+        supportedErc1155Tokens[_courtID].add(_token);
     }
 }

--- a/contracts/src/test/DisputeKitGatedShutterMock.sol
+++ b/contracts/src/test/DisputeKitGatedShutterMock.sol
@@ -3,13 +3,28 @@
 pragma solidity ^0.8.24;
 
 import {DisputeKitGatedShutter} from "../arbitration/dispute-kits/DisputeKitGatedShutter.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title DisputeKitGatedShutterMock
 /// DisputeKitGatedShutter with view functions to use in the tests.
 contract DisputeKitGatedShutterMock is DisputeKitGatedShutter {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     function extraDataToTokenInfo(
         bytes memory _extraData
     ) public pure returns (address tokenGate, bool isERC1155, uint256 tokenId) {
         (, tokenGate, isERC1155, tokenId) = _extraDataToTokenInfo(_extraData);
+    }
+
+    /// @notice TEST ONLY: bypasses governance validation.
+    /// @dev May violate invariants. For example, `address(0)` is normally forbidden as a token gate.
+    function unsafeAddSupportedErc721Token(uint96 _courtID, address _token) external onlyByOwner {
+        supportedErc721Tokens[_courtID].add(_token);
+    }
+
+    /// @notice TEST ONLY: bypasses governance validation.
+    /// @dev May violate invariants. For example, `address(0)` is normally forbidden as a token gate.
+    function unsafeAddSupportedErc1155Token(uint96 _courtID, address _token) external onlyByOwner {
+        supportedErc1155Tokens[_courtID].add(_token);
     }
 }

--- a/contracts/test/arbitration/dispute-kit-gated-shutter.ts
+++ b/contracts/test/arbitration/dispute-kit-gated-shutter.ts
@@ -7,7 +7,8 @@ import {
   testERC721Gating,
   testERC1155Gating,
   testWhitelistIntegration,
-  testNoTokenGateAddress,
+  testTokenGateRequired,
+  testCourtEligibilityMisconfiguration,
   TokenGatedTestContext,
 } from "./helpers/dispute-kit-gated-common";
 import {
@@ -49,7 +50,8 @@ describe("DisputeKitGatedShutter", async () => {
     testERC721Gating(() => tokenContext);
     testERC1155Gating(() => tokenContext);
     testWhitelistIntegration(() => tokenContext);
-    testNoTokenGateAddress(() => tokenContext);
+    testTokenGateRequired(() => tokenContext);
+    testCourtEligibilityMisconfiguration(() => tokenContext);
   });
 
   describe("Shutter Features", async () => {

--- a/contracts/test/arbitration/dispute-kit-gated.ts
+++ b/contracts/test/arbitration/dispute-kit-gated.ts
@@ -7,7 +7,8 @@ import {
   testERC721Gating,
   testERC1155Gating,
   testWhitelistIntegration,
-  testNoTokenGateAddress,
+  testTokenGateRequired,
+  testCourtEligibilityMisconfiguration,
   TokenGatedTestContext,
 } from "./helpers/dispute-kit-gated-common";
 
@@ -39,5 +40,6 @@ describe("DisputeKitGated", async () => {
   testERC721Gating(() => context);
   testERC1155Gating(() => context);
   testWhitelistIntegration(() => context);
-  testNoTokenGateAddress(() => context);
+  testTokenGateRequired(() => context);
+  testCourtEligibilityMisconfiguration(() => context);
 });

--- a/contracts/test/arbitration/draw.ts
+++ b/contracts/test/arbitration/draw.ts
@@ -1,6 +1,6 @@
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 import { deployments, ethers, getNamedAccounts, network } from "hardhat";
-import { toBigInt, ContractTransactionResponse, HDNodeWallet } from "ethers";
+import { toBigInt, ContractTransactionResponse, HDNodeWallet, ZeroAddress } from "ethers";
 import {
   PNK,
   KlerosCore,
@@ -97,7 +97,8 @@ describe("Draw Benchmark", async () => {
         256,
         [0, 0, 0, 10], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
         ethers.toBeHex(5), // Extra data for sortition module will return the default value of K)
-        [1]
+        [1],
+        ZeroAddress
       )
       .then((tx) => tx.wait());
   });

--- a/contracts/test/arbitration/helpers/dispute-kit-gated-common.ts
+++ b/contracts/test/arbitration/helpers/dispute-kit-gated-common.ts
@@ -47,7 +47,7 @@ export interface TokenGatedTestContext {
 
 // Configuration for setting up a token gated test
 export interface TokenGatedTestConfig {
-  contractName: string; // "DisputeKitGatedMock" or "DisputeKitGatedShutterMock"
+  contractName: "DisputeKitGatedMock" | "DisputeKitGatedShutterMock";
 }
 
 // Constants for token amounts
@@ -81,7 +81,15 @@ export const whitelistTokens = async (
   courtId: BigNumberish = Courts.GENERAL
 ) => {
   const tokenAddresses = tokens.map((token) => (typeof token === "string" ? token : token.toString()));
-  return context.disputeKit.changeSupportedTokens(courtId, tokenAddresses, supported);
+
+  const nft1155Address = context.nft1155.target.toString();
+  const isErc1155Included = tokenAddresses.some((tokenAddress) => tokenAddress === nft1155Address);
+  const erc721LikeTokens = tokenAddresses.filter((tokenAddress) => tokenAddress !== nft1155Address);
+
+  if (erc721LikeTokens.length > 0)
+    await context.disputeKit.changeSupportedErc721Tokens(courtId, erc721LikeTokens, supported);
+  if (isErc1155Included)
+    await context.disputeKit.changeSupportedErc1155TokenIds(courtId, nft1155Address, [context.TOKEN_ID], supported);
 };
 
 // Helper function to create a dispute with the specified token gate
@@ -102,10 +110,23 @@ export const expectTokenSupported = async (
   context: TokenGatedTestContext,
   token: string | Addressable,
   supported: boolean,
-  courtId: BigNumberish = Courts.GENERAL
+  courtId: BigNumberish = Courts.GENERAL,
+  tokenId?: BigNumberish
 ) => {
   const tokenAddress = typeof token === "string" ? token : token.toString();
-  expect(await context.disputeKit.supportedTokens(courtId, tokenAddress)).to.equal(supported);
+
+  const nft1155Address = context.nft1155.target.toString();
+  const isKnownErc1155 = tokenAddress === nft1155Address;
+
+  if (tokenId !== undefined || isKnownErc1155) {
+    const effectiveTokenId = tokenId ?? context.TOKEN_ID;
+    expect(await context.disputeKit.isErc1155TokenIdSupported(courtId, tokenAddress, effectiveTokenId)).to.equal(
+      supported
+    );
+    return;
+  }
+
+  expect(await context.disputeKit.isErc721TokenSupported(courtId, tokenAddress)).to.equal(supported);
 };
 
 // Helper function to stake and draw jurors
@@ -242,7 +263,7 @@ export async function setupTokenGatedTest(config: TokenGatedTestConfig): Promise
 
 export function testTokenWhitelistManagement(context: () => TokenGatedTestContext) {
   describe("Token Whitelist Management", async () => {
-    describe("changeSupportedTokens function", async () => {
+    describe("changeSupportedErc721Tokens / changeSupportedErc1155TokenIds functions", async () => {
       it("Should allow owner to whitelist single token", async () => {
         const ctx = context();
         await whitelistTokens(ctx, [ctx.dai.target], true);
@@ -335,20 +356,20 @@ export function testTokenWhitelistManagement(context: () => TokenGatedTestContex
 
 export function testAccessControl(context: () => TokenGatedTestContext) {
   describe("Access Control", async () => {
-    it("Should revert when non-owner tries to change supported tokens", async () => {
+    it("Should revert when non-owner tries to change supported ERC721-like tokens", async () => {
       const ctx = context();
-      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens(Courts.GENERAL, [ctx.dai.target], true)).to
-        .be.reverted;
+      await expect(
+        ctx.disputeKit.connect(ctx.juror1).changeSupportedErc721Tokens(Courts.GENERAL, [ctx.dai.target], true)
+      ).to.be.reverted;
     });
 
-    it("Should revert when non-owner tries to remove supported tokens", async () => {
+    it("Should revert when non-owner tries to change supported ERC1155 tokenIds", async () => {
       const ctx = context();
-      // First whitelist as owner
-      await whitelistTokens(ctx, [ctx.dai.target], true);
-
-      // Then try to remove as non-owner
-      await expect(ctx.disputeKit.connect(ctx.juror1).changeSupportedTokens(Courts.GENERAL, [ctx.dai.target], false)).to
-        .be.reverted;
+      await expect(
+        ctx.disputeKit
+          .connect(ctx.juror1)
+          .changeSupportedErc1155TokenIds(Courts.GENERAL, ctx.nft1155.target, [ctx.TOKEN_ID], true)
+      ).to.be.reverted;
     });
   });
 }
@@ -671,94 +692,25 @@ export function testWhitelistIntegration(context: () => TokenGatedTestContext) {
   });
 }
 
-export function testNoTokenGateAddress(context: () => TokenGatedTestContext) {
-  describe("No Token Gate Edge Case (address(0))", async () => {
-    it("Should verify that address(0) is supported by default", async () => {
+export function testTokenGateRequired(context: () => TokenGatedTestContext) {
+  describe("Token Gate Required (address(0) is invalid)", async () => {
+    it("Should revert when whitelisting address(0)", async () => {
       const ctx = context();
-      await expectTokenSupported(ctx, ethers.ZeroAddress, true);
+      await expect(
+        ctx.disputeKit.changeSupportedErc721Tokens(Courts.GENERAL, [ethers.ZeroAddress], true)
+      ).to.be.revertedWithCustomError(ctx.disputeKit, "TokenGateRequired");
     });
 
-    it("Should verify that address(0) is court-scoped (GENERAL only by default)", async () => {
+    it("Should revert when creating dispute with tokenGate = address(0)", async () => {
       const ctx = context();
-      await expectTokenSupported(ctx, ethers.ZeroAddress, true, Courts.GENERAL);
-      await expectTokenSupported(ctx, ethers.ZeroAddress, false, Courts.FORKING);
-    });
-
-    it("Should require explicit support for address(0) outside GENERAL", async () => {
-      const ctx = context();
-
-      // Enable the dispute kit in FORKING court so dispute creation reaches DK logic.
-      const deployerSigner = await ethers.getSigner(ctx.deployer);
-      await ctx.core.connect(deployerSigner).enableDisputeKits(Courts.FORKING, [ctx.gatedDisputeKitID], true);
-
-      // Dispute without token gating should revert in FORKING unless whitelisted there.
-      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0, Courts.FORKING))
-        .to.be.revertedWithCustomError(ctx.disputeKit, "TokenNotSupported")
-        .withArgs(Courts.FORKING, ethers.ZeroAddress);
-
-      await whitelistTokens(ctx, [ethers.ZeroAddress], true, Courts.FORKING);
-      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0, Courts.FORKING)).to.not.be.reverted;
-    });
-
-    it("Should allow dispute creation with address(0) as tokenGate", async () => {
-      const ctx = context();
-      // Create dispute with address(0) as tokenGate - should not revert
-      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0)).to.not.be.reverted;
-    });
-
-    it("Should draw all staked jurors when tokenGate is address(0)", async () => {
-      const ctx = context();
-      // Neither juror has any special tokens, but both are staked
-      const nbOfJurors = 15n;
-      const tx = await stakeAndDraw(
-        ctx,
-        Courts.GENERAL,
-        nbOfJurors,
-        ctx.gatedDisputeKitID,
-        ethers.ZeroAddress,
-        false,
-        0
-      ).then((tx) => tx.wait());
-
-      // Both jurors should be eligible for drawing since there's no token gate
-      const drawLogs =
-        tx?.logs.filter((log: any) => log.fragment?.name === "Draw" && log.address === ctx.core.target) || [];
-      expect(drawLogs.length).to.equal(nbOfJurors);
-
-      // Verify that draws include both jurors (not just one)
-      const drawnJurors = new Set(drawLogs.map((log: any) => log.args[0]));
-      expect(drawnJurors.size).to.be.greaterThan(1, "Should draw from multiple jurors");
-    });
-
-    it("Should behave like non-gated dispute kit when tokenGate is address(0)", async () => {
-      const ctx = context();
-      // Verify that with address(0), jurors don't need any token balance
-      const nbOfJurors = 3n;
-
-      // Ensure jurors have no DAI tokens
-      expect(await ctx.dai.balanceOf(ctx.juror1.address)).to.equal(0);
-      expect(await ctx.dai.balanceOf(ctx.juror2.address)).to.equal(0);
-
-      const tx = await stakeAndDraw(
-        ctx,
-        Courts.GENERAL,
-        nbOfJurors,
-        ctx.gatedDisputeKitID,
-        ethers.ZeroAddress,
-        false,
-        0
-      ).then((tx) => tx.wait());
-
-      // Jurors should still be drawn despite having no tokens
-      const drawLogs =
-        tx?.logs.filter((log: any) => log.fragment?.name === "Draw" && log.address === ctx.core.target) || [];
-      expect(drawLogs).to.have.length(nbOfJurors);
+      await expect(createDisputeWithToken(ctx, ethers.ZeroAddress, false, 0)).to.be.revertedWithCustomError(
+        ctx.disputeKit,
+        "TokenGateRequired"
+      );
     });
 
     it("Should parse address(0) correctly from insufficient extraData", async () => {
       const ctx = context();
-      // Create extraData that's too short (less than 160 bytes)
-      // This should return address(0) from _extraDataToTokenInfo
       const shortExtraData = ethers.AbiCoder.defaultAbiCoder().encode(
         ["uint256", "uint256", "uint256"],
         [Courts.GENERAL, 3, ctx.gatedDisputeKitID]
@@ -768,6 +720,91 @@ export function testNoTokenGateAddress(context: () => TokenGatedTestContext) {
       expect(tokenInfo[0]).to.equal(ethers.ZeroAddress);
       expect(tokenInfo[1]).to.equal(false);
       expect(tokenInfo[2]).to.equal(0);
+    });
+  });
+}
+
+export function testCourtEligibilityMisconfiguration(context: () => TokenGatedTestContext) {
+  describe("Court eligibility misconfiguration (eligibility set before token config)", async () => {
+    async function createCourtWithEligibility(ctx: TokenGatedTestContext): Promise<number> {
+      const deployerSigner = await ethers.getSigner(ctx.deployer);
+
+      const tx = await ctx.core
+        .connect(deployerSigner)
+        .createCourt(
+          Courts.GENERAL, // parent
+          false, // hiddenVotes
+          ctx.minStake, // minStake
+          10000, // alpha
+          ethers.parseEther("0.1"), // feeForJuror
+          16, // jurorsForCourtJump
+          [300, 300, 300, 300], // timesPerPeriod
+          ethers.toBeHex(5), // sortitionExtraData
+          [1, ctx.gatedDisputeKitID], // supportedDisputeKits (must include Classic)
+          ctx.disputeKit.target // eligibility predicate
+        )
+        .then((tx) => tx.wait());
+
+      const createdLog = (tx?.logs as any[])?.find(
+        (log) => log.fragment?.name === "CourtCreated" && log.address === ctx.core.target
+      );
+      expect(createdLog, "CourtCreated log not found").to.not.equal(undefined);
+
+      return Number(createdLog.args[0]);
+    }
+
+    async function fundAndApprove(ctx: TokenGatedTestContext, juror: HardhatEthersSigner, amount: bigint) {
+      await ctx.pnk.transfer(juror.address, amount).then((tx) => tx.wait());
+      await ctx.pnk
+        .connect(juror)
+        .approve(ctx.core.target, amount, { gasLimit: 300000 })
+        .then((tx) => tx.wait());
+    }
+
+    it("Should revert NotEligibleForStaking when eligibility is set but no supported tokens are configured", async () => {
+      const ctx = context();
+      const courtId = await createCourtWithEligibility(ctx);
+
+      expect(await ctx.disputeKit.supportedErc721TokensLength(courtId)).to.equal(0);
+      expect(await ctx.disputeKit.supportedErc1155TokensLength(courtId)).to.equal(0);
+
+      await fundAndApprove(ctx, ctx.juror1, ctx.thousandPNK(10));
+      await expect(ctx.core.connect(ctx.juror1).setStake(courtId, ctx.thousandPNK(10))).to.be.revertedWithCustomError(
+        ctx.core,
+        "NotEligibleForStaking"
+      );
+    });
+
+    it("Should not revert eligibility when ERC721 supported set contains address(0)", async () => {
+      const ctx = context();
+      const courtId = await createCourtWithEligibility(ctx);
+      await ctx.disputeKit.unsafeAddSupportedErc721Token(courtId, ethers.ZeroAddress);
+
+      expect(await ctx.disputeKit.supportedErc721TokensLength(courtId)).to.equal(1);
+      expect(await ctx.disputeKit.supportedErc721TokensAt(courtId, 0)).to.equal(ethers.ZeroAddress);
+      expect(await ctx.disputeKit.isEligible(ctx.juror1.address, courtId)).to.equal(false);
+
+      await fundAndApprove(ctx, ctx.juror1, ctx.thousandPNK(10));
+      await expect(ctx.core.connect(ctx.juror1).setStake(courtId, ctx.thousandPNK(10))).to.be.revertedWithCustomError(
+        ctx.core,
+        "NotEligibleForStaking"
+      );
+    });
+
+    it("Should not revert eligibility when ERC1155 supported set contains address(0)", async () => {
+      const ctx = context();
+      const courtId = await createCourtWithEligibility(ctx);
+      await ctx.disputeKit.unsafeAddSupportedErc1155Token(courtId, ethers.ZeroAddress);
+
+      expect(await ctx.disputeKit.supportedErc1155TokensLength(courtId)).to.equal(1);
+      expect(await ctx.disputeKit.supportedErc1155TokensAt(courtId, 0)).to.equal(ethers.ZeroAddress);
+      expect(await ctx.disputeKit.isEligible(ctx.juror1.address, courtId)).to.equal(false);
+
+      await fundAndApprove(ctx, ctx.juror1, ctx.thousandPNK(10));
+      await expect(ctx.core.connect(ctx.juror1).setStake(courtId, ctx.thousandPNK(10))).to.be.revertedWithCustomError(
+        ctx.core,
+        "NotEligibleForStaking"
+      );
     });
   });
 }

--- a/contracts/test/arbitration/helpers/dispute-kit-shutter-common.ts
+++ b/contracts/test/arbitration/helpers/dispute-kit-shutter-common.ts
@@ -1,5 +1,5 @@
 import { deployments, ethers, getNamedAccounts, network } from "hardhat";
-import { toBigInt, BigNumberish } from "ethers";
+import { toBigInt, BigNumberish, ZeroAddress } from "ethers";
 import {
   PNK,
   KlerosCore,
@@ -236,7 +236,8 @@ export async function setupShutterTest(config: ShutterTestConfig): Promise<Shutt
       16, // jurorsForCourtJump
       [300, 300, 300, 300], // timesPerPeriod for evidence, commit, vote, appeal
       ethers.toBeHex(5), // sortitionExtraData
-      [1, shutterDKID] // supportedDisputeKits - must include Classic (1) and Shutter (2)
+      [1, shutterDKID], // supportedDisputeKits - must include Classic (1) and Shutter (2)
+      ZeroAddress
     );
   } else if (config.contractName === "DisputeKitGatedShutter") {
     // For gated shutter, we need to deploy it if not already deployed
@@ -263,7 +264,8 @@ export async function setupShutterTest(config: ShutterTestConfig): Promise<Shutt
       10000, // alpha
       ethers.parseEther("0.1"), // feeForJuror
       16, // jurorsForCourtJump
-      [300, 300, 300, 300] // timesPerPeriod
+      [300, 300, 300, 300], // timesPerPeriod
+      ZeroAddress
     );
 
     await core.enableDisputeKits(Courts.GENERAL, [shutterDKID], true);
@@ -273,7 +275,7 @@ export async function setupShutterTest(config: ShutterTestConfig): Promise<Shutt
     // If gated, whitelist DAI token
     if (config.isGated) {
       const gatedKit = disputeKit as DisputeKitGatedShutterMock;
-      await gatedKit.changeSupportedTokens(Courts.GENERAL, [dai.target], true);
+      await gatedKit.changeSupportedErc721Tokens(Courts.GENERAL, [dai.target], true);
     }
   } else {
     throw new Error(`Unknown contract name: ${config.contractName}`);

--- a/contracts/test/arbitration/staking-neo.ts
+++ b/contracts/test/arbitration/staking-neo.ts
@@ -1,8 +1,6 @@
 import { ethers, getNamedAccounts, network, deployments } from "hardhat";
 import {
   PNK,
-  RandomizerRNG,
-  RandomizerMock,
   SortitionModule,
   KlerosCore,
   TestERC721,
@@ -12,6 +10,7 @@ import {
 } from "../../typechain-types";
 import { expect } from "chai";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { ZeroAddress } from "ethers";
 
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-unused-expressions */
@@ -440,7 +439,7 @@ describe("Staking", async () => {
   describe("When outside the Staking phase", async () => {
     const createSubcourtStakeAndCreateDispute = async () => {
       expect(await sortition.phase()).to.be.equal(0); // Staking
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1], ZeroAddress); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));
@@ -755,7 +754,7 @@ describe("Staking", async () => {
     });
 
     it("Should unstake from all courts", async () => {
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1], ZeroAddress); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));

--- a/contracts/test/arbitration/staking.ts
+++ b/contracts/test/arbitration/staking.ts
@@ -1,6 +1,7 @@
 import { ethers, getNamedAccounts, network, deployments } from "hardhat";
 import { PNK, KlerosCore, SortitionModule, ChainlinkRNG, ChainlinkVRFCoordinatorV2Mock } from "../../typechain-types";
 import { expect } from "chai";
+import { ZeroAddress } from "ethers";
 
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-unused-expressions */
@@ -40,7 +41,7 @@ describe("Staking", async () => {
     const reachDrawingPhase = async () => {
       expect(await sortition.phase()).to.be.equal(0); // Staking
       const arbitrationCost = ETH(0.1) * 3n;
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1], ZeroAddress); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));
@@ -361,7 +362,7 @@ describe("Staking", async () => {
 
     it("Should unstake from all courts", async () => {
       const arbitrationCost = ETH(0.1) * 3n;
-      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1]); // Parent - general court, Classic dispute kit
+      await core.createCourt(1, false, PNK(1000), 1000, ETH(0.1), 3, [0, 0, 0, 0], ethers.toBeHex(3), [1], ZeroAddress); // Parent - general court, Classic dispute kit
 
       await pnk.approve(core.target, PNK(4000));
       await core.setStake(1, PNK(2000));

--- a/contracts/test/evidence/index.ts
+++ b/contracts/test/evidence/index.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { deployments, ethers } from "hardhat";
-import { ContractTransactionReceipt, EventLog } from "ethers";
+import { ContractTransactionReceipt, EventLog, ZeroAddress } from "ethers";
 import { DisputeTemplateRegistry, KlerosCore, ModeratedEvidenceModule } from "../../typechain-types";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
@@ -61,7 +61,8 @@ describe("Home Evidence contract", async () => {
       court.alpha,
       arbitrationFee,
       court.jurorsForCourtJump,
-      [0, 0, 0, appealTimeout]
+      [0, 0, 0, appealTimeout],
+      ZeroAddress
     );
 
     const EvidenceModule = await ethers.getContractFactory("ModeratedEvidenceModule");

--- a/contracts/test/foundry/DisputeKitGatedArgentinaConsumerProtection_Drawing.t.sol
+++ b/contracts/test/foundry/DisputeKitGatedArgentinaConsumerProtection_Drawing.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitGatedArgentinaConsumerProtection} from "../../src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {ArbitrableExample} from "../../src/arbitration/arbitrables/ArbitrableExample.sol";
 import {TestERC721} from "../../src/token/TestERC721.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
@@ -92,7 +93,8 @@ contract DisputeKitGatedArgentinaConsumerProtection_DrawingTest is KlerosCore_Te
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         uint256[] memory children = core.getCourtChildren(GENERAL_COURT);
@@ -142,7 +144,8 @@ contract DisputeKitGatedArgentinaConsumerProtection_DrawingTest is KlerosCore_Te
             uint256 minStakeValue,
             uint256 alphaValue,
             uint256 feeForJurorValue,
-            uint256 jurorsForJumpValue
+            uint256 jurorsForJumpValue,
+
         ) = core.courts(argentinaCourt);
         assertEq(parent, GENERAL_COURT, "Wrong parent court");
         assertEq(courtHiddenVotes, false, "Wrong hiddenVotes");

--- a/contracts/test/foundry/DisputeKitGatedArgentinaConsumerProtection_Staking.t.sol
+++ b/contracts/test/foundry/DisputeKitGatedArgentinaConsumerProtection_Staking.t.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
+import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import {DisputeKitGatedArgentinaConsumerProtection} from "../../src/arbitration/dispute-kits/DisputeKitGatedArgentinaConsumerProtection.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
+import {TestERC721} from "../../src/token/TestERC721.sol";
+import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
+import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title DisputeKitGatedArgentinaConsumerProtection_StakingTest
+/// @dev Tests for ICourtEligibility enforcement during staking via DisputeKitGatedArgentinaConsumerProtection
+contract DisputeKitGatedArgentinaConsumerProtection_StakingTest is KlerosCore_TestBase {
+    // ************************************* //
+    // *          Test Contracts           * //
+    // ************************************* //
+
+    DisputeKitGatedArgentinaConsumerProtection argentinaDK;
+    TestERC721 accreditedProfessionalToken;
+    TestERC721 accreditedConsumerProtectionLawyerToken;
+
+    // ************************************* //
+    // *            Test Accounts          * //
+    // ************************************* //
+
+    address eligibleLawyer; // Has only accredited professional token
+    address eligibleConsumerLawyer; // Has only consumer protection lawyer token
+    address eligibleBothLawyer; // Has both tokens
+    address ineligibleJuror; // Has no tokens
+
+    // ************************************* //
+    // *         Test Parameters           * //
+    // ************************************* //
+
+    uint96 argentinaCourt;
+    uint256 constant ARGENTINA_DK_ID = 2;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Set up test accounts
+        eligibleLawyer = vm.addr(10);
+        eligibleConsumerLawyer = vm.addr(11);
+        eligibleBothLawyer = vm.addr(12);
+        ineligibleJuror = vm.addr(13);
+
+        // Deploy token contracts
+        accreditedProfessionalToken = new TestERC721("Accredited Lawyer", "AL");
+        accreditedConsumerProtectionLawyerToken = new TestERC721("Consumer Protection Lawyer", "CPL");
+
+        // Mint tokens to eligible jurors
+        accreditedProfessionalToken.safeMint(eligibleLawyer);
+        accreditedConsumerProtectionLawyerToken.safeMint(eligibleConsumerLawyer);
+        accreditedProfessionalToken.safeMint(eligibleBothLawyer);
+        accreditedConsumerProtectionLawyerToken.safeMint(eligibleBothLawyer);
+
+        // Deploy and initialize the Argentina dispute kit
+        DisputeKitGatedArgentinaConsumerProtection dkLogic = new DisputeKitGatedArgentinaConsumerProtection();
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,address,address,address,address)",
+            owner,
+            address(core),
+            address(wNative),
+            address(accreditedProfessionalToken),
+            address(accreditedConsumerProtectionLawyerToken)
+        );
+        UUPSProxy proxyDK = new UUPSProxy(address(dkLogic), initData);
+        argentinaDK = DisputeKitGatedArgentinaConsumerProtection(address(proxyDK));
+
+        // Add the dispute kit to core
+        vm.prank(owner);
+        core.addNewDisputeKit(argentinaDK);
+
+        // Create a court with the Argentina DK as the eligibility predicate
+        uint256[] memory supportedDK = new uint256[](2);
+        supportedDK[0] = DISPUTE_KIT_CLASSIC;
+        supportedDK[1] = ARGENTINA_DK_ID;
+
+        vm.prank(owner);
+        core.createCourt(
+            GENERAL_COURT,
+            false, // hiddenVotes
+            1000, // minStake
+            10000, // alpha
+            0.03 ether, // feeForJuror
+            50, // jurorsForJump
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // timesPerPeriod
+            sortitionExtraData,
+            supportedDK,
+            ICourtEligibility(address(argentinaDK)) // eligibility predicate
+        );
+
+        uint256[] memory children = core.getCourtChildren(GENERAL_COURT);
+        argentinaCourt = uint96(children[children.length - 1]);
+
+        // Give PNK to all test jurors and approve core
+        address[4] memory jurors = [eligibleLawyer, eligibleConsumerLawyer, eligibleBothLawyer, ineligibleJuror];
+        for (uint256 i = 0; i < jurors.length; i++) {
+            vm.prank(owner);
+            pinakion.transfer(jurors[i], 5000);
+            vm.prank(jurors[i]);
+            pinakion.approve(address(core), 5000);
+        }
+    }
+
+    // ************************************* //
+    // *              Tests                * //
+    // ************************************* //
+
+    /// @notice Juror holding only the accredited professional token can stake
+    function test_stakeSucceedsWithAccreditedProfessionalToken() public {
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 3000);
+
+        (uint256 totalStaked, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(
+            eligibleLawyer,
+            argentinaCourt
+        );
+        assertEq(stakedInCourt, 3000, "Wrong staked amount");
+        assertEq(totalStaked, 3000, "Wrong total staked");
+    }
+
+    /// @notice Juror holding only the consumer protection lawyer token can stake
+    function test_stakeSucceedsWithConsumerProtectionLawyerToken() public {
+        vm.prank(eligibleConsumerLawyer);
+        core.setStake(argentinaCourt, 3000);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(eligibleConsumerLawyer, argentinaCourt);
+        assertEq(stakedInCourt, 3000, "Wrong staked amount");
+    }
+
+    /// @notice Juror holding both tokens can stake
+    function test_stakeSucceedsWithBothTokens() public {
+        vm.prank(eligibleBothLawyer);
+        core.setStake(argentinaCourt, 3000);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(eligibleBothLawyer, argentinaCourt);
+        assertEq(stakedInCourt, 3000, "Wrong staked amount");
+    }
+
+    /// @notice Juror without any token reverts NotEligibleForStaking on stake increase
+    function test_stakeRevertsWithoutTokens() public {
+        vm.expectRevert(KlerosCore.NotEligibleForStaking.selector);
+        vm.prank(ineligibleJuror);
+        core.setStake(argentinaCourt, 3000);
+    }
+
+    /// @notice Juror who staked while eligible can unstake after losing eligibility
+    function test_unstakeSucceedsAfterLosingEligibility() public {
+        // Stake while eligible
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 3000);
+
+        // Simulate losing eligibility by swapping token addresses to ones the juror doesn't hold
+        TestERC721 dummyToken = new TestERC721("Dummy", "D");
+        vm.startPrank(owner);
+        argentinaDK.changeAccreditedProfessionalToken(address(dummyToken));
+        argentinaDK.changeAccreditedConsumerProtectionLawyerToken(address(dummyToken));
+        vm.stopPrank();
+        assertFalse(argentinaDK.isEligible(eligibleLawyer, argentinaCourt), "Should be ineligible now");
+
+        // Unstake should still succeed (eligibility not checked on decrease)
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 0);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(eligibleLawyer, argentinaCourt);
+        assertEq(stakedInCourt, 0, "Should be fully unstaked");
+    }
+
+    /// @notice Stake increase reverts after juror loses eligibility
+    function test_stakeIncreaseRevertsAfterLosingEligibility() public {
+        // Stake while eligible
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 2000);
+
+        // Simulate losing eligibility
+        TestERC721 dummyToken = new TestERC721("Dummy", "D");
+        vm.startPrank(owner);
+        argentinaDK.changeAccreditedProfessionalToken(address(dummyToken));
+        argentinaDK.changeAccreditedConsumerProtectionLawyerToken(address(dummyToken));
+        vm.stopPrank();
+
+        // Stake increase should revert
+        vm.expectRevert(KlerosCore.NotEligibleForStaking.selector);
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 3000);
+    }
+
+    /// @notice Stake decrease succeeds after juror loses eligibility
+    function test_stakeDecreaseSucceedsAfterLosingEligibility() public {
+        // Stake while eligible
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 3000);
+
+        // Simulate losing eligibility
+        TestERC721 dummyToken = new TestERC721("Dummy", "D");
+        vm.startPrank(owner);
+        argentinaDK.changeAccreditedProfessionalToken(address(dummyToken));
+        argentinaDK.changeAccreditedConsumerProtectionLawyerToken(address(dummyToken));
+        vm.stopPrank();
+
+        // Stake decrease should succeed
+        vm.prank(eligibleLawyer);
+        core.setStake(argentinaCourt, 1000);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(eligibleLawyer, argentinaCourt);
+        assertEq(stakedInCourt, 1000, "Wrong staked amount after decrease");
+    }
+
+    /// @notice Court with address(0) eligibility allows anyone to stake
+    function test_noEligibilityRestrictionWithAddressZero() public {
+        // General Court has eligibility = address(0), so anyone can stake
+        vm.prank(ineligibleJuror);
+        core.setStake(GENERAL_COURT, 1000);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(ineligibleJuror, GENERAL_COURT);
+        assertEq(stakedInCourt, 1000, "Should be able to stake in court with no eligibility");
+    }
+
+    /// @notice Adding eligibility predicate via changeCourtParameters blocks ineligible stakers,
+    /// removing it re-allows them
+    function test_changeCourtEligibility() public {
+        // Create a court with no eligibility restriction
+        uint96 openCourt = _createStandardCourt(GENERAL_COURT, 1000, 10000, 0.03 ether, 50);
+
+        // Ineligible juror can stake in the open court
+        vm.prank(ineligibleJuror);
+        core.setStake(openCourt, 2000);
+
+        (, , uint256 stakedInCourt, ) = sortitionModule.getJurorBalance(ineligibleJuror, openCourt);
+        assertEq(stakedInCourt, 2000, "Should stake in open court");
+
+        // Owner adds eligibility predicate
+        vm.prank(owner);
+        core.changeCourtParameters(
+            openCourt,
+            false, // hiddenVotes
+            1000, // minStake
+            10000, // alpha
+            0.03 ether, // feeForJuror
+            50, // jurorsForJump
+            [uint256(10), uint256(20), uint256(30), uint256(40)],
+            ICourtEligibility(address(argentinaDK))
+        );
+
+        // Ineligible juror can no longer increase stake
+        vm.expectRevert(KlerosCore.NotEligibleForStaking.selector);
+        vm.prank(ineligibleJuror);
+        core.setStake(openCourt, 3000);
+
+        // But can still decrease
+        vm.prank(ineligibleJuror);
+        core.setStake(openCourt, 1000);
+
+        // Owner removes eligibility predicate
+        vm.prank(owner);
+        core.changeCourtParameters(
+            openCourt,
+            false,
+            1000,
+            10000,
+            0.03 ether,
+            50,
+            [uint256(10), uint256(20), uint256(30), uint256(40)],
+            ICourtEligibility(address(0))
+        );
+
+        // Ineligible juror can increase again
+        vm.prank(ineligibleJuror);
+        core.setStake(openCourt, 3000);
+
+        (, , stakedInCourt, ) = sortitionModule.getJurorBalance(ineligibleJuror, openCourt);
+        assertEq(stakedInCourt, 3000, "Should stake after eligibility removed");
+    }
+}

--- a/contracts/test/foundry/KlerosCore_Appeals.t.sol
+++ b/contracts/test/foundry/KlerosCore_Appeals.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitClassic, DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {DisputeKitClassicMockUncheckedNextRoundSettings} from "../../src/test/DisputeKitClassicMockUncheckedNextRoundSettings.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
 import "../../src/libraries/Constants.sol";
@@ -253,7 +254,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // jurors for jump. Low number to ensure jump after the first appeal
             [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         arbitrable.changeArbitratorExtraData(newExtraData);
@@ -400,7 +402,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // jurors for jump. Low number to ensure jump after the first appeal
             [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
         assertEq(core.isSupported(newCourtID, dkID3), true, "dkID3 should be supported by new court");
 
@@ -588,11 +591,12 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             7, // jurors for jump. Minimal number to ensure jump after the first appeal
             [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
         assertEq(core.isSupported(courtID2, dkID2), true, "dkID2 should be supported by Court2");
 
-        (uint96 courtParent, , , , , uint256 courtJurorsForCourtJump) = core.courts(courtID2);
+        (uint96 courtParent, , , , , uint256 courtJurorsForCourtJump, ) = core.courts(courtID2);
         assertEq(courtParent, GENERAL_COURT, "Wrong court parent for court2");
         assertEq(courtJurorsForCourtJump, 7, "Wrong jurors for jump value for court2");
 
@@ -610,11 +614,12 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // jurors for jump. Minimal number to ensure jump after the first appeal
             [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
         assertEq(core.isSupported(courtID3, dkID3), true, "dkID3 should be supported by Court3");
 
-        (courtParent, , , , , courtJurorsForCourtJump) = core.courts(courtID3);
+        (courtParent, , , , , courtJurorsForCourtJump, ) = core.courts(courtID3);
         assertEq(courtParent, courtID2, "Wrong court parent for court3");
         assertEq(courtJurorsForCourtJump, 3, "Wrong jurors for jump value for court3");
 
@@ -1029,7 +1034,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // jurorsForCourtJump - low to ensure jump
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (also child of GENERAL_COURT, making it a sibling of Court2) with feeForJuror = 0.07 ether
@@ -1043,7 +1049,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure Court2's NextRoundSettings to jump to Court3 (a sibling, not parent)
@@ -1157,7 +1164,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (child of Court2)
@@ -1171,7 +1179,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court4 (child of Court3) - so hierarchy is: GENERAL_COURT -> Court2 -> Court3 -> Court4
@@ -1185,7 +1194,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // Low threshold to ensure jump
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure Court4 to jump directly to GENERAL_COURT (skipping Court3 and Court2)
@@ -1276,7 +1286,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (sibling of Court2)
@@ -1290,7 +1301,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure Court2's NextRoundSettings with enabled = FALSE
@@ -1384,7 +1396,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure Court2's NextRoundSettings with invalid jumpCourtID
@@ -1478,7 +1491,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (sibling of Court2)
@@ -1492,7 +1506,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure Court2 to jump to Court3 with custom nbVotes
@@ -1600,7 +1615,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             7, // HIGH jurorsForCourtJump threshold
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure NextRoundSettings with custom nbVotes > jurorsForCourtJump
@@ -1738,7 +1754,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // Low jurorsForCourtJump to ensure jump
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (sibling of Court2) also supporting all 3 DKs
@@ -1752,7 +1769,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // CRITICAL: Configure NextRoundSettings with BOTH jumpDisputeKitID and jumpDisputeKitIDOnCourtJump set
@@ -1899,7 +1917,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 (valid target court)
@@ -1913,7 +1932,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure NextRoundSettings with INVALID jumpDisputeKitID
@@ -2045,7 +2065,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             3, // Low threshold to ensure jump
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Create Court3 supporting ONLY DISPUTE_KIT_CLASSIC (NOT DK2)
@@ -2061,7 +2082,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Verify Court3 does NOT support DK2
@@ -2219,7 +2241,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure NextRoundSettings with jumpCourtID = FORKING_COURT (0)
@@ -2351,7 +2374,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.prank(owner);
@@ -2364,7 +2388,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure NextRoundSettings with jumpDisputeKitID = NULL_DISPUTE_KIT (0)
@@ -2486,7 +2511,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.prank(owner);
@@ -2499,7 +2525,8 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             5,
             [uint256(60), uint256(120), uint256(180), uint256(240)],
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Configure NextRoundSettings with nbVotes = 0

--- a/contracts/test/foundry/KlerosCore_Disputes.t.sol
+++ b/contracts/test/foundry/KlerosCore_Disputes.t.sol
@@ -6,6 +6,7 @@ import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {IArbitratorV2} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassicBase.sol";
 import {IArbitrableV2} from "../../src/arbitration/arbitrables/ArbitrableExample.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import "../../src/libraries/Constants.sol";
 
 /// @title KlerosCore_DisputesTest
@@ -35,7 +36,8 @@ contract KlerosCore_DisputesTest is KlerosCore_TestBase {
             50, // jurors for jump
             newTimesPerPeriod,
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         arbitrable.changeArbitratorExtraData(newExtraData);

--- a/contracts/test/foundry/KlerosCore_Drawing.t.sol
+++ b/contracts/test/foundry/KlerosCore_Drawing.t.sol
@@ -5,6 +5,7 @@ import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
 import {ISortitionModule} from "../../src/arbitration/interfaces/ISortitionModule.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {Vm} from "forge-std/Vm.sol";
 import "../../src/libraries/Constants.sol";
 
@@ -103,7 +104,8 @@ contract KlerosCore_DrawingTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             sortitionExtraData, // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         uint256[] memory children = core.getCourtChildren(GENERAL_COURT);

--- a/contracts/test/foundry/KlerosCore_Execution.t.sol
+++ b/contracts/test/foundry/KlerosCore_Execution.t.sol
@@ -6,10 +6,11 @@ import {KlerosCore, SafeERC20} from "../../src/arbitration/KlerosCore.sol";
 import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
 import {DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassicBase.sol";
 import {IArbitratorV2, IArbitrableV2} from "../../src/arbitration/KlerosCore.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {IERC20} from "../../src/libraries/SafeERC20.sol";
-import "../../src/libraries/Constants.sol";
 import {console} from "forge-std/console.sol";
 import {MaliciousArbitrableMock} from "../../src/test/MaliciousArbitrableMock.sol";
+import "../../src/libraries/Constants.sol";
 
 /// @title KlerosCore_ExecutionTest
 /// @dev Tests for KlerosCore execution, rewards, and ruling finalization
@@ -365,7 +366,8 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             sortitionExtraData, // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         uint256 disputeID = 0;

--- a/contracts/test/foundry/KlerosCore_Governance.t.sol
+++ b/contracts/test/foundry/KlerosCore_Governance.t.sol
@@ -9,6 +9,7 @@ import {DisputeKitSybilResistant} from "../../src/arbitration/dispute-kits/Dispu
 import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
 import {SortitionModuleMock} from "../../src/test/SortitionModuleMock.sol";
 import {RatesConverter} from "../../src/arbitration/RatesConverter.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {PNK} from "../../src/token/PNK.sol";
 import "../../src/libraries/Constants.sol";
 
@@ -390,7 +391,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.expectRevert(KlerosCore.MinStakeLowerThanParentCourt.selector);
@@ -404,7 +406,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.expectRevert(KlerosCore.UnsupportedDisputeKit.selector);
@@ -419,7 +422,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            emptySupportedDK
+            emptySupportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.expectRevert(KlerosCore.InvalidForkingCourtAsParent.selector);
@@ -433,7 +437,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         uint256[] memory badSupportedDK = new uint256[](2);
@@ -450,7 +455,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            badSupportedDK
+            badSupportedDK,
+            ICourtEligibility(address(0))
         );
 
         badSupportedDK[0] = DISPUTE_KIT_CLASSIC;
@@ -466,7 +472,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            badSupportedDK
+            badSupportedDK,
+            ICourtEligibility(address(0))
         );
 
         // Add new DK to check the requirement for classic DK
@@ -486,7 +493,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            badSupportedDK
+            badSupportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.prank(owner);
@@ -504,7 +512,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             0.04 ether,
             50,
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Explicitly convert otherwise it throws
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
         core.createCourt(
             GENERAL_COURT,
@@ -515,7 +524,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         _assertCourtParameters(2, GENERAL_COURT, true, 2000, 20000, 0.04 ether, 50);
@@ -548,7 +558,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             50, // jurors for jump
             [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
             abi.encode(uint256(4)), // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         vm.expectRevert(KlerosCore.OwnerOnly.selector);
@@ -560,7 +571,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             50, // jurors for jump
-            [uint256(10), uint256(20), uint256(30), uint256(40)] // Times per period
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
+            ICourtEligibility(address(0))
         );
         vm.expectRevert(abi.encodeWithSelector(KlerosCore.MinStakeHigherThanChildCourt.selector, newCourtID));
         vm.prank(owner);
@@ -572,7 +584,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             50, // jurors for jump
-            [uint256(10), uint256(20), uint256(30), uint256(40)] // Times per period
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
+            ICourtEligibility(address(0))
         );
         // Min stake of a child became lower than of a parent
         vm.expectRevert(KlerosCore.MinStakeLowerThanParentCourt.selector);
@@ -584,7 +597,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             50, // jurors for jump
-            [uint256(10), uint256(20), uint256(30), uint256(40)] // Times per period
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         vm.prank(owner);
@@ -596,7 +610,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             20000,
             0.04 ether,
             50,
-            [uint256(10), uint256(20), uint256(30), uint256(40)] // Explicitly convert otherwise it throws
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Explicitly convert otherwise it throws
+            ICourtEligibility(address(0))
         );
         core.changeCourtParameters(
             GENERAL_COURT,
@@ -605,7 +620,8 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
             20000, // alpha
             0.04 ether, // fee for juror
             50, // jurors for jump
-            [uint256(10), uint256(20), uint256(30), uint256(40)] // Times per period
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         _assertCourtParameters(GENERAL_COURT, FORKING_COURT, true, 2000, 20000, 0.04 ether, 50);

--- a/contracts/test/foundry/KlerosCore_Initialization.t.sol
+++ b/contracts/test/foundry/KlerosCore_Initialization.t.sol
@@ -10,6 +10,7 @@ import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
 import {BlockHashRNG} from "../../src/rng/BlockHashRNG.sol";
 import {ISortitionModule} from "../../src/arbitration/interfaces/ISortitionModule.sol";
 import {RatesConverter} from "../../src/arbitration/RatesConverter.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {PNK} from "../../src/token/PNK.sol";
 import "../../src/libraries/Constants.sol";
 
@@ -161,7 +162,8 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
             0.03 ether,
             511,
             [uint256(60), uint256(120), uint256(180), uint256(240)], // Explicitly convert otherwise it throws
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.DisputeKitEnabled(GENERAL_COURT, DISPUTE_KIT_CLASSIC, true);

--- a/contracts/test/foundry/KlerosCore_Staking.t.sol
+++ b/contracts/test/foundry/KlerosCore_Staking.t.sol
@@ -5,6 +5,7 @@ import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
 import {ISortitionModule} from "../../src/arbitration/interfaces/ISortitionModule.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {IKlerosCore, KlerosCoreSnapshotProxy} from "../../src/arbitration/view/KlerosCoreSnapshotProxy.sol";
 import "../../src/libraries/Constants.sol";
 import {console} from "forge-std/console.sol";
@@ -183,7 +184,8 @@ contract KlerosCore_StakingTest is KlerosCore_TestBase {
                 50,
                 [uint256(10), uint256(20), uint256(30), uint256(40)],
                 abi.encode(uint256(4)),
-                supportedDK
+                supportedDK,
+                ICourtEligibility(address(0))
             );
             vm.prank(staker1);
             core.setStake(i, 2000);
@@ -540,7 +542,8 @@ contract KlerosCore_StakingTest is KlerosCore_TestBase {
             jurorsForCourtJump,
             timesPerPeriod, // Times per period
             sortitionExtraData, // Sortition extra data
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         uint96 newCourtID = 2;

--- a/contracts/test/foundry/KlerosCore_TestBase.sol
+++ b/contracts/test/foundry/KlerosCore_TestBase.sol
@@ -21,6 +21,7 @@ import {ArbitrableExample, IArbitrableV2} from "../../src/arbitration/arbitrable
 import {DisputeTemplateRegistry} from "../../src/arbitration/DisputeTemplateRegistry.sol";
 import {IKlerosCore, KlerosCoreSnapshotProxy} from "../../src/arbitration/view/KlerosCoreSnapshotProxy.sol";
 import {RatesConverter} from "../../src/arbitration/RatesConverter.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import "../../src/libraries/Constants.sol";
 
 /// @title KlerosCore_TestBase
@@ -215,7 +216,8 @@ abstract contract KlerosCore_TestBase is Test {
             jurorsForJumpValue,
             timesPerPeriod,
             sortitionExtraData,
-            supportedDK
+            supportedDK,
+            ICourtEligibility(address(0))
         );
 
         return uint96(core.getCourtChildren(parent)[core.getCourtChildren(parent).length - 1]);
@@ -237,7 +239,8 @@ abstract contract KlerosCore_TestBase is Test {
             uint256 courtMinStake,
             uint256 courtAlpha,
             uint256 courtFeeForJuror,
-            uint256 courtJurorsForCourtJump
+            uint256 courtJurorsForCourtJump,
+
         ) = core.courts(courtId);
 
         assertEq(courtParent, expectedParent, "Wrong court parent");

--- a/contracts/test/foundry/KlerosCore_Voting.t.sol
+++ b/contracts/test/foundry/KlerosCore_Voting.t.sol
@@ -5,6 +5,7 @@ import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore, IArbitratorV2, IArbitrableV2} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitClassic, DisputeKitClassicBase} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
 import {IDisputeKit} from "../../src/arbitration/interfaces/IDisputeKit.sol";
+import {ICourtEligibility} from "../../src/arbitration/interfaces/ICourtEligibility.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
 import "../../src/libraries/Constants.sol";
 
@@ -22,7 +23,8 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             511, // jurors for jump
-            [uint256(60), uint256(120), uint256(180), uint256(240)] // Times per period
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         vm.prank(staker1);
@@ -58,7 +60,8 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             511, // jurors for jump
-            [uint256(60), uint256(120), uint256(180), uint256(240)] // Times per period
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         vm.expectEmit(true, true, true, true);
@@ -161,7 +164,8 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             511, // jurors for jump
-            [uint256(60), uint256(120), uint256(180), uint256(240)] // Times per period
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         vm.prank(staker1);
@@ -365,7 +369,8 @@ contract KlerosCore_VotingTest is KlerosCore_TestBase {
             10000, // alpha
             0.03 ether, // fee for juror
             511, // jurors for jump
-            [uint256(60), uint256(120), uint256(180), uint256(240)] // Times per period
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            ICourtEligibility(address(0))
         );
 
         vm.prank(staker1);


### PR DESCRIPTION
Intended for the most specialized courts only. Disabled unless `KlerosCore.Court.eligibility` is set to other than `address(0)`. 

Many files are touched by this PR but it's mostly because of the extra parameter returned by the `courts()` getter. 

Previous attempts at tackling this issue: #2232, #1653 

## Overview

`ICourtEligibility` is a **pluggable per-court predicate** that Kleros uses to decide whether an address is allowed to **increase stake** (and, by extension, be in the juror pool for draws) for that court.

### What the interface is
`ICourtEligibility` is intentionally tiny: one view function.

```5:13:contracts/src/arbitration/interfaces/ICourtEligibility.sol
interface ICourtEligibility {
    /// @notice Checks if the juror is eligible to stake or to vote in the court.
    function isEligible(address _juror, uint96 _courtID) external view returns (bool);
}
```

Think of it as: “Given `juror` and `courtID`, should we treat them as eligible for that court’s juror set?”

### Where it’s stored (KlerosCore)
Each `Court` has an `eligibility` field pointing to a contract that implements `ICourtEligibility`.

```40:52:contracts/src/arbitration/KlerosCore.sol
struct Court {
    // ...
    ICourtEligibility eligibility; // The eligibility predicate for the court.
    // ...
}
```

It’s set/updated by governance when courts are created/modified:

- `createCourt(..., ICourtEligibility _eligibility)` sets `court.eligibility = _eligibility`
- `changeCourtParameters(..., ICourtEligibility _eligibility)` updates it

### Where it’s enforced (SortitionModule via KlerosCore)
The enforcement point is **staking validation** inside the SortitionModule, called from `KlerosCore._setStake()`.

In `SortitionModule._validateStake`, eligibility is only checked on **stake increases**:

```300:305:contracts/src/arbitration/SortitionModule.sol
if (stakeIncrease) {
    // Check if the juror is eligible to stake in the court.
    if (_eligibility != ICourtEligibility(address(0)) && !_eligibility.isEligible(_account, _courtID)) {
        return (0, 0, StakingResult.NotEligibleForStaking);
    }
    // ...
}
```

Then `KlerosCore` converts that staking result into a revert:

```1411:1453:contracts/src/arbitration/KlerosCore.sol
(uint256 pnkDeposit, uint256 pnkWithdrawal, StakingResult stakingResult) = sortitionModule.validateStake(
    _account,
    _courtID,
    _newStake,
    _noDelay,
    courts[_courtID].eligibility
);
// ...
if (_result == StakingResult.NotEligibleForStaking) revert NotEligibleForStaking();
```

So the runtime behavior is:

- If `court.eligibility == address(0)`: **no extra eligibility restriction** (everyone can stake, subject to other rules).
- Else: stake increases require `eligibility.isEligible(account, courtID) == true`, otherwise revert `NotEligibleForStaking`.

### How dispute kits relate
Dispute kits can *also* implement `ICourtEligibility`, but they don’t have to. When they do, it lets the court’s eligibility predicate be “whatever logic the dispute kit wants.”

Examples:

- **`DisputeKitGated` / `DisputeKitGatedShutter`** implement `isEligible` based on token-gate configuration for that `courtID` (ERC721 list + ERC1155 tokenId lists).
- **`DisputeKitSybilResistant`** implements `isEligible` based on Proof of Humanity, ignoring `_courtID`.

```71:74:contracts/src/arbitration/dispute-kits/DisputeKitSybilResistant.sol
function isEligible(address _juror, uint96 /* _courtID */) external view override returns (bool) {
    return poh.isHuman(_juror);
}
```

So the dispute kit is effectively being reused as a **court policy module** for staking eligibility.

### The mental model / flow
- **KlerosCore** owns court config (including the pointer to an eligibility contract).
- **SortitionModule** is the gatekeeper for staking changes and enforces eligibility on stake increases by calling `eligibility.isEligible`.
- **Dispute kits** are one possible implementation of that eligibility predicate (token gating, sybil resistance, etc.).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily introduces the `ICourtEligibility` interface and its integration across various contracts and tests to enforce eligibility checks for jurors in staking processes.

### Detailed summary
- Added `ICourtEligibility` interface with `isEligible` function.
- Integrated eligibility checks in `SortitionModule` and `KlerosCore`.
- Updated dispute kits to implement eligibility logic.
- Modified tests to cover eligibility scenarios and edge cases.
- Renamed and adjusted existing tests to reflect new eligibility requirements.

> The following files were skipped due to too many changes: `contracts/test/arbitration/helpers/dispute-kit-gated-common.ts`, `contracts/src/arbitration/dispute-kits/DisputeKitGated.sol`, `contracts/src/arbitration/dispute-kits/DisputeKitGatedShutter.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Courts support per‑court eligibility predicates surfaced in events and enforced during staking and juror draws.
  * Token‑gated courts now support multiple ERC721/ERC1155 collections and token‑ID gating with query APIs.
  * Sybil‑resistant mode exposes human‑eligibility checks; staking can yield an explicit "not eligible" outcome.

* **Tests**
  * Test suites updated to provide and assert the new eligibility parameter and the expanded token‑gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->