### PR TITLE
fix(gateway): replace transfer() with call() in withdrawFees

### DIFF
--- a/contracts/src/gateway/ForeignGateway.sol
+++ b/contracts/src/gateway/ForeignGateway.sol
@@ -227,7 +227,8 @@ contract ForeignGateway is IForeignGateway, UUPSProxiable, Initializable {
 
         uint256 amount = dispute.paid;
         dispute.paid = 0;
-        payable(dispute.relayer).transfer(amount);
+        (bool success, ) = payable(dispute.relayer).call{value: amount}("");
+        if (!success) revert TransferFailed();
     }
 
     // ************************************* //
@@ -283,4 +284,5 @@ contract ForeignGateway is IForeignGateway, UUPSProxiable, Initializable {
     error DisputeDoesNotExist();
     error CannotRuleTwice();
     error NotRuledYet();
+    error TransferFailed();
 }


### PR DESCRIPTION
## Summary
  Replace `.transfer()` with `.call{value:}()` in `ForeignGateway.withdrawFees()`

## Problem
`.transfer()` only forwards 2300 gas. If the relayer is a smart contract wallet (e.g., Gnosis Safe, automated relayer service), the fee  withdrawal will fail.

## Solution
Use `.call{value:}()` which forwards all available gas.

## Changes
- `contracts/src/gateway/ForeignGateway.sol` (3 lines)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ForeignGateway` contract by improving the payment transfer mechanism when resolving disputes, ensuring it handles failures more gracefully.

### Detailed summary
- Replaced direct transfer with a `call` method for transferring `amount` to `dispute.relayer`.
- Added a check for the success of the transfer; if it fails, it reverts with a `TransferFailed()` error.
- Introduced a new error `TransferFailed()` for handling transfer failures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fee withdrawal error handling with improved transfer mechanism and explicit failure notifications for unsuccessful withdrawal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->