### PR TITLE
feat: classic-university-dk-support

### DIFF
--- a/subgraph/core/subgraph.template.yaml
+++ b/subgraph/core/subgraph.template.yaml
@@ -139,6 +139,8 @@ dataSources:
       abis:
         - name: DisputeKitClassicUniversity
           file: ../../contracts/deployments/_PLACEHOLDER_/DisputeKitClassicUniversity.json
+        - name: DisputeKitClassic # Required on Alchemy
+          file: ../../contracts/deployments/_PLACEHOLDER_/DisputeKitClassic.json
         - name: KlerosCore
           file: ../../contracts/deployments/_PLACEHOLDER_/KlerosCore.json
       eventHandlers:

--- a/subgraph/core/subgraph.yaml
+++ b/subgraph/core/subgraph.yaml
@@ -140,6 +140,8 @@ dataSources:
       abis:
         - name: DisputeKitClassicUniversity
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/DisputeKitClassicUniversity.json
+        - name: DisputeKitClassic # Required on Alchemy
+          file: ../../contracts/deployments/arbitrumSepoliaDevnet/DisputeKitClassic.json
         - name: KlerosCore
           file: ../../contracts/deployments/arbitrumSepoliaDevnet/KlerosCore.json
       eventHandlers:

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/kleros-v2-subgraph",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "drtVersion": "2.0.0--rc.2",
   "license": "MIT",
   "scripts": {

--- a/web/src/actions/commit/builders/classicUniversity.builder.ts
+++ b/web/src/actions/commit/builders/classicUniversity.builder.ts
@@ -1,0 +1,29 @@
+import { getVoteKey } from "actions/helpers/storage/getVoteKey";
+
+import { disputeKitClassicUniversityAbi, disputeKitClassicUniversityAddress } from "hooks/contracts/generated";
+import { hashVote } from "utils/crypto/hashVote";
+
+import { ClassicUniversityCommitDeps } from "../deps";
+import { ClassicUniversityCommitParams } from "../params";
+
+import { defineCommitBuilder } from "./baseBuilder";
+
+export const classicUniversityCommitBuilder = defineCommitBuilder({
+  build: async (params: ClassicUniversityCommitParams, context, deps: ClassicUniversityCommitDeps) => {
+    const { disputeId, voteIds, choice, salt, roundIndex } = params;
+    const { chain, account } = context;
+
+    const key = getVoteKey(disputeId, roundIndex, voteIds);
+    deps.storeCommitData(key, { choice, salt });
+
+    const commit = hashVote(choice, salt);
+    return {
+      account,
+      address: disputeKitClassicUniversityAddress[chain.id],
+      abi: disputeKitClassicUniversityAbi,
+      functionName: "castCommit",
+      args: [disputeId, voteIds, commit],
+      chain,
+    };
+  },
+});

--- a/web/src/actions/commit/builders/index.ts
+++ b/web/src/actions/commit/builders/index.ts
@@ -3,9 +3,10 @@ import { DisputeKits } from "src/consts";
 import { CommitContext } from "../context";
 import { CommitParams } from "../params";
 
-import { CommitBuilder } from "./baseBuilder";
 import { argentinaConsumerProtectionCommitBuilder } from "./argentinaConsumerProtection.builder";
+import { CommitBuilder } from "./baseBuilder";
 import { classicCommitBuilder } from "./classic.builder";
+import { classicUniversityCommitBuilder } from "./classicUniversity.builder";
 import { gatedCommitBuilder } from "./gated.builder";
 import { gatedShutterCommitBuilder } from "./gatedShutter.builder";
 import { shutterCommitBuilder } from "./shutter.builder";
@@ -23,6 +24,7 @@ const builders: Record<DisputeKits, CommitBuilder> = {
   [DisputeKits.Gated]: gatedCommitBuilder,
   [DisputeKits.GatedShutter]: gatedShutterCommitBuilder,
   [DisputeKits.ArgentinaConsumerProtection]: argentinaConsumerProtectionCommitBuilder,
+  [DisputeKits.ClassicUniversity]: classicUniversityCommitBuilder,
 };
 
 /**

--- a/web/src/actions/commit/deps.ts
+++ b/web/src/actions/commit/deps.ts
@@ -32,12 +32,17 @@ export interface GatedShutterCommitDeps extends BaseCommitBuilderDeps {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ArgentinaConsumerProtectionCommitDeps extends BaseCommitBuilderDeps {}
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ClassicUniversityCommitDeps extends BaseCommitBuilderDeps {}
+
 export type CommitBuilderDeps =
   | ClassicCommitDeps
   | ShutterCommitDeps
   | GatedCommitDeps
   | GatedShutterCommitDeps
-  | ArgentinaConsumerProtectionCommitDeps;
+  | ArgentinaConsumerProtectionCommitDeps
+  | ClassicUniversityCommitDeps;
+
 export const defaultCommitBuilderDeps: BaseCommitBuilderDeps = {
   storeCommitData,
 };

--- a/web/src/actions/commit/params.ts
+++ b/web/src/actions/commit/params.ts
@@ -33,9 +33,14 @@ export interface ArgentinaConsumerProtectionCommitParams extends BaseCommitParam
   type: DisputeKits.ArgentinaConsumerProtection;
 }
 
+export interface ClassicUniversityCommitParams extends BaseCommitParams {
+  type: DisputeKits.ClassicUniversity;
+}
+
 export type CommitParams =
   | ClassicCommitParams
   | ShutterCommitParams
   | GatedCommitParams
   | GatedShutterCommitParams
-  | ArgentinaConsumerProtectionCommitParams;
+  | ArgentinaConsumerProtectionCommitParams
+  | ClassicUniversityCommitParams;

--- a/web/src/actions/fundAppeal/builders/classicUniversity.builder.ts
+++ b/web/src/actions/fundAppeal/builders/classicUniversity.builder.ts
@@ -1,0 +1,22 @@
+import { disputeKitClassicUniversityAbi, disputeKitClassicUniversityAddress } from "hooks/contracts/generated";
+
+import { ClassicUniversityFundAppealParams } from "../params";
+
+import { defineFundAppealBuilder } from "./baseBuilder";
+
+export const classicUniversityFundAppealBuilder = defineFundAppealBuilder({
+  build: async (params: ClassicUniversityFundAppealParams, context) => {
+    const { disputeId, choice, fundAmount } = params;
+    const { chain, account } = context;
+
+    return {
+      account,
+      address: disputeKitClassicUniversityAddress[chain.id],
+      abi: disputeKitClassicUniversityAbi,
+      functionName: "fundAppeal",
+      args: [disputeId, choice],
+      value: fundAmount,
+      chain,
+    };
+  },
+});

--- a/web/src/actions/fundAppeal/builders/index.ts
+++ b/web/src/actions/fundAppeal/builders/index.ts
@@ -3,9 +3,10 @@ import { DisputeKits } from "src/consts";
 import { FundAppealContext } from "../context";
 import { FundAppealParams } from "../params";
 
-import { FundAppealBuilder } from "./baseBuilder";
 import { argentinaConsumerProtectionFundAppealBuilder } from "./argentinaConsumerProtection.builder";
+import { FundAppealBuilder } from "./baseBuilder";
 import { classicFundAppealBuilder } from "./classic.builder";
+import { classicUniversityFundAppealBuilder } from "./classicUniversity.builder";
 import { gatedFundAppealBuilder } from "./gated.builder";
 import { gatedShutterFundAppealBuilder } from "./gatedShutter.builder";
 import { shutterFundAppealBuilder } from "./shutter.builder";
@@ -23,6 +24,7 @@ const builders: Record<DisputeKits, FundAppealBuilder> = {
   [DisputeKits.Gated]: gatedFundAppealBuilder,
   [DisputeKits.GatedShutter]: gatedShutterFundAppealBuilder,
   [DisputeKits.ArgentinaConsumerProtection]: argentinaConsumerProtectionFundAppealBuilder,
+  [DisputeKits.ClassicUniversity]: classicUniversityFundAppealBuilder,
 };
 
 /**

--- a/web/src/actions/fundAppeal/params.ts
+++ b/web/src/actions/fundAppeal/params.ts
@@ -27,9 +27,14 @@ export interface ArgentinaConsumerProtectionFundAppealParams extends BaseFundApp
   type: DisputeKits.ArgentinaConsumerProtection;
 }
 
+export interface ClassicUniversityFundAppealParams extends BaseFundAppealParams {
+  type: DisputeKits.ClassicUniversity;
+}
+
 export type FundAppealParams =
   | ClassicFundAppealParams
   | ShutterFundAppealParams
   | GatedFundAppealParams
   | GatedShutterFundAppealParams
-  | ArgentinaConsumerProtectionFundAppealParams;
+  | ArgentinaConsumerProtectionFundAppealParams
+  | ClassicUniversityFundAppealParams;

--- a/web/src/actions/reveal/builders/classicUniversity.builder.ts
+++ b/web/src/actions/reveal/builders/classicUniversity.builder.ts
@@ -1,0 +1,21 @@
+import { disputeKitClassicUniversityAbi, disputeKitClassicUniversityAddress } from "hooks/contracts/generated";
+
+import { ClassicUniversityRevealParams } from "../params";
+
+import { defineRevealBuilder } from "./baseBuilder";
+
+export const classicUniversityRevealBuilder = defineRevealBuilder({
+  build: async (params: ClassicUniversityRevealParams, context) => {
+    const { disputeId, voteIds, choice, salt, justification } = params;
+    const { chain, account } = context;
+
+    return {
+      account,
+      address: disputeKitClassicUniversityAddress[chain.id],
+      abi: disputeKitClassicUniversityAbi,
+      functionName: "castVote",
+      args: [disputeId, voteIds, choice, salt, justification],
+      chain,
+    };
+  },
+});

--- a/web/src/actions/reveal/builders/index.ts
+++ b/web/src/actions/reveal/builders/index.ts
@@ -3,9 +3,10 @@ import { DisputeKits } from "src/consts";
 import { RevealContext } from "../context";
 import { RevealParams } from "../params";
 
-import { RevealBuilder } from "./baseBuilder";
 import { argentinaConsumerProtectionRevealBuilder } from "./argentinaConsumerProtection.builder";
+import { RevealBuilder } from "./baseBuilder";
 import { classicRevealBuilder } from "./classic.builder";
+import { classicUniversityRevealBuilder } from "./classicUniversity.builder";
 import { gatedRevealBuilder } from "./gated.builder";
 import { gatedShutterRevealBuilder } from "./gatedShutter.builder";
 import { shutterRevealBuilder } from "./shutter.builder";
@@ -23,6 +24,7 @@ const builders: Record<DisputeKits, RevealBuilder> = {
   [DisputeKits.Gated]: gatedRevealBuilder,
   [DisputeKits.GatedShutter]: gatedShutterRevealBuilder,
   [DisputeKits.ArgentinaConsumerProtection]: argentinaConsumerProtectionRevealBuilder,
+  [DisputeKits.ClassicUniversity]: classicUniversityRevealBuilder,
 };
 
 /**

--- a/web/src/actions/reveal/params.ts
+++ b/web/src/actions/reveal/params.ts
@@ -36,12 +36,17 @@ export interface ArgentinaConsumerProtectionRevealParams extends BaseRevealParam
   type: DisputeKits.ArgentinaConsumerProtection;
 }
 
+export interface ClassicUniversityRevealParams extends BaseRevealParams {
+  type: DisputeKits.ClassicUniversity;
+}
+
 export type RevealParams =
   | ClassicRevealParams
   | ShutterRevealParams
   | GatedRevealParams
   | GatedShutterRevealParams
-  | ArgentinaConsumerProtectionRevealParams;
+  | ArgentinaConsumerProtectionRevealParams
+  | ClassicUniversityRevealParams;
 
 export type ResolveRevealParams = DistributiveOmit<PartialBy<RevealParams, "justification">, "choice" | "salt">;
 export type ResolveRevealContext = {

--- a/web/src/actions/vote/builders/classicUniversity.builder.ts
+++ b/web/src/actions/vote/builders/classicUniversity.builder.ts
@@ -1,0 +1,21 @@
+import { disputeKitClassicUniversityAbi, disputeKitClassicUniversityAddress } from "hooks/contracts/generated";
+
+import { ClassicUniversityVoteParams } from "../params";
+
+import { defineVoteBuilder } from "./baseBuilder";
+
+export const classicUniversityVoteBuilder = defineVoteBuilder({
+  build: async (params: ClassicUniversityVoteParams, context) => {
+    const { disputeId, voteIds, choice, salt, justification } = params;
+    const { chain, account } = context;
+
+    return {
+      account,
+      address: disputeKitClassicUniversityAddress[chain.id],
+      abi: disputeKitClassicUniversityAbi,
+      functionName: "castVote",
+      args: [disputeId, voteIds, choice, salt, justification],
+      chain,
+    };
+  },
+});

--- a/web/src/actions/vote/builders/index.ts
+++ b/web/src/actions/vote/builders/index.ts
@@ -3,9 +3,10 @@ import { DisputeKits } from "src/consts";
 import { VoteContext } from "../context";
 import { VoteParams } from "../params";
 
-import { VoteBuilder } from "./baseBuilder";
 import { argentinaConsumerProtectionVoteBuilder } from "./argentinaConsumerProtection.builder";
+import { VoteBuilder } from "./baseBuilder";
 import { classicVoteBuilder } from "./classic.builder";
+import { classicUniversityVoteBuilder } from "./classicUniversity.builder";
 import { gatedVoteBuilder } from "./gated.builder";
 import { gatedShutterVoteBuilder } from "./gatedShutter.builder";
 import { shutterVoteBuilder } from "./shutter.builder";
@@ -25,6 +26,7 @@ const builders: Record<DisputeKits, VoteBuilder> = {
   [DisputeKits.Shutter]: shutterVoteBuilder,
   [DisputeKits.GatedShutter]: gatedShutterVoteBuilder,
   [DisputeKits.ArgentinaConsumerProtection]: argentinaConsumerProtectionVoteBuilder,
+  [DisputeKits.ClassicUniversity]: classicUniversityVoteBuilder,
 };
 
 /**

--- a/web/src/actions/vote/params.ts
+++ b/web/src/actions/vote/params.ts
@@ -29,9 +29,14 @@ export interface ArgentinaConsumerProtectionVoteParams extends BaseVoteParams {
   type: DisputeKits.ArgentinaConsumerProtection;
 }
 
+export interface ClassicUniversityVoteParams extends BaseVoteParams {
+  type: DisputeKits.ClassicUniversity;
+}
+
 export type VoteParams =
   | ClassicVoteParams
   | ShutterVoteParams
   | GatedVoteParams
   | GatedShutterVoteParams
-  | ArgentinaConsumerProtectionVoteParams;
+  | ArgentinaConsumerProtectionVoteParams
+  | ClassicUniversityVoteParams;

--- a/web/src/components/AddressExplorerLink.tsx
+++ b/web/src/components/AddressExplorerLink.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Address } from "viem";
+
+import { shortenAddress } from "utils/shortenAddress";
+
+import { getAddressExplorerLink } from "src/utils";
+
+import { ExternalLink } from "./ExternalLink";
+
+interface IAddressExplorerLink {
+  address: Address;
+}
+
+/**
+ * @description Renders a link of the Address to the relevant explorer
+ * @param address Address to be displayed
+ */
+const AddressExplorerLink: React.FC<IAddressExplorerLink> = ({ address }) => {
+  return (
+    <ExternalLink to={getAddressExplorerLink(address)} target="_blank" rel="noopener noreferrer">
+      {shortenAddress(address)}
+    </ExternalLink>
+  );
+};
+export default AddressExplorerLink;

--- a/web/src/components/DisputeFeatures/Features/UniversityVote.tsx
+++ b/web/src/components/DisputeFeatures/Features/UniversityVote.tsx
@@ -1,0 +1,69 @@
+import React, { Fragment } from "react";
+import styled from "styled-components";
+
+import { useTranslation } from "react-i18next";
+
+import NewTabIcon from "svgs/icons/new-tab.svg";
+
+import { Features } from "consts/disputeFeature";
+import { useReadDisputeKitClassicUniversityInstructor } from "hooks/contracts/generated";
+import { shortenAddress } from "utils/shortenAddress";
+
+import { getAddressExplorerLink } from "src/utils";
+
+import { ExternalLink } from "components/ExternalLink";
+import { StyledSkeleton } from "components/StyledSkeleton";
+import WithHelpTooltip from "components/WithHelpTooltip";
+
+import { RadioInput, StyledRadio } from ".";
+
+const InstructorContainer = styled.div`
+  padding-left: 32px;
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.secondaryText};
+`;
+
+const InstructorLabel = styled.span`
+  color: ${({ theme }) => theme.primaryText};
+`;
+
+const StyledNewTabIcon = styled(NewTabIcon)`
+  width: 14px;
+  height: 14px;
+`;
+
+const UniversityVote: React.FC<RadioInput> = (props) => {
+  const { t } = useTranslation();
+
+  const { data: instructorAddress, isLoading: isLoadingInstructor } = useReadDisputeKitClassicUniversityInstructor({
+    query: { enabled: props.checked },
+  });
+
+  return (
+    <Fragment key={Features.UniversityVote}>
+      <WithHelpTooltip tooltipMsg={t("features.university_vote_tooltip")}>
+        <StyledRadio label={t("features.university_vote")} small {...props} />
+      </WithHelpTooltip>
+      {props.checked && isLoadingInstructor ? (
+        <InstructorContainer>
+          <InstructorLabel>{t("features.university_instructor")}:</InstructorLabel>
+          <StyledSkeleton width="120px" height="16px" />
+        </InstructorContainer>
+      ) : null}
+      {props.checked && instructorAddress ? (
+        <InstructorContainer>
+          <InstructorLabel>{t("features.university_instructor")}:</InstructorLabel>
+          <ExternalLink to={getAddressExplorerLink(instructorAddress)} target="_blank" rel="noopener noreferrer">
+            {shortenAddress(instructorAddress)} <StyledNewTabIcon />
+          </ExternalLink>
+        </InstructorContainer>
+      ) : null}
+    </Fragment>
+  );
+};
+
+export default UniversityVote;

--- a/web/src/components/DisputeFeatures/Features/index.tsx
+++ b/web/src/components/DisputeFeatures/Features/index.tsx
@@ -13,6 +13,7 @@ import ArgentinaConsumerProtection from "./ArgentinaConsumerProtection";
 import ClassicVote from "./ClassicVote";
 import GatedErc1155 from "./GatedErc1155";
 import GatedErc20 from "./GatedErc20";
+import UniversityVote from "./UniversityVote";
 
 export type RadioInput = {
   name: string;
@@ -47,6 +48,7 @@ const ClassicEligibilityComponent: React.FC<RadioInput> = (props) => {
 export const FeatureUIs: Record<Features, FeatureUI> = {
   [Features.ShieldedVote]: ShieldedVoteComponent,
   [Features.ClassicVote]: ClassicVote,
+  [Features.UniversityVote]: UniversityVote,
   [Features.ClassicEligibility]: ClassicEligibilityComponent,
   [Features.GatedErc20]: GatedErc20,
   [Features.GatedErc1155]: GatedErc1155,

--- a/web/src/consts/disputeFeature.ts
+++ b/web/src/consts/disputeFeature.ts
@@ -1,3 +1,5 @@
+import { isProductionDeployment } from "./index";
+
 export enum Group {
   Voting = "Voting",
   Eligibility = "Eligibility",
@@ -8,6 +10,7 @@ export enum Group {
 export enum Features {
   ShieldedVote = "shieldedVote",
   ClassicVote = "classicVote",
+  UniversityVote = "universityVote",
   ClassicEligibility = "classicEligibility",
   GatedErc20 = "gatedErc20",
   GatedErc1155 = "gatedErc1155",
@@ -38,7 +41,7 @@ export type DisputeKits = DisputeKit[];
 // NOTE: a feature cannot appear in more than one Group
 // DEV: the order of features in array , determine the order the radios appear on UI
 export const featureGroups: FeatureGroups = {
-  [Group.Voting]: [Features.ClassicVote, Features.ShieldedVote],
+  [Group.Voting]: [Features.ClassicVote, Features.ShieldedVote, Features.UniversityVote],
   [Group.Eligibility]: [
     Features.ClassicEligibility,
     Features.GatedErc20,
@@ -78,7 +81,34 @@ export const disputeKits: DisputeKits = [
     featureSets: [[Features.ClassicVote, Features.ArgentinaConsumerProtection]],
     type: "general",
   },
+  {
+    id: 6,
+    featureSets: [[Features.UniversityVote, Features.ClassicEligibility]],
+    type: "general",
+  },
 ];
+
+// excluded on mainnet, we can later update it to an array if we want to have more deployment specific kits
+const UNIVERSITY_DISPUTE_KIT_ID = 6;
+
+/**
+ * Dispute kits available for the current deployment.
+ * University DK is excluded on mainnet.
+ */
+export const getDisputeKitsForDeployment = (): DisputeKits =>
+  isProductionDeployment() ? disputeKits.filter((kit) => kit.id !== UNIVERSITY_DISPUTE_KIT_ID) : disputeKits;
+
+/**
+ * Feature groups for the current deployment.
+ * University vote is excluded on mainnet.
+ */
+export const getFeatureGroupsForDeployment = (): FeatureGroups =>
+  isProductionDeployment()
+    ? {
+        ...featureGroups,
+        [Group.Voting]: featureGroups[Group.Voting].filter((f) => f !== Features.UniversityVote),
+      }
+    : featureGroups;
 
 /** Canonical string for a feature set (order-independent) */
 function normalize(features: Features[]): string {

--- a/web/src/consts/index.ts
+++ b/web/src/consts/index.ts
@@ -44,13 +44,15 @@ export enum DisputeKits {
   Shutter = "Shutter",
   Gated = "Token Gated",
   GatedShutter = "Token Gated Shutter",
+  ClassicUniversity = "Classic University",
   ArgentinaConsumerProtection = "Argentina Consumer Protection",
 }
 
 export const isClassicLikeDisputeKit = (disputeKit?: DisputeKits): boolean =>
   disputeKit === DisputeKits.Classic ||
   disputeKit === DisputeKits.Gated ||
-  disputeKit === DisputeKits.ArgentinaConsumerProtection;
+  disputeKit === DisputeKits.ArgentinaConsumerProtection ||
+  disputeKit === DisputeKits.ClassicUniversity;
 
 export const isShutterLikeDisputeKit = (disputeKit?: DisputeKits): boolean =>
   disputeKit === DisputeKits.Shutter || disputeKit === DisputeKits.GatedShutter;

--- a/web/src/hooks/useDisputeKitAddresses.ts
+++ b/web/src/hooks/useDisputeKitAddresses.ts
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useChainId } from "wagmi";
 
-import { DisputeKits } from "consts/index";
+import { DisputeKits, isProductionDeployment } from "consts/index";
 
 interface UseDisputeKitAddressesParams {
   disputeKitAddress?: string;
@@ -14,13 +14,28 @@ interface UseDisputeKitAddressesAllReturn {
   error: string | null;
 }
 
-const DISPUTE_KIT_CONFIG = {
+const BASE_DISPUTE_KIT_CONFIG: Record<DisputeKits, string> = {
   [DisputeKits.Classic]: "disputeKitClassicAddress",
   [DisputeKits.Shutter]: "disputeKitShutterAddress",
   [DisputeKits.Gated]: "disputeKitGatedAddress",
   [DisputeKits.GatedShutter]: "disputeKitGatedShutterAddress",
   [DisputeKits.ArgentinaConsumerProtection]: "disputeKitGatedArgentinaConsumerProtectionAddress",
-} as const;
+  [DisputeKits.ClassicUniversity]: "disputeKitClassicUniversityAddress",
+};
+
+/** Dispute kits available in production (ClassicUniversity is devnet only) */
+type ProductionDisputeKits = Exclude<DisputeKits, DisputeKits.ClassicUniversity>;
+
+type DisputeKitConfigMap = Record<DisputeKits, string> | Record<ProductionDisputeKits, string>;
+
+/** Returns the dispute kits config based on deployment */
+const getDisputeKitConfig = (): DisputeKitConfigMap => {
+  if (isProductionDeployment()) {
+    const { [DisputeKits.ClassicUniversity]: _, ...restKits } = BASE_DISPUTE_KIT_CONFIG;
+    return restKits as Record<ProductionDisputeKits, string>;
+  }
+  return { ...BASE_DISPUTE_KIT_CONFIG };
+};
 
 /**
  * Hook to get dispute kit name based on address
@@ -32,6 +47,7 @@ export const useDisputeKitAddresses = ({ disputeKitAddress }: UseDisputeKitAddre
   const [disputeKitName, setDisputeKitName] = useState<DisputeKits | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const disputeKitConfig = useMemo(() => getDisputeKitConfig(), []);
 
   useEffect(() => {
     const loadDisputeKitName = async () => {
@@ -58,7 +74,7 @@ export const useDisputeKitAddresses = ({ disputeKitAddress }: UseDisputeKitAddre
           const generatedContracts = await import("hooks/contracts/generated");
 
           // Check each dispute kit to see if the address matches
-          for (const [humanName, contractKey] of Object.entries(DISPUTE_KIT_CONFIG)) {
+          for (const [humanName, contractKey] of Object.entries(disputeKitConfig)) {
             const addressMapping = generatedContracts[contractKey as keyof typeof generatedContracts];
 
             if (addressMapping && typeof addressMapping === "object" && chainId in addressMapping) {
@@ -90,7 +106,7 @@ export const useDisputeKitAddresses = ({ disputeKitAddress }: UseDisputeKitAddre
     };
 
     loadDisputeKitName();
-  }, [chainId, disputeKitAddress]);
+  }, [chainId, disputeKitAddress, disputeKitConfig]);
 
   return {
     disputeKitName,
@@ -108,6 +124,7 @@ export const useDisputeKitAddressesAll = (): UseDisputeKitAddressesAllReturn => 
   const [availableDisputeKits, setAvailableDisputeKits] = useState<Record<string, DisputeKits>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const disputeKitConfig = useMemo(() => getDisputeKitConfig(), []);
 
   useEffect(() => {
     const loadAllDisputeKitAddresses = async () => {
@@ -128,7 +145,7 @@ export const useDisputeKitAddressesAll = (): UseDisputeKitAddressesAllReturn => 
           const newAvailableDisputeKits: Record<string, DisputeKits> = {};
 
           // Iterate through all dispute kits and get their addresses
-          for (const [humanName, contractKey] of Object.entries(DISPUTE_KIT_CONFIG)) {
+          for (const [humanName, contractKey] of Object.entries(disputeKitConfig)) {
             const addressMapping = generatedContracts[contractKey as keyof typeof generatedContracts];
 
             if (addressMapping && typeof addressMapping === "object" && chainId in addressMapping) {
@@ -154,7 +171,7 @@ export const useDisputeKitAddressesAll = (): UseDisputeKitAddressesAllReturn => 
     };
 
     loadAllDisputeKitAddresses();
-  }, [chainId]);
+  }, [chainId, disputeKitConfig]);
 
   return {
     availableDisputeKits,

--- a/web/src/hooks/useVotingContext.tsx
+++ b/web/src/hooks/useVotingContext.tsx
@@ -10,6 +10,7 @@ import {
   useReadDisputeKitGatedIsVoteActive,
   useReadDisputeKitGatedShutterIsVoteActive,
   useReadDisputeKitGatedArgentinaConsumerProtectionIsVoteActive,
+  useReadDisputeKitClassicUniversityIsVoteActive,
 } from "hooks/contracts/generated";
 import { useDisputeDetailsQuery } from "hooks/queries/useDisputeDetailsQuery";
 import { useDrawQuery } from "hooks/queries/useDrawQuery";
@@ -90,6 +91,14 @@ export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({
     args: hookArgs,
   });
 
+  const classicUniversityVoteResult = useReadDisputeKitClassicUniversityIsVoteActive({
+    query: {
+      enabled: isEnabled && disputeKitName === DisputeKits.ClassicUniversity,
+      refetchInterval: REFETCH_INTERVAL,
+    },
+    args: hookArgs,
+  });
+
   // Add a return for each DisputeKit
   const hasVoted = useMemo(() => {
     switch (disputeKitName) {
@@ -103,6 +112,8 @@ export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({
         return gatedShutterVoteResult.data;
       case DisputeKits.ArgentinaConsumerProtection:
         return argentinaConsumerProtectionVoteResult.data;
+      case DisputeKits.ClassicUniversity:
+        return classicUniversityVoteResult.data;
       default:
         return undefined;
     }
@@ -113,6 +124,7 @@ export const VotingContextProvider: React.FC<{ children: React.ReactNode }> = ({
     gatedVoteResult.data,
     gatedShutterVoteResult.data,
     argentinaConsumerProtectionVoteResult.data,
+    classicUniversityVoteResult.data,
   ]);
 
   const wasDrawn = useMemo(() => !isUndefined(drawData) && drawData.draws.length > 0, [drawData]);

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -32,6 +32,7 @@
     "reveal_your_vote": "Reveal Your Vote",
     "justify_and_reveal": "Justify & Reveal",
     "draw": "Draw",
+    "set_jurors": "Set Jurors",
     "rule": "Rule",
     "pass_period": "Pass Period",
     "pass_phase": "Pass Phase",
@@ -63,6 +64,7 @@
       "amount_to_withdraw": "Amount to withdraw",
       "amount_to_fund": "Amount to fund",
       "juror_address": "Juror Address",
+      "juror_addresses_comma_separated": "0x123..., 0x456... (comma-separated)",
       "search_evidence": "Search evidence by number, word, or submitter",
       "freelance_example": "eg. Freelance",
       "alice_bob_example": "eg. Freelance work disagreement between Alice and Bob",
@@ -447,7 +449,8 @@
   },
   "maintenance": {
     "jurors_drawn_in_drawing_phase": "Jurors can be drawn in drawing phase.",
-    "pass_phase_here": "Pass phase <anchor>here</anchor>."
+    "pass_phase_here": "Pass phase <anchor>here</anchor>.",
+    "jurors_in_queue": "Jurors in queue: {{count}}"
   },
   "phase": {
     "label": "Phase: {{phase}}",
@@ -635,7 +638,10 @@
     "hidden_votes_tooltip": "The jurors votes are hidden. Nobody can see them before the voting period completes. It takes place in a two-step commit-reveal process.",
     "non_hidden_votes_tooltip": "The jurors votes are not hidden. Everybody can see the justification and voted choice before the voting period completes.",
     "argentina_consumer_protection": "Argentina Consumer Protection",
-    "argentina_consumer_protection_tooltip": "Jurors must hold either an accredited professional token or an accredited consumer protection lawyer token to participate. At least one drawn juror must hold the consumer protection lawyer token."
+    "argentina_consumer_protection_tooltip": "Jurors must hold either an accredited professional token or an accredited consumer protection lawyer token to participate. At least one drawn juror must hold the consumer protection lawyer token.",
+    "university_vote": "University (Instructor-Selected Jurors)",
+    "university_vote_tooltip": "Designed for educational use. An instructor pre-selects the jurors instead of random sortition. Uses standard commit-reveal voting like the classic dispute kit.",
+    "university_instructor": "Instructor"
   },
   "swap": {
     "claimed_testnet": "Claimed: {{amount}} PNK (Testnet)",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -32,6 +32,7 @@
     "reveal_your_vote": "Revelar tu voto",
     "justify_and_reveal": "Justificar y revelar",
     "draw": "Sortear",
+    "set_jurors": "Establecer jurados",
     "rule": "Decidir",
     "pass_period": "Pasar período",
     "pass_phase": "Pasar fase",
@@ -63,6 +64,7 @@
       "amount_to_withdraw": "Cantidad a retirar",
       "amount_to_fund": "Cantidad a financiar",
       "juror_address": "Dirección del jurado",
+      "juror_addresses_comma_separated": "0x123..., 0x456... (separados por comas)",
       "search_evidence": "Buscar evidencia por número, palabra o remitente",
       "freelance_example": "ej. Freelance",
       "alice_bob_example": "ej. Desacuerdo de trabajo freelance entre Alice y Bob",
@@ -446,6 +448,7 @@
     "unknown_court": "Corte desconocida"
   },
   "maintenance": {
+    "jurors_in_queue": "Jurados en cola: {{count}}",
     "jurors_drawn_in_drawing_phase": "Los jurados pueden ser sorteados en la fase de sorteo.",
     "pass_phase_here": "Pasar fase <anchor>aquí</anchor>."
   },
@@ -635,7 +638,10 @@
     "hidden_votes_tooltip": "Los votos de los jurados están ocultos. Nadie puede verlos antes de que se complete el período de votación. Se lleva a cabo en un proceso de dos pasos: comprometer y revelar.",
     "non_hidden_votes_tooltip": "Los votos de los jurados no están ocultos. Todos pueden ver la justificación y la opción votada antes de que se complete el período de votación.",
     "argentina_consumer_protection": "Protección al Consumidor de Argentina",
-    "argentina_consumer_protection_tooltip": "Los jurados deben poseer un token de profesional acreditado o un token de abogado acreditado en protección al consumidor para participar. Al menos un jurado sorteado debe poseer el token de abogado de protección al consumidor."
+    "argentina_consumer_protection_tooltip": "Los jurados deben poseer un token de profesional acreditado o un token de abogado acreditado en protección al consumidor para participar. Al menos un jurado sorteado debe poseer el token de abogado de protección al consumidor.",
+    "university_vote": "Universidad (Jurados seleccionados por el instructor)",
+    "university_vote_tooltip": "Diseñado para uso educativo. Un instructor preselecciona los jurados en lugar del sorteo aleatorio. Utiliza el voto compromiso-revelación estándar como el kit de disputa clásico.",
+    "university_instructor": "Instructor"
   },
   "swap": {
     "claimed_testnet": "Reclamado: {{amount}} PNK (Testnet)",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -32,6 +32,7 @@
     "reveal_your_vote": "Révéler votre vote",
     "justify_and_reveal": "Justifier et révéler",
     "draw": "Tirer au sort",
+    "set_jurors": "Définir les jurés",
     "rule": "Statuer",
     "pass_period": "Passer la période",
     "pass_phase": "Passer la phase",
@@ -63,6 +64,7 @@
       "amount_to_withdraw": "Montant à retirer",
       "amount_to_fund": "Montant à financer",
       "juror_address": "Adresse du juré",
+      "juror_addresses_comma_separated": "0x123..., 0x456... (séparés par des virgules)",
       "search_evidence": "Rechercher des preuves par numéro, mot ou soumetteur",
       "freelance_example": "ex. Freelance",
       "alice_bob_example": "ex. Désaccord sur un travail freelance entre Alice et Bob",
@@ -446,6 +448,7 @@
     "unknown_court": "Cour inconnue"
   },
   "maintenance": {
+    "jurors_in_queue": "Jurés en file d'attente : {{count}}",
     "jurors_drawn_in_drawing_phase": "Les jurés peuvent être tirés en phase de tirage.",
     "pass_phase_here": "Passer la phase <anchor>ici</anchor>."
   },
@@ -635,7 +638,10 @@
     "hidden_votes_tooltip": "Les votes des jurés sont cachés. Personne ne peut les voir avant la fin de la période de vote. Cela se déroule en un processus d'engagement-révélation en deux étapes.",
     "non_hidden_votes_tooltip": "Les votes des jurés ne sont pas cachés. Tout le monde peut voir la justification et le choix voté avant la fin de la période de vote.",
     "argentina_consumer_protection": "Protection du consommateur en Argentine",
-    "argentina_consumer_protection_tooltip": "Les jurés doivent détenir soit un token de professionnel accrédité, soit un token d'avocat accrédité en protection du consommateur pour participer. Au moins un juré tiré au sort doit détenir le token d'avocat en protection du consommateur."
+    "argentina_consumer_protection_tooltip": "Les jurés doivent détenir soit un token de professionnel accrédité, soit un token d'avocat accrédité en protection du consommateur pour participer. Au moins un juré tiré au sort doit détenir le token d'avocat en protection du consommateur.",
+    "university_vote": "Université (Jurés sélectionnés par l'instructeur)",
+    "university_vote_tooltip": "Conçu pour un usage éducatif. Un instructeur présélectionne les jurés au lieu du tirage aléatoire. Utilise le vote engagement-révélation standard comme le kit de litige classique.",
+    "university_instructor": "Instructeur"
   },
   "swap": {
     "claimed_testnet": "Réclamé : {{amount}} PNK (Testnet)",

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DrawButton.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/DrawButton.tsx
@@ -3,12 +3,13 @@ import styled from "styled-components";
 
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { isAddress } from "viem";
 import { usePublicClient } from "wagmi";
 
-import { Button, Field } from "@kleros/ui-components-library";
+import { Button } from "@kleros/ui-components-library";
 
+import { DisputeKits } from "consts/index";
 import { useSimulateKlerosCoreDraw, useWriteKlerosCoreDraw } from "hooks/contracts/generated";
+import { useDisputeKitAddresses } from "hooks/useDisputeKitAddresses";
 import { useSortitionModulePhase } from "hooks/useSortitionModule";
 import { wrapWithToast } from "utils/wrapWithToast";
 
@@ -19,6 +20,8 @@ import { isUndefined } from "src/utils";
 
 import { Phases } from "components/Phase";
 
+import SetJurorsButton from "./SetJurorsButton";
+
 import { IBaseMaintenanceButton } from ".";
 
 const StyledButton = styled(Button)`
@@ -26,22 +29,22 @@ const StyledButton = styled(Button)`
 `;
 
 const StyledLabel = styled.label``;
+
 interface IDrawButton extends IBaseMaintenanceButton {
   numberOfVotes?: string;
   period?: string;
+  disputeKitAddress?: string;
 }
 
-// TODO: rely on DK Uni here, for now just hardcoding to `false` to wait for DK Uni support
-const isUniversity = false;
-
-const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, period }) => {
+const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, period, disputeKitAddress }) => {
   const { t } = useTranslation();
   const publicClient = usePublicClient();
+  const { disputeKitName } = useDisputeKitAddresses({ disputeKitAddress });
   const { data: maintenanceData } = useDisputeMaintenanceQuery(id);
   const { data: phase } = useSortitionModulePhase();
   const [isSending, setIsSending] = useState(false);
-  const [drawJuror, setDrawJuror] = useState("");
 
+  const isUniversity = disputeKitName === DisputeKits.ClassicUniversity;
   const isDrawn = useMemo(() => maintenanceData?.dispute?.currentRound.jurorsDrawn, [maintenanceData]);
 
   const canDraw = useMemo(
@@ -49,16 +52,26 @@ const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, perio
       !isUndefined(maintenanceData) &&
       !isDrawn &&
       period === Period.Evidence &&
+      // university DK doesn't rely on sortition module, so we skip this check
       (isUniversity ? true : phase === Phases.drawing),
-    [maintenanceData, isDrawn, phase, period]
+    [maintenanceData, isDrawn, phase, period, isUniversity]
   );
 
   const needToPassPhase = useMemo(
-    () => !isUndefined(maintenanceData) && !isDrawn && period === Period.Evidence && phase !== Phases.drawing,
-    [maintenanceData, isDrawn, phase, period]
+    () =>
+      !isUniversity &&
+      !isUndefined(maintenanceData) &&
+      !isDrawn &&
+      period === Period.Evidence &&
+      phase !== Phases.drawing,
+    [maintenanceData, isDrawn, phase, period, isUniversity]
   );
 
-  const drawIterations = useMemo(() => Math.min(100, Number(numberOfVotes ?? 0) * 4), [numberOfVotes]);
+  const drawIterations = useMemo(
+    // for uni DK, the jurors are drawn from the jurorQueue, so calling the exact number of Votes is sufficient
+    () => (isUniversity ? Number(numberOfVotes ?? 0) : Math.min(100, Number(numberOfVotes ?? 0) * 4)),
+    [numberOfVotes, isUniversity]
+  );
 
   const {
     data: drawConfig,
@@ -66,31 +79,19 @@ const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, perio
     isError,
   } = useSimulateKlerosCoreDraw({
     query: {
-      enabled:
-        !isUndefined(id) &&
-        !isUndefined(numberOfVotes) &&
-        !isUndefined(period) &&
-        canDraw &&
-        (isUniversity ? isAddress(drawJuror) : true),
+      enabled: !isUndefined(id) && !isUndefined(numberOfVotes) && !isUndefined(period) && canDraw,
     },
-    // eslint-disable-next-line
-    // @ts-ignore
-    args: [BigInt(id ?? 0), isUniversity ? drawJuror : drawIterations],
+    args: [BigInt(id ?? 0), BigInt(drawIterations)],
   });
 
   const { writeContractAsync: draw } = useWriteKlerosCoreDraw();
 
   const isLoading = useMemo(() => isLoadingConfig || isSending, [isLoadingConfig, isSending]);
   const isDisabled = useMemo(
-    () =>
-      isUndefined(id) ||
-      isUndefined(numberOfVotes) ||
-      isError ||
-      isLoading ||
-      !canDraw ||
-      (isUniversity && !isAddress(drawJuror)),
-    [id, numberOfVotes, isError, isLoading, canDraw, drawJuror]
+    () => isUndefined(id) || isUndefined(numberOfVotes) || isError || isLoading || !canDraw || drawIterations <= 0,
+    [id, numberOfVotes, isError, isLoading, canDraw, drawIterations]
   );
+
   const handleClick = () => {
     if (!drawConfig || !publicClient) return;
 
@@ -101,9 +102,10 @@ const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, perio
       setIsOpen(false);
     });
   };
+
   return (
     <>
-      {needToPassPhase && !isUniversity ? (
+      {needToPassPhase ? (
         <StyledLabel>
           {t("maintenance.jurors_drawn_in_drawing_phase")}
           <br />
@@ -113,13 +115,7 @@ const DrawButton: React.FC<IDrawButton> = ({ id, numberOfVotes, setIsOpen, perio
           />
         </StyledLabel>
       ) : null}
-      {isUniversity && canDraw ? (
-        <Field
-          placeholder={t("forms.placeholders.juror_address")}
-          onChange={(e) => setDrawJuror(e.target.value)}
-          value={drawJuror}
-        />
-      ) : null}
+      {isUniversity && canDraw ? <SetJurorsButton {...{ id, disputeKitAddress }} /> : null}
       <StyledButton text={t("buttons.draw")} small isLoading={isLoading} disabled={isDisabled} onClick={handleClick} />
     </>
   );

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
@@ -59,12 +59,14 @@ interface ISetJurorsButton extends Pick<IBaseMaintenanceButton, "id"> {
   disputeKitAddress?: string;
 }
 
-const parseJurorAddresses = (input: string): Address[] => {
-  return input
+const parseJurorAddresses = (input: string): { jurors: Address[]; hasInvalidTokens: boolean } => {
+  const tokens = input
     .split(/[,\s]+/)
     .map((s) => s.trim())
-    .filter(Boolean)
-    .filter((addr) => isAddress(addr));
+    .filter(Boolean);
+
+  const jurors = tokens.filter((addr): addr is Address => isAddress(addr));
+  return { jurors, hasInvalidTokens: jurors.length !== tokens.length };
 };
 
 const SetJurorsButton: React.FC<ISetJurorsButton> = ({ id, disputeKitAddress }) => {
@@ -73,8 +75,8 @@ const SetJurorsButton: React.FC<ISetJurorsButton> = ({ id, disputeKitAddress }) 
   const [isSending, setIsSending] = useState(false);
   const [jurorsInput, setJurorsInput] = useState("");
 
-  const jurors = useMemo(() => parseJurorAddresses(jurorsInput), [jurorsInput]);
-  const hasValidJurors = jurors.length > 0;
+  const { jurors, hasInvalidTokens } = useMemo(() => parseJurorAddresses(jurorsInput), [jurorsInput]);
+  const hasValidJurors = jurors.length > 0 && !hasInvalidTokens;
 
   const { data: instructorAddress } = useReadDisputeKitClassicUniversityInstructor();
   const { data: jurorsInQueue, refetch: refetchJurorsInQueue } = useReadDisputeKitClassicUniversityGetJurors({

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useState } from "react";
+import styled from "styled-components";
+
+import { useTranslation } from "react-i18next";
+import { Address, isAddress } from "viem";
+import { usePublicClient } from "wagmi";
+
+import { Button, Field } from "@kleros/ui-components-library";
+
+import AddressExplorerLink from "~src/components/AddressExplorerLink";
+
+import {
+  useReadDisputeKitClassicUniversityGetJurors,
+  useReadDisputeKitClassicUniversityInstructor,
+  useSimulateDisputeKitClassicUniversitySetJurors,
+  useWriteDisputeKitClassicUniversitySetJurors,
+} from "hooks/contracts/generated";
+import { wrapWithToast } from "utils/wrapWithToast";
+
+import { isUndefined } from "src/utils";
+
+import { IBaseMaintenanceButton } from ".";
+
+const InstructorContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.secondaryText};
+`;
+
+const InstructorLabel = styled.span`
+  color: ${({ theme }) => theme.primaryText};
+`;
+
+const JurorsQueueContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.secondaryText};
+`;
+
+const JurorsQueueLabel = styled.span`
+  color: ${({ theme }) => theme.primaryText};
+`;
+
+const JurorsList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
+`;
+
+interface ISetJurorsButton extends Pick<IBaseMaintenanceButton, "id"> {
+  disputeKitAddress?: string;
+}
+
+const parseJurorAddresses = (input: string): Address[] => {
+  return input
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .filter((addr) => isAddress(addr));
+};
+
+const SetJurorsButton: React.FC<ISetJurorsButton> = ({ id, disputeKitAddress }) => {
+  const { t } = useTranslation();
+  const publicClient = usePublicClient();
+  const [isSending, setIsSending] = useState(false);
+  const [jurorsInput, setJurorsInput] = useState("");
+
+  const jurors = useMemo(() => parseJurorAddresses(jurorsInput), [jurorsInput]);
+  const hasValidJurors = jurors.length > 0;
+
+  const { data: instructorAddress } = useReadDisputeKitClassicUniversityInstructor();
+  const { data: jurorsInQueue, refetch: refetchJurorsInQueue } = useReadDisputeKitClassicUniversityGetJurors({
+    args: [BigInt(id ?? 0)],
+    query: { enabled: !isUndefined(id) },
+  });
+
+  const {
+    data: setJurorsConfig,
+    isLoading: isLoadingConfig,
+    isError,
+  } = useSimulateDisputeKitClassicUniversitySetJurors({
+    query: {
+      enabled: !isUndefined(id) && hasValidJurors,
+    },
+    args: [BigInt(id ?? 0), jurors],
+  });
+
+  const { writeContractAsync: setJurors } = useWriteDisputeKitClassicUniversitySetJurors();
+
+  const isLoading = useMemo(() => isLoadingConfig || isSending, [isLoadingConfig, isSending]);
+  const isDisabled = useMemo(
+    () => isUndefined(id) || isUndefined(disputeKitAddress) || isError || isLoading || !hasValidJurors,
+    [id, disputeKitAddress, isError, isLoading, hasValidJurors]
+  );
+
+  const handleClick = () => {
+    if (!setJurorsConfig || !publicClient) return;
+
+    setIsSending(true);
+
+    wrapWithToast(async () => await setJurors(setJurorsConfig.request), publicClient).finally(() => {
+      setIsSending(false);
+      setJurorsInput("");
+      refetchJurorsInQueue();
+    });
+  };
+
+  return (
+    <>
+      {instructorAddress ? (
+        <InstructorContainer>
+          <InstructorLabel>{t("features.university_instructor")}:</InstructorLabel>
+          <AddressExplorerLink address={instructorAddress} />
+        </InstructorContainer>
+      ) : null}
+
+      {jurorsInQueue && jurorsInQueue.length > 0 ? (
+        <JurorsQueueContainer>
+          <JurorsQueueLabel>{t("maintenance.jurors_in_queue", { count: jurorsInQueue.length })}</JurorsQueueLabel>
+          <JurorsList>
+            {jurorsInQueue.map((address) => (
+              <AddressExplorerLink key={address} {...{ address }} />
+            ))}
+          </JurorsList>
+        </JurorsQueueContainer>
+      ) : null}
+
+      <Field
+        placeholder={t("forms.placeholders.juror_addresses_comma_separated")}
+        onChange={(e) => setJurorsInput(e.target.value)}
+        value={jurorsInput}
+      />
+      <StyledButton
+        text={t("buttons.set_jurors")}
+        small
+        isLoading={isLoading}
+        disabled={isDisabled}
+        onClick={handleClick}
+      />
+    </>
+  );
+};
+
+export default SetJurorsButton;

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/SetJurorsButton.tsx
@@ -106,11 +106,16 @@ const SetJurorsButton: React.FC<ISetJurorsButton> = ({ id, disputeKitAddress }) 
 
     setIsSending(true);
 
-    wrapWithToast(async () => await setJurors(setJurorsConfig.request), publicClient).finally(() => {
-      setIsSending(false);
-      setJurorsInput("");
-      refetchJurorsInQueue();
-    });
+    wrapWithToast(async () => await setJurors(setJurorsConfig.request), publicClient)
+      .then((res) => {
+        if (res.status) {
+          setJurorsInput("");
+          refetchJurorsInQueue();
+        }
+      })
+      .finally(() => {
+        setIsSending(false);
+      });
   };
 
   return (

--- a/web/src/pages/Cases/CaseDetails/MaintenanceButtons/index.tsx
+++ b/web/src/pages/Cases/CaseDetails/MaintenanceButtons/index.tsx
@@ -109,6 +109,7 @@ const MaintenanceButtons: React.FC = () => {
                   {...{ id, setIsOpen }}
                   numberOfVotes={dispute?.currentRound.nbVotes}
                   period={dispute?.period}
+                  disputeKitAddress={dispute?.currentRound?.disputeKit?.address}
                 />
                 <PassPeriodButton {...{ id, setIsOpen }} period={dispute?.period} />
                 <ExecuteRulingButton {...{ id, setIsOpen }} period={dispute?.period} ruled={dispute?.ruled} />

--- a/web/src/pages/Resolver/Parameters/Court/FeatureSelection/index.tsx
+++ b/web/src/pages/Resolver/Parameters/Court/FeatureSelection/index.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from "react-i18next";
 import { Card } from "@kleros/ui-components-library";
 
 import {
-  disputeKits,
   ensureValidSmart,
-  featureGroups,
   Features,
   findMatchingKits,
   getDisabledOptions,
+  getDisputeKitsForDeployment,
+  getFeatureGroupsForDeployment,
   getVisibleFeaturesForCourt,
   Group,
   toggleFeature,
@@ -54,10 +54,13 @@ const FeatureSelection: React.FC = () => {
   } = useNewDisputeContext();
   const { data: supportedDisputeKits } = useSupportedDisputeKits(disputeData.courtId);
 
+  const disputeKitsForDeployment = useMemo(() => getDisputeKitsForDeployment(), []);
+  const featureGroupsForDeployment = useMemo(() => getFeatureGroupsForDeployment(), []);
+
   // DEV: initial feature selection logic, included hardcoded logic
   useEffect(() => {
     if (!isUndefined(disputeData?.disputeKitId)) {
-      const defaultKit = disputeKits.find((dk) => dk.id === disputeData.disputeKitId);
+      const defaultKit = disputeKitsForDeployment.find((dk) => dk.id === disputeData.disputeKitId);
       if (!defaultKit) return;
 
       // some kits like gated can have two feature sets, one for gatedERC20 and other for ERC1155
@@ -77,15 +80,15 @@ const FeatureSelection: React.FC = () => {
   const allowedDisputeKits = useMemo(() => {
     if (!supportedDisputeKits?.court?.supportedDisputeKits) return [];
     const allowedIds = supportedDisputeKits.court.supportedDisputeKits.map((dk) => Number(dk.id));
-    return disputeKits.filter((kit) => allowedIds.includes(kit.id));
-  }, [supportedDisputeKits]);
+    return disputeKitsForDeployment.filter((kit) => allowedIds.includes(kit.id));
+  }, [supportedDisputeKits, disputeKitsForDeployment]);
 
   // Court specific groups
   const courtGroups = useMemo(() => {
     const courtKits = supportedDisputeKits?.court?.supportedDisputeKits.map((dk) => Number(dk.id));
     if (isUndefined(courtKits) || allowedDisputeKits.length === 0) return {};
-    return getVisibleFeaturesForCourt(courtKits, allowedDisputeKits, featureGroups);
-  }, [supportedDisputeKits, allowedDisputeKits]);
+    return getVisibleFeaturesForCourt(courtKits, allowedDisputeKits, featureGroupsForDeployment);
+  }, [supportedDisputeKits, allowedDisputeKits, featureGroupsForDeployment]);
 
   const disabled = useMemo(
     () => getDisabledOptions(selected, courtGroups, allowedDisputeKits),

--- a/web/wagmi.config.ts
+++ b/web/wagmi.config.ts
@@ -4,7 +4,7 @@ import { parse, join } from "path";
 import { type Config, type ContractConfig, defineConfig } from "@wagmi/cli";
 import { react, actions } from "@wagmi/cli/plugins";
 import dotenv from "dotenv";
-import { type Chain } from "viem";
+import { Address, zeroAddress, type Abi, type Chain } from "viem";
 import { arbitrum, arbitrumSepolia, gnosis, gnosisChiado, mainnet, sepolia, hardhat } from "viem/chains";
 
 import IArbitrableV2 from "../contracts/artifacts/src/arbitration/interfaces/IArbitrableV2.sol/IArbitrableV2.json" assert { type: "json" };
@@ -40,7 +40,7 @@ const readArtifacts = async (viemChainName: string, hardhatChainName?: string) =
     if (ext === ".json") {
       const filePath = join(directoryPath, file);
       const fileContent = await readFile(filePath, "utf-8");
-      const jsonContent = JSON.parse(fileContent);
+      const jsonContent = JSON.parse(fileContent) as { address: Address; abi: Abi };
       results.push({
         name,
         address: {
@@ -86,10 +86,29 @@ const getConfig = async (): Promise<Config> => {
 
   const deploymentContracts = await readArtifacts(viemNetwork, hardhatNetwork);
 
+  // On mainnet, DisputeKitClassicUniversity is not deployed. Adding a stub so the generated
+  // hook exists (when useVotingContext, setJurorsButton imports it).
+  // The hook is never enabled on mainnet since we filter out the DisputeKitConfig in useDisputeKitAddresses.
+  let universityStub: ContractConfig[] = [];
+  if (deployment === "mainnet") {
+    console.info("Injecting DisputeKitClassicUniversity stub from arbitrum sepolia deployment");
+    const stubPath = "../contracts/deployments/arbitrumSepoliaDevnet/DisputeKitClassicUniversity.json";
+
+    const stubContent = JSON.parse(await readFile(stubPath, "utf-8")) as { address: Address; abi: Abi };
+    universityStub = [
+      {
+        name: "DisputeKitClassicUniversity",
+        address: { [arbitrum.id]: zeroAddress },
+        abi: stubContent.abi,
+      },
+    ];
+  }
+
   return {
     out: "src/hooks/contracts/generated.ts",
     contracts: [
       ...deploymentContracts,
+      ...universityStub,
       {
         name: "IHomeGateway",
         abi: arbitratorContracts.iHomeGatewayAbi,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on introducing support for a new `ClassicUniversity` dispute kit in the Kleros system, enhancing various components to accommodate this feature, and updating the relevant logic and UI elements.

### Detailed summary
- Updated `package.json` version to `2.0.1`.
- Added `disputeKitAddress` prop in `MaintenanceButtons`.
- Introduced `ClassicUniversityVoteParams`, `ClassicUniversityCommitParams`, `ClassicUniversityFundAppealParams`, and `ClassicUniversityRevealParams` interfaces.
- Updated `subgraph.template.yaml` and `subgraph.yaml` to include `DisputeKitClassic`.
- Added `UniversityVote` component for UI representation.
- Implemented juror management functionality in `SetJurorsButton`.
- Enhanced `DrawButton` to handle `ClassicUniversity` logic.
- Updated translation files for new features and labels.
- Adjusted dispute kit configuration logic to include `ClassicUniversity`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a Classic University dispute kit (instructor-selected jurors): commit/reveal voting, funding flows, and juror management UI (set jurors, view instructor and queue); adjusted draw behavior for university disputes.
  * New small UI: clickable explorer-address links and a University vote option.

* **Localization**
  * Added English, Spanish, and French strings for juror controls and university feature text.

* **Chores**
  * Package version bumped to 2.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->