### PR TITLE
Feat/voting e2e base test

### DIFF
--- a/contracts/deploy/05-dispute-kit-acp.ts
+++ b/contracts/deploy/05-dispute-kit-acp.ts
@@ -18,6 +18,10 @@ const config = {
     consumerProtectionCourtID: 32,
     courtUrl: "https://v2.kleros.builders/#/courts/32/purpose",
   },
+  hardhat: {
+    consumerProtectionCourtID: 4,
+    courtUrl: "http://localhost:5173/#/courts/4/purpose",
+  },
 };
 
 const deployArbitration: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {

--- a/contracts/deployments/hardhat.viem.ts
+++ b/contracts/deployments/hardhat.viem.ts
@@ -1777,6 +1777,1742 @@ export const disputeKitClassicConfig = {
 } as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitClassicUniversity
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityAbi = [
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
+  { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
+  { type: "error", inputs: [], name: "CoreIsPaused" },
+  { type: "error", inputs: [], name: "DisputeJumpedToAnotherDisputeKit" },
+  { type: "error", inputs: [], name: "DisputeNotResolved" },
+  { type: "error", inputs: [], name: "DisputeUnknownInThisDisputeKit" },
+  { type: "error", inputs: [], name: "EmptyCommit" },
+  { type: "error", inputs: [], name: "EmptyVoteIDs" },
+  { type: "error", inputs: [], name: "FailedDelegateCall" },
+  { type: "error", inputs: [], name: "InstructorOnly" },
+  {
+    type: "error",
+    inputs: [{ name: "implementation", internalType: "address", type: "address" }],
+    name: "InvalidImplementation",
+  },
+  { type: "error", inputs: [], name: "JurorHasToOwnTheVote" },
+  { type: "error", inputs: [], name: "KlerosCoreOnly" },
+  { type: "error", inputs: [], name: "NotAppealPeriod" },
+  { type: "error", inputs: [], name: "NotAppealPeriodForLoser" },
+  { type: "error", inputs: [], name: "NotCommitPeriod" },
+  { type: "error", inputs: [], name: "NotInitializing" },
+  { type: "error", inputs: [], name: "NotVotePeriod" },
+  { type: "error", inputs: [], name: "OwnerOnly" },
+  { type: "error", inputs: [], name: "OwnerOrInstructorOnly" },
+  { type: "error", inputs: [], name: "UUPSUnauthorizedCallContext" },
+  {
+    type: "error",
+    inputs: [{ name: "slot", internalType: "bytes32", type: "bytes32" }],
+    name: "UUPSUnsupportedProxiableUUID",
+  },
+  { type: "error", inputs: [], name: "UnsuccessfulCall" },
+  { type: "error", inputs: [], name: "VoteAlreadyCast" },
+  { type: "error", inputs: [], name: "WhenArbitrationNotPausedOnly" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "ChoiceFunded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_commit",
+        internalType: "bytes32",
+        type: "bytes32",
+        indexed: false,
+      },
+    ],
+    name: "CommitCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Contribution",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_numberOfChoices",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_extraData",
+        internalType: "bytes",
+        type: "bytes",
+        indexed: false,
+      },
+    ],
+    name: "DisputeCreation",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "version",
+        internalType: "uint64",
+        type: "uint64",
+        indexed: false,
+      },
+    ],
+    name: "Initialized",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_instructor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "InstructorChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "JurorsCleared",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_jurors",
+        internalType: "address[]",
+        type: "address[]",
+        indexed: false,
+      },
+    ],
+    name: "JurorsSet",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_courtID",
+        internalType: "uint96",
+        type: "uint96",
+        indexed: true,
+      },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+        indexed: false,
+      },
+    ],
+    name: "NextRoundSettingsChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "newImplementation",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "Upgraded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_justification",
+        internalType: "string",
+        type: "string",
+        indexed: false,
+      },
+    ],
+    name: "VoteCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Withdrawal",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_APPEAL_PERIOD_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "WINNER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areCommitsAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areVotesAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_commit", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "castCommit",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "_justification", internalType: "string", type: "string" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_core", internalType: "address", type: "address" }],
+    name: "changeCore",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_instructor", internalType: "address", type: "address" }],
+    name: "changeInstructor",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_courtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+      },
+    ],
+    name: "changeNextRoundSettings",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_owner", internalType: "address payable", type: "address" }],
+    name: "changeOwner",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "clearJurors",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "core",
+    outputs: [{ name: "", internalType: "contract KlerosCore", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToActive",
+    outputs: [
+      { name: "dispute", internalType: "bool", type: "bool" },
+      { name: "currentRound", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToLocal",
+    outputs: [{ name: "localDisputeID", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "currentCourtID", internalType: "uint96", type: "uint96" }],
+    name: "courtIDToNextRoundSettings",
+    outputs: [
+      { name: "enabled", internalType: "bool", type: "bool" },
+      { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+      { name: "jumpDisputeKitID", internalType: "uint256", type: "uint256" },
+      {
+        name: "jumpDisputeKitIDOnCourtJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      { name: "nbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "_extraData", internalType: "bytes", type: "bytes" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "createDispute",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "currentRuling",
+    outputs: [
+      { name: "ruling", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "overridden", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    name: "disputes",
+    outputs: [
+      { name: "numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "extraData", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_roundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    name: "draw",
+    outputs: [
+      { name: "drawnAddress", internalType: "address", type: "address" },
+      { name: "fromSubcourtID", internalType: "uint96", type: "uint96" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_destination", internalType: "address", type: "address" },
+      { name: "_amount", internalType: "uint256", type: "uint256" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "executeOwnerProposal",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "fundAppeal",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getCoherentCount",
+    outputs: [{ name: "coherentCount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherencePenalty",
+    outputs: [{ name: "pnkCoherence", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherenceReward",
+    outputs: [
+      { name: "pnkCoherence", internalType: "uint256", type: "uint256" },
+      { name: "feeCoherence", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getFundedChoices",
+    outputs: [{ name: "fundedChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getJurorQueueCursor",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getJurors",
+    outputs: [{ name: "", internalType: "address[]", type: "address[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getLocalDisputeRoundID",
+    outputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_currentCourtID", internalType: "uint96", type: "uint96" },
+      { name: "_parentCourtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_currentCourtJurorsForJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentDisputeKitID",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentRoundNbVotes",
+        internalType: "uint256",
+        type: "uint256",
+      },
+    ],
+    name: "getNextRoundSettings",
+    outputs: [
+      { name: "newCourtID", internalType: "uint96", type: "uint96" },
+      { name: "newDisputeKitID", internalType: "uint256", type: "uint256" },
+      { name: "newRoundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_localDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getNumberOfRounds",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getRoundInfo",
+    outputs: [
+      { name: "winningChoice", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "totalVoted", internalType: "uint256", type: "uint256" },
+      { name: "totalCommitted", internalType: "uint256", type: "uint256" },
+      { name: "nbVoters", internalType: "uint256", type: "uint256" },
+      { name: "choiceCount", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getVoteInfo",
+    outputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "commit", internalType: "bytes32", type: "bytes32" },
+      { name: "choice", internalType: "uint256", type: "uint256" },
+      { name: "voted", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getWinningChoices",
+    outputs: [{ name: "winningChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "string", type: "string" },
+    ],
+    name: "hashVote",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_owner", internalType: "address", type: "address" },
+      { name: "_core", internalType: "contract KlerosCore", type: "address" },
+      { name: "_wNative", internalType: "address", type: "address" },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "instructor",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "isAppealFunded",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "isVoteActive",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_jurors", internalType: "address[]", type: "address[]" },
+    ],
+    name: "setJurors",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "singleDrawPerJuror",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "newImplementation", internalType: "address", type: "address" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "version",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "wNative",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      {
+        name: "_beneficiary",
+        internalType: "address payable",
+        type: "address",
+      },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "withdrawFeesAndRewards",
+    outputs: [{ name: "amount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_implementation", internalType: "address", type: "address" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityAddress = {
+  1337: "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityConfig = {
+  address: disputeKitClassicUniversityAddress,
+  abi: disputeKitClassicUniversityAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitClassicUniversity_Implementation
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityImplementationAbi = [
+  { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
+  { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
+  { type: "error", inputs: [], name: "CoreIsPaused" },
+  { type: "error", inputs: [], name: "DisputeJumpedToAnotherDisputeKit" },
+  { type: "error", inputs: [], name: "DisputeNotResolved" },
+  { type: "error", inputs: [], name: "DisputeUnknownInThisDisputeKit" },
+  { type: "error", inputs: [], name: "EmptyCommit" },
+  { type: "error", inputs: [], name: "EmptyVoteIDs" },
+  { type: "error", inputs: [], name: "FailedDelegateCall" },
+  { type: "error", inputs: [], name: "InstructorOnly" },
+  {
+    type: "error",
+    inputs: [{ name: "implementation", internalType: "address", type: "address" }],
+    name: "InvalidImplementation",
+  },
+  { type: "error", inputs: [], name: "JurorHasToOwnTheVote" },
+  { type: "error", inputs: [], name: "KlerosCoreOnly" },
+  { type: "error", inputs: [], name: "NotAppealPeriod" },
+  { type: "error", inputs: [], name: "NotAppealPeriodForLoser" },
+  { type: "error", inputs: [], name: "NotCommitPeriod" },
+  { type: "error", inputs: [], name: "NotInitializing" },
+  { type: "error", inputs: [], name: "NotVotePeriod" },
+  { type: "error", inputs: [], name: "OwnerOnly" },
+  { type: "error", inputs: [], name: "OwnerOrInstructorOnly" },
+  { type: "error", inputs: [], name: "UUPSUnauthorizedCallContext" },
+  {
+    type: "error",
+    inputs: [{ name: "slot", internalType: "bytes32", type: "bytes32" }],
+    name: "UUPSUnsupportedProxiableUUID",
+  },
+  { type: "error", inputs: [], name: "UnsuccessfulCall" },
+  { type: "error", inputs: [], name: "VoteAlreadyCast" },
+  { type: "error", inputs: [], name: "WhenArbitrationNotPausedOnly" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "ChoiceFunded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_commit",
+        internalType: "bytes32",
+        type: "bytes32",
+        indexed: false,
+      },
+    ],
+    name: "CommitCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Contribution",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_numberOfChoices",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_extraData",
+        internalType: "bytes",
+        type: "bytes",
+        indexed: false,
+      },
+    ],
+    name: "DisputeCreation",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "version",
+        internalType: "uint64",
+        type: "uint64",
+        indexed: false,
+      },
+    ],
+    name: "Initialized",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_instructor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "InstructorChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "JurorsCleared",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_jurors",
+        internalType: "address[]",
+        type: "address[]",
+        indexed: false,
+      },
+    ],
+    name: "JurorsSet",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_courtID",
+        internalType: "uint96",
+        type: "uint96",
+        indexed: true,
+      },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+        indexed: false,
+      },
+    ],
+    name: "NextRoundSettingsChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "newImplementation",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "Upgraded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_justification",
+        internalType: "string",
+        type: "string",
+        indexed: false,
+      },
+    ],
+    name: "VoteCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Withdrawal",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_APPEAL_PERIOD_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "WINNER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areCommitsAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areVotesAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_commit", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "castCommit",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "_justification", internalType: "string", type: "string" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_core", internalType: "address", type: "address" }],
+    name: "changeCore",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_instructor", internalType: "address", type: "address" }],
+    name: "changeInstructor",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_courtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+      },
+    ],
+    name: "changeNextRoundSettings",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_owner", internalType: "address payable", type: "address" }],
+    name: "changeOwner",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "clearJurors",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "core",
+    outputs: [{ name: "", internalType: "contract KlerosCore", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToActive",
+    outputs: [
+      { name: "dispute", internalType: "bool", type: "bool" },
+      { name: "currentRound", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToLocal",
+    outputs: [{ name: "localDisputeID", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "currentCourtID", internalType: "uint96", type: "uint96" }],
+    name: "courtIDToNextRoundSettings",
+    outputs: [
+      { name: "enabled", internalType: "bool", type: "bool" },
+      { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+      { name: "jumpDisputeKitID", internalType: "uint256", type: "uint256" },
+      {
+        name: "jumpDisputeKitIDOnCourtJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      { name: "nbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "_extraData", internalType: "bytes", type: "bytes" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "createDispute",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "currentRuling",
+    outputs: [
+      { name: "ruling", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "overridden", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    name: "disputes",
+    outputs: [
+      { name: "numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "extraData", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_roundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    name: "draw",
+    outputs: [
+      { name: "drawnAddress", internalType: "address", type: "address" },
+      { name: "fromSubcourtID", internalType: "uint96", type: "uint96" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_destination", internalType: "address", type: "address" },
+      { name: "_amount", internalType: "uint256", type: "uint256" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "executeOwnerProposal",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "fundAppeal",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getCoherentCount",
+    outputs: [{ name: "coherentCount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherencePenalty",
+    outputs: [{ name: "pnkCoherence", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherenceReward",
+    outputs: [
+      { name: "pnkCoherence", internalType: "uint256", type: "uint256" },
+      { name: "feeCoherence", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getFundedChoices",
+    outputs: [{ name: "fundedChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getJurorQueueCursor",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getJurors",
+    outputs: [{ name: "", internalType: "address[]", type: "address[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getLocalDisputeRoundID",
+    outputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_currentCourtID", internalType: "uint96", type: "uint96" },
+      { name: "_parentCourtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_currentCourtJurorsForJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentDisputeKitID",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentRoundNbVotes",
+        internalType: "uint256",
+        type: "uint256",
+      },
+    ],
+    name: "getNextRoundSettings",
+    outputs: [
+      { name: "newCourtID", internalType: "uint96", type: "uint96" },
+      { name: "newDisputeKitID", internalType: "uint256", type: "uint256" },
+      { name: "newRoundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_localDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getNumberOfRounds",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getRoundInfo",
+    outputs: [
+      { name: "winningChoice", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "totalVoted", internalType: "uint256", type: "uint256" },
+      { name: "totalCommitted", internalType: "uint256", type: "uint256" },
+      { name: "nbVoters", internalType: "uint256", type: "uint256" },
+      { name: "choiceCount", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getVoteInfo",
+    outputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "commit", internalType: "bytes32", type: "bytes32" },
+      { name: "choice", internalType: "uint256", type: "uint256" },
+      { name: "voted", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getWinningChoices",
+    outputs: [{ name: "winningChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "string", type: "string" },
+    ],
+    name: "hashVote",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_owner", internalType: "address", type: "address" },
+      { name: "_core", internalType: "contract KlerosCore", type: "address" },
+      { name: "_wNative", internalType: "address", type: "address" },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "instructor",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "isAppealFunded",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "isVoteActive",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_jurors", internalType: "address[]", type: "address[]" },
+    ],
+    name: "setJurors",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "singleDrawPerJuror",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "newImplementation", internalType: "address", type: "address" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "version",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "wNative",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      {
+        name: "_beneficiary",
+        internalType: "address payable",
+        type: "address",
+      },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "withdrawFeesAndRewards",
+    outputs: [{ name: "amount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityImplementationAddress = {
+  1337: "0x36C02dA8a0983159322a80FFE9F24b1acfF8B570",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityImplementationConfig = {
+  address: disputeKitClassicUniversityImplementationAddress,
+  abi: disputeKitClassicUniversityImplementationAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitClassicUniversity_Proxy
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityProxyAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_implementation", internalType: "address", type: "address" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityProxyAddress = {
+  1337: "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitClassicUniversityProxyConfig = {
+  address: disputeKitClassicUniversityProxyAddress,
+  abi: disputeKitClassicUniversityProxyAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DisputeKitClassic_Implementation
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -3503,6 +5239,1708 @@ export const disputeKitGatedConfig = {
 } as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitGatedArgentinaConsumerProtection
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionAbi = [
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
+  { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
+  { type: "error", inputs: [], name: "CoreIsPaused" },
+  { type: "error", inputs: [], name: "DisputeJumpedToAnotherDisputeKit" },
+  { type: "error", inputs: [], name: "DisputeNotResolved" },
+  { type: "error", inputs: [], name: "DisputeUnknownInThisDisputeKit" },
+  { type: "error", inputs: [], name: "EmptyCommit" },
+  { type: "error", inputs: [], name: "EmptyVoteIDs" },
+  { type: "error", inputs: [], name: "FailedDelegateCall" },
+  {
+    type: "error",
+    inputs: [{ name: "implementation", internalType: "address", type: "address" }],
+    name: "InvalidImplementation",
+  },
+  { type: "error", inputs: [], name: "JurorHasToOwnTheVote" },
+  { type: "error", inputs: [], name: "KlerosCoreOnly" },
+  { type: "error", inputs: [], name: "NotAppealPeriod" },
+  { type: "error", inputs: [], name: "NotAppealPeriodForLoser" },
+  { type: "error", inputs: [], name: "NotCommitPeriod" },
+  { type: "error", inputs: [], name: "NotInitializing" },
+  { type: "error", inputs: [], name: "NotVotePeriod" },
+  { type: "error", inputs: [], name: "OwnerOnly" },
+  {
+    type: "error",
+    inputs: [{ name: "tokenGate", internalType: "address", type: "address" }],
+    name: "TokenNotSupported",
+  },
+  { type: "error", inputs: [], name: "UUPSUnauthorizedCallContext" },
+  {
+    type: "error",
+    inputs: [{ name: "slot", internalType: "bytes32", type: "bytes32" }],
+    name: "UUPSUnsupportedProxiableUUID",
+  },
+  { type: "error", inputs: [], name: "UnsuccessfulCall" },
+  { type: "error", inputs: [], name: "VoteAlreadyCast" },
+  { type: "error", inputs: [], name: "WhenArbitrationNotPausedOnly" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "ChoiceFunded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_commit",
+        internalType: "bytes32",
+        type: "bytes32",
+        indexed: false,
+      },
+    ],
+    name: "CommitCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Contribution",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_numberOfChoices",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_extraData",
+        internalType: "bytes",
+        type: "bytes",
+        indexed: false,
+      },
+    ],
+    name: "DisputeCreation",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "version",
+        internalType: "uint64",
+        type: "uint64",
+        indexed: false,
+      },
+    ],
+    name: "Initialized",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_courtID",
+        internalType: "uint96",
+        type: "uint96",
+        indexed: true,
+      },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+        indexed: false,
+      },
+    ],
+    name: "NextRoundSettingsChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "newImplementation",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "Upgraded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_justification",
+        internalType: "string",
+        type: "string",
+        indexed: false,
+      },
+    ],
+    name: "VoteCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Withdrawal",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_APPEAL_PERIOD_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "WINNER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "accreditedConsumerProtectionLawyerToken",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "accreditedProfessionalToken",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areCommitsAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areVotesAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_commit", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "castCommit",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "_justification", internalType: "string", type: "string" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      {
+        name: "_accreditedConsumerProtectionLawyerToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "changeAccreditedConsumerProtectionLawyerToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      {
+        name: "_accreditedProfessionalToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "changeAccreditedProfessionalToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_core", internalType: "address", type: "address" }],
+    name: "changeCore",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_courtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+      },
+    ],
+    name: "changeNextRoundSettings",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_owner", internalType: "address payable", type: "address" }],
+    name: "changeOwner",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "core",
+    outputs: [{ name: "", internalType: "contract KlerosCore", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToActive",
+    outputs: [
+      { name: "dispute", internalType: "bool", type: "bool" },
+      { name: "currentRound", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToLocal",
+    outputs: [{ name: "localDisputeID", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "currentCourtID", internalType: "uint96", type: "uint96" }],
+    name: "courtIDToNextRoundSettings",
+    outputs: [
+      { name: "enabled", internalType: "bool", type: "bool" },
+      { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+      { name: "jumpDisputeKitID", internalType: "uint256", type: "uint256" },
+      {
+        name: "jumpDisputeKitIDOnCourtJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      { name: "nbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "_extraData", internalType: "bytes", type: "bytes" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "createDispute",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "currentRuling",
+    outputs: [
+      { name: "ruling", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "overridden", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    name: "disputes",
+    outputs: [
+      { name: "numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "extraData", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_nonce", internalType: "uint256", type: "uint256" },
+      { name: "_roundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    name: "draw",
+    outputs: [
+      { name: "drawnAddress", internalType: "address", type: "address" },
+      { name: "fromSubcourtID", internalType: "uint96", type: "uint96" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "drawnConsumerProtectionLawyer",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_destination", internalType: "address", type: "address" },
+      { name: "_amount", internalType: "uint256", type: "uint256" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "executeOwnerProposal",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "fundAppeal",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getCoherentCount",
+    outputs: [{ name: "coherentCount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherencePenalty",
+    outputs: [{ name: "pnkCoherence", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherenceReward",
+    outputs: [
+      { name: "pnkCoherence", internalType: "uint256", type: "uint256" },
+      { name: "feeCoherence", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getFundedChoices",
+    outputs: [{ name: "fundedChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getLocalDisputeRoundID",
+    outputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_currentCourtID", internalType: "uint96", type: "uint96" },
+      { name: "_parentCourtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_currentCourtJurorsForJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentDisputeKitID",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentRoundNbVotes",
+        internalType: "uint256",
+        type: "uint256",
+      },
+    ],
+    name: "getNextRoundSettings",
+    outputs: [
+      { name: "newCourtID", internalType: "uint96", type: "uint96" },
+      { name: "newDisputeKitID", internalType: "uint256", type: "uint256" },
+      { name: "newRoundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_localDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getNumberOfRounds",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getRoundInfo",
+    outputs: [
+      { name: "winningChoice", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "totalVoted", internalType: "uint256", type: "uint256" },
+      { name: "totalCommitted", internalType: "uint256", type: "uint256" },
+      { name: "nbVoters", internalType: "uint256", type: "uint256" },
+      { name: "choiceCount", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getVoteInfo",
+    outputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "commit", internalType: "bytes32", type: "bytes32" },
+      { name: "choice", internalType: "uint256", type: "uint256" },
+      { name: "voted", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getWinningChoices",
+    outputs: [{ name: "winningChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "string", type: "string" },
+    ],
+    name: "hashVote",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_owner", internalType: "address", type: "address" },
+      { name: "_core", internalType: "contract KlerosCore", type: "address" },
+      { name: "_wNative", internalType: "address", type: "address" },
+      {
+        name: "_accreditedProfessionalToken",
+        internalType: "address",
+        type: "address",
+      },
+      {
+        name: "_accreditedConsumerProtectionLawyerToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "isAppealFunded",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_juror", internalType: "address", type: "address" },
+      { name: "", internalType: "uint96", type: "uint96" },
+    ],
+    name: "isEligible",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "isVoteActive",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "singleDrawPerJuror",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "newImplementation", internalType: "address", type: "address" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "version",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "wNative",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      {
+        name: "_beneficiary",
+        internalType: "address payable",
+        type: "address",
+      },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "withdrawFeesAndRewards",
+    outputs: [{ name: "amount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_implementation", internalType: "address", type: "address" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionAddress = {
+  1337: "0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionConfig = {
+  address: disputeKitGatedArgentinaConsumerProtectionAddress,
+  abi: disputeKitGatedArgentinaConsumerProtectionAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitGatedArgentinaConsumerProtection_Implementation
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionImplementationAbi = [
+  { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
+  { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
+  { type: "error", inputs: [], name: "CoreIsPaused" },
+  { type: "error", inputs: [], name: "DisputeJumpedToAnotherDisputeKit" },
+  { type: "error", inputs: [], name: "DisputeNotResolved" },
+  { type: "error", inputs: [], name: "DisputeUnknownInThisDisputeKit" },
+  { type: "error", inputs: [], name: "EmptyCommit" },
+  { type: "error", inputs: [], name: "EmptyVoteIDs" },
+  { type: "error", inputs: [], name: "FailedDelegateCall" },
+  {
+    type: "error",
+    inputs: [{ name: "implementation", internalType: "address", type: "address" }],
+    name: "InvalidImplementation",
+  },
+  { type: "error", inputs: [], name: "JurorHasToOwnTheVote" },
+  { type: "error", inputs: [], name: "KlerosCoreOnly" },
+  { type: "error", inputs: [], name: "NotAppealPeriod" },
+  { type: "error", inputs: [], name: "NotAppealPeriodForLoser" },
+  { type: "error", inputs: [], name: "NotCommitPeriod" },
+  { type: "error", inputs: [], name: "NotInitializing" },
+  { type: "error", inputs: [], name: "NotVotePeriod" },
+  { type: "error", inputs: [], name: "OwnerOnly" },
+  {
+    type: "error",
+    inputs: [{ name: "tokenGate", internalType: "address", type: "address" }],
+    name: "TokenNotSupported",
+  },
+  { type: "error", inputs: [], name: "UUPSUnauthorizedCallContext" },
+  {
+    type: "error",
+    inputs: [{ name: "slot", internalType: "bytes32", type: "bytes32" }],
+    name: "UUPSUnsupportedProxiableUUID",
+  },
+  { type: "error", inputs: [], name: "UnsuccessfulCall" },
+  { type: "error", inputs: [], name: "VoteAlreadyCast" },
+  { type: "error", inputs: [], name: "WhenArbitrationNotPausedOnly" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "ChoiceFunded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_commit",
+        internalType: "bytes32",
+        type: "bytes32",
+        indexed: false,
+      },
+    ],
+    name: "CommitCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_coreRoundID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Contribution",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_numberOfChoices",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_extraData",
+        internalType: "bytes",
+        type: "bytes",
+        indexed: false,
+      },
+    ],
+    name: "DisputeCreation",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "version",
+        internalType: "uint64",
+        type: "uint64",
+        indexed: false,
+      },
+    ],
+    name: "Initialized",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_courtID",
+        internalType: "uint96",
+        type: "uint96",
+        indexed: true,
+      },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+        indexed: false,
+      },
+    ],
+    name: "NextRoundSettingsChanged",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "newImplementation",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "Upgraded",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_juror",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_voteIDs",
+        internalType: "uint256[]",
+        type: "uint256[]",
+        indexed: false,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_justification",
+        internalType: "string",
+        type: "string",
+        indexed: false,
+      },
+    ],
+    name: "VoteCast",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_coreDisputeID",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+      {
+        name: "_choice",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_contributor",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "_amount",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "Withdrawal",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_APPEAL_PERIOD_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "LOSER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "WINNER_STAKE_MULTIPLIER",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "accreditedConsumerProtectionLawyerToken",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "accreditedProfessionalToken",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areCommitsAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "areVotesAllCast",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_commit", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "castCommit",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_voteIDs", internalType: "uint256[]", type: "uint256[]" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "_justification", internalType: "string", type: "string" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      {
+        name: "_accreditedConsumerProtectionLawyerToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "changeAccreditedConsumerProtectionLawyerToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      {
+        name: "_accreditedProfessionalToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "changeAccreditedProfessionalToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_core", internalType: "address", type: "address" }],
+    name: "changeCore",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_courtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_nextRoundSettings",
+        internalType: "struct DisputeKitClassicBase.NextRoundSettings",
+        type: "tuple",
+        components: [
+          { name: "enabled", internalType: "bool", type: "bool" },
+          { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+          {
+            name: "jumpDisputeKitID",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "jumpDisputeKitIDOnCourtJump",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "nbVotes", internalType: "uint256", type: "uint256" },
+        ],
+      },
+    ],
+    name: "changeNextRoundSettings",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_owner", internalType: "address payable", type: "address" }],
+    name: "changeOwner",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "core",
+    outputs: [{ name: "", internalType: "contract KlerosCore", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToActive",
+    outputs: [
+      { name: "dispute", internalType: "bool", type: "bool" },
+      { name: "currentRound", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "coreDisputeIDToLocal",
+    outputs: [{ name: "localDisputeID", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "currentCourtID", internalType: "uint96", type: "uint96" }],
+    name: "courtIDToNextRoundSettings",
+    outputs: [
+      { name: "enabled", internalType: "bool", type: "bool" },
+      { name: "jumpCourtID", internalType: "uint96", type: "uint96" },
+      { name: "jumpDisputeKitID", internalType: "uint256", type: "uint256" },
+      {
+        name: "jumpDisputeKitIDOnCourtJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      { name: "nbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "_extraData", internalType: "bytes", type: "bytes" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "createDispute",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "currentRuling",
+    outputs: [
+      { name: "ruling", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "overridden", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    name: "disputes",
+    outputs: [
+      { name: "numberOfChoices", internalType: "uint256", type: "uint256" },
+      { name: "extraData", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_nonce", internalType: "uint256", type: "uint256" },
+      { name: "_roundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    name: "draw",
+    outputs: [
+      { name: "drawnAddress", internalType: "address", type: "address" },
+      { name: "fromSubcourtID", internalType: "uint96", type: "uint96" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "drawnConsumerProtectionLawyer",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_destination", internalType: "address", type: "address" },
+      { name: "_amount", internalType: "uint256", type: "uint256" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "executeOwnerProposal",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "fundAppeal",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getCoherentCount",
+    outputs: [{ name: "coherentCount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherencePenalty",
+    outputs: [{ name: "pnkCoherence", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getDegreeOfCoherenceReward",
+    outputs: [
+      { name: "pnkCoherence", internalType: "uint256", type: "uint256" },
+      { name: "feeCoherence", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getFundedChoices",
+    outputs: [{ name: "fundedChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getLocalDisputeRoundID",
+    outputs: [
+      { name: "localDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "localRoundID", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "_currentCourtID", internalType: "uint96", type: "uint96" },
+      { name: "_parentCourtID", internalType: "uint96", type: "uint96" },
+      {
+        name: "_currentCourtJurorsForJump",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentDisputeKitID",
+        internalType: "uint256",
+        type: "uint256",
+      },
+      {
+        name: "_currentRoundNbVotes",
+        internalType: "uint256",
+        type: "uint256",
+      },
+    ],
+    name: "getNextRoundSettings",
+    outputs: [
+      { name: "newCourtID", internalType: "uint96", type: "uint96" },
+      { name: "newDisputeKitID", internalType: "uint256", type: "uint256" },
+      { name: "newRoundNbVotes", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_localDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getNumberOfRounds",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getRoundInfo",
+    outputs: [
+      { name: "winningChoice", internalType: "uint256", type: "uint256" },
+      { name: "tied", internalType: "bool", type: "bool" },
+      { name: "totalVoted", internalType: "uint256", type: "uint256" },
+      { name: "totalCommitted", internalType: "uint256", type: "uint256" },
+      { name: "nbVoters", internalType: "uint256", type: "uint256" },
+      { name: "choiceCount", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "getVoteInfo",
+    outputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "commit", internalType: "bytes32", type: "bytes32" },
+      { name: "choice", internalType: "uint256", type: "uint256" },
+      { name: "voted", internalType: "bool", type: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "getWinningChoices",
+    outputs: [{ name: "winningChoices", internalType: "uint256[]", type: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+      { name: "_salt", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "string", type: "string" },
+    ],
+    name: "hashVote",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_owner", internalType: "address", type: "address" },
+      { name: "_core", internalType: "contract KlerosCore", type: "address" },
+      { name: "_wNative", internalType: "address", type: "address" },
+      {
+        name: "_accreditedProfessionalToken",
+        internalType: "address",
+        type: "address",
+      },
+      {
+        name: "_accreditedConsumerProtectionLawyerToken",
+        internalType: "address",
+        type: "address",
+      },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_coreDisputeID", internalType: "uint256", type: "uint256" }],
+    name: "isAppealFunded",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_juror", internalType: "address", type: "address" },
+      { name: "", internalType: "uint96", type: "uint96" },
+    ],
+    name: "isEligible",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      { name: "_coreRoundID", internalType: "uint256", type: "uint256" },
+      { name: "_voteID", internalType: "uint256", type: "uint256" },
+    ],
+    name: "isVoteActive",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "singleDrawPerJuror",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "newImplementation", internalType: "address", type: "address" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "version",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "wNative",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_coreDisputeID", internalType: "uint256", type: "uint256" },
+      {
+        name: "_beneficiary",
+        internalType: "address payable",
+        type: "address",
+      },
+      { name: "_choice", internalType: "uint256", type: "uint256" },
+    ],
+    name: "withdrawFeesAndRewards",
+    outputs: [{ name: "amount", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionImplementationAddress = {
+  1337: "0x7969c5eD335650692Bc04293B07F5BF2e7A673C0",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionImplementationConfig = {
+  address: disputeKitGatedArgentinaConsumerProtectionImplementationAddress,
+  abi: disputeKitGatedArgentinaConsumerProtectionImplementationAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DisputeKitGatedArgentinaConsumerProtection_Proxy
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionProxyAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_implementation", internalType: "address", type: "address" },
+      { name: "_data", internalType: "bytes", type: "bytes" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  { type: "fallback", stateMutability: "payable" },
+  { type: "receive", stateMutability: "payable" },
+] as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionProxyAddress = {
+  1337: "0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650",
+} as const;
+
+/**
+ *
+ */
+export const disputeKitGatedArgentinaConsumerProtectionProxyConfig = {
+  address: disputeKitGatedArgentinaConsumerProtectionProxyAddress,
+  abi: disputeKitGatedArgentinaConsumerProtectionProxyAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DisputeKitGatedShutter
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -3514,6 +6952,7 @@ export const disputeKitGatedShutterAbi = [
   { type: "receive", stateMutability: "payable" },
   { type: "error", inputs: [], name: "AlreadyInitialized" },
   { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "CallerMustBeJurorIfNoHiddenVotes" },
   { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
   { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
   { type: "error", inputs: [], name: "CoreIsPaused" },
@@ -4553,6 +7992,7 @@ export const disputeKitGatedShutterImplementationAbi = [
   { type: "constructor", inputs: [], stateMutability: "nonpayable" },
   { type: "error", inputs: [], name: "AlreadyInitialized" },
   { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "CallerMustBeJurorIfNoHiddenVotes" },
   { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
   { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
   { type: "error", inputs: [], name: "CoreIsPaused" },
@@ -6583,6 +10023,7 @@ export const disputeKitShutterAbi = [
   { type: "receive", stateMutability: "payable" },
   { type: "error", inputs: [], name: "AlreadyInitialized" },
   { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "CallerMustBeJurorIfNoHiddenVotes" },
   { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
   { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
   { type: "error", inputs: [], name: "CoreIsPaused" },
@@ -7448,6 +10889,7 @@ export const disputeKitShutterImplementationAbi = [
   { type: "constructor", inputs: [], stateMutability: "nonpayable" },
   { type: "error", inputs: [], name: "AlreadyInitialized" },
   { type: "error", inputs: [], name: "AppealFeeIsAlreadyPaid" },
+  { type: "error", inputs: [], name: "CallerMustBeJurorIfNoHiddenVotes" },
   { type: "error", inputs: [], name: "ChoiceCommitmentMismatch" },
   { type: "error", inputs: [], name: "ChoiceOutOfBounds" },
   { type: "error", inputs: [], name: "CoreIsPaused" },
@@ -8533,7 +11975,7 @@ export const disputeResolverAbi = [
  * - [__View Contract on Gnosis Chiado Blockscout__](https://blockscout.chiadochain.net/address/0x16f20604a51Ac1e68c9aAd1C0E53e951B62CC1Cb)
  */
 export const disputeResolverAddress = {
-  1337: "0x4c5859f0F772848b2D91F1D83E2Fe57935348029",
+  1337: "0xCD8a1C3ba11CF5ECfa6267617243239504a98d90",
   10200: "0x16f20604a51Ac1e68c9aAd1C0E53e951B62CC1Cb",
 } as const;
 
@@ -11773,7 +15215,7 @@ export const klerosCoreSnapshotProxyAbi = [
  *
  */
 export const klerosCoreSnapshotProxyAddress = {
-  1337: "0x36C02dA8a0983159322a80FFE9F24b1acfF8B570",
+  1337: "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
 } as const;
 
 /**
@@ -13212,7 +16654,7 @@ export const leaderboardOffsetAbi = [
  *
  */
 export const leaderboardOffsetAddress = {
-  1337: "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+  1337: "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575",
 } as const;
 
 /**
@@ -14433,6 +17875,930 @@ export const ratesConverterAddress = {
 export const ratesConverterConfig = {
   address: ratesConverterAddress,
   abi: ratesConverterAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// SBTACPExperience
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const sbtacpExperienceAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_name", internalType: "string", type: "string" },
+      { name: "_symbol", internalType: "string", type: "string" },
+      { name: "_description", internalType: "string", type: "string" },
+      { name: "_imageUri", internalType: "string", type: "string" },
+      { name: "_externalUrl", internalType: "string", type: "string" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  { type: "error", inputs: [], name: "AddressAlreadyHasToken" },
+  {
+    type: "error",
+    inputs: [
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+      { name: "owner", internalType: "address", type: "address" },
+    ],
+    name: "ERC721IncorrectOwner",
+  },
+  {
+    type: "error",
+    inputs: [
+      { name: "operator", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "ERC721InsufficientApproval",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "approver", internalType: "address", type: "address" }],
+    name: "ERC721InvalidApprover",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "operator", internalType: "address", type: "address" }],
+    name: "ERC721InvalidOperator",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "ERC721InvalidOwner",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "receiver", internalType: "address", type: "address" }],
+    name: "ERC721InvalidReceiver",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "sender", internalType: "address", type: "address" }],
+    name: "ERC721InvalidSender",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "ERC721NonexistentToken",
+  },
+  { type: "error", inputs: [], name: "EnforcedPause" },
+  { type: "error", inputs: [], name: "ExpectedPause" },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "OwnableInvalidOwner",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "account", internalType: "address", type: "address" }],
+    name: "OwnableUnauthorizedAccount",
+  },
+  { type: "error", inputs: [], name: "TransfersNotPermitted" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "owner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "approved",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "Approval",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "owner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "operator",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      { name: "approved", internalType: "bool", type: "bool", indexed: false },
+    ],
+    name: "ApprovalForAll",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_fromTokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_toTokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "BatchMetadataUpdate",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "MetadataUpdate",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "previousOwner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "newOwner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "OwnershipTransferred",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "account",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "Paused",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      { name: "from", internalType: "address", type: "address", indexed: true },
+      { name: "to", internalType: "address", type: "address", indexed: true },
+      {
+        name: "tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "Transfer",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "account",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "Unpaused",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "to", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "approve",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_fromTokenId", internalType: "uint256", type: "uint256" },
+      { name: "_toTokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "batchMetadataUpdate",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "burn",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_description", internalType: "string", type: "string" }],
+    name: "changeDescription",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_externalUrl", internalType: "string", type: "string" }],
+    name: "changeExternalUrl",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_imageUri", internalType: "string", type: "string" }],
+    name: "changeImageUri",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_name", internalType: "string", type: "string" }],
+    name: "changeName",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "description",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "externalUrl",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "getApproved",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "imageUri",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "owner", internalType: "address", type: "address" },
+      { name: "operator", internalType: "address", type: "address" },
+    ],
+    name: "isApprovedForAll",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "name",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "ownerOf",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "pause",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "paused",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_to", internalType: "address", type: "address" }],
+    name: "safeMint",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "from", internalType: "address", type: "address" },
+      { name: "to", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "operator", internalType: "address", type: "address" },
+      { name: "approved", internalType: "bool", type: "bool" },
+    ],
+    name: "setApprovalForAll",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_interfaceId", internalType: "bytes4", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "symbol",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_tokenId", internalType: "uint256", type: "uint256" }],
+    name: "tokenURI",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "transferFrom",
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "newOwner", internalType: "address", type: "address" }],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "unpause",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const sbtacpExperienceAddress = {
+  1337: "0x82e01223d51Eb87e16A03E24687EDF0F294da6f1",
+} as const;
+
+/**
+ *
+ */
+export const sbtacpExperienceConfig = {
+  address: sbtacpExperienceAddress,
+  abi: sbtacpExperienceAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// SBTACPLawyer
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const sbtacpLawyerAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "_name", internalType: "string", type: "string" },
+      { name: "_symbol", internalType: "string", type: "string" },
+      { name: "_description", internalType: "string", type: "string" },
+      { name: "_imageUri", internalType: "string", type: "string" },
+      { name: "_externalUrl", internalType: "string", type: "string" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  { type: "error", inputs: [], name: "AddressAlreadyHasToken" },
+  {
+    type: "error",
+    inputs: [
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+      { name: "owner", internalType: "address", type: "address" },
+    ],
+    name: "ERC721IncorrectOwner",
+  },
+  {
+    type: "error",
+    inputs: [
+      { name: "operator", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "ERC721InsufficientApproval",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "approver", internalType: "address", type: "address" }],
+    name: "ERC721InvalidApprover",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "operator", internalType: "address", type: "address" }],
+    name: "ERC721InvalidOperator",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "ERC721InvalidOwner",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "receiver", internalType: "address", type: "address" }],
+    name: "ERC721InvalidReceiver",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "sender", internalType: "address", type: "address" }],
+    name: "ERC721InvalidSender",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "ERC721NonexistentToken",
+  },
+  { type: "error", inputs: [], name: "EnforcedPause" },
+  { type: "error", inputs: [], name: "ExpectedPause" },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "OwnableInvalidOwner",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "account", internalType: "address", type: "address" }],
+    name: "OwnableUnauthorizedAccount",
+  },
+  { type: "error", inputs: [], name: "TransfersNotPermitted" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "owner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "approved",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "Approval",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "owner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "operator",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      { name: "approved", internalType: "bool", type: "bool", indexed: false },
+    ],
+    name: "ApprovalForAll",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_fromTokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+      {
+        name: "_toTokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "BatchMetadataUpdate",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "_tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: false,
+      },
+    ],
+    name: "MetadataUpdate",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "previousOwner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "newOwner",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+    ],
+    name: "OwnershipTransferred",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "account",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "Paused",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      { name: "from", internalType: "address", type: "address", indexed: true },
+      { name: "to", internalType: "address", type: "address", indexed: true },
+      {
+        name: "tokenId",
+        internalType: "uint256",
+        type: "uint256",
+        indexed: true,
+      },
+    ],
+    name: "Transfer",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "account",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "Unpaused",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "to", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "approve",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "_fromTokenId", internalType: "uint256", type: "uint256" },
+      { name: "_toTokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "batchMetadataUpdate",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "burn",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_description", internalType: "string", type: "string" }],
+    name: "changeDescription",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_externalUrl", internalType: "string", type: "string" }],
+    name: "changeExternalUrl",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_imageUri", internalType: "string", type: "string" }],
+    name: "changeImageUri",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_name", internalType: "string", type: "string" }],
+    name: "changeName",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "description",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "externalUrl",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "getApproved",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "imageUri",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "owner", internalType: "address", type: "address" },
+      { name: "operator", internalType: "address", type: "address" },
+    ],
+    name: "isApprovedForAll",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "name",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "tokenId", internalType: "uint256", type: "uint256" }],
+    name: "ownerOf",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "pause",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "paused",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_to", internalType: "address", type: "address" }],
+    name: "safeMint",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "from", internalType: "address", type: "address" },
+      { name: "to", internalType: "address", type: "address" },
+      { name: "tokenId", internalType: "uint256", type: "uint256" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "operator", internalType: "address", type: "address" },
+      { name: "approved", internalType: "bool", type: "bool" },
+    ],
+    name: "setApprovalForAll",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_interfaceId", internalType: "bytes4", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "symbol",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "_tokenId", internalType: "uint256", type: "uint256" }],
+    name: "tokenURI",
+    outputs: [{ name: "", internalType: "string", type: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+    ],
+    name: "transferFrom",
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "newOwner", internalType: "address", type: "address" }],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "unpause",
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ *
+ */
+export const sbtacpLawyerAddress = {
+  1337: "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
+} as const;
+
+/**
+ *
+ */
+export const sbtacpLawyerConfig = {
+  address: sbtacpLawyerAddress,
+  abi: sbtacpLawyerAbi,
 } as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -60,7 +60,7 @@
     "test": "TS_NODE_TRANSPILE_ONLY=1 hardhat test",
     "coverage": "scripts/coverage.sh",
     "start": "hardhat node --tags nop",
-    "start-local": "hardhat node --tags Arbitration,HomeArbitrable,Resolver --hostname 0.0.0.0",
+    "start-local": "hardhat node --tags Arbitration,HomeArbitrable,Resolver,ArgentinaConsumerProtectionDK --hostname 0.0.0.0",
     "deploy": "hardhat deploy",
     "deploy-local": "hardhat deploy --tags Arbitration,HomeArbitrable,Resolver --network localhost",
     "validate-upgrades": "openzeppelin-upgrades-core validate --exclude 'src/proxy/mock/**/*.sol' --exclude 'src/test/**/*.sol' artifacts/build-info",

--- a/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes.ts
+++ b/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import DisputeDetailsSchema, { AliasSchema, AnswerSchema, AttachmentSchema } from "./disputeDetailsSchema";
 
-export { QuestionType } from "./disputeDetailsSchema";
+export { QuestionType, RefuseToArbitrateAnswer } from "./disputeDetailsSchema";
 export type DisputeDetails = z.infer<typeof DisputeDetailsSchema>;
 export type Answer = z.infer<typeof AnswerSchema>;
 export type Alias = z.infer<typeof AliasSchema>;

--- a/web/src/hooks/queries/usePopulatedDisputeData.ts
+++ b/web/src/hooks/queries/usePopulatedDisputeData.ts
@@ -71,6 +71,7 @@ export const usePopulatedDisputeData = (disputeID?: string, arbitrableAddress?: 
 
           return disputeDetails;
         } catch (error) {
+          console.warn({ error });
           if (error instanceof HttpRequestError || error instanceof RpcError) {
             debounceErrorToast("RPC failed!, Please avoid voting.");
             throw Error;

--- a/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
+++ b/web/src/pages/Resolver/NavigationButtons/SubmitDisputeButton.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import styled from "styled-components";
 
 import { useTranslation } from "react-i18next";
-import { Log, decodeEventLog, parseAbi } from "viem";
+import { useNavigate } from "react-router-dom";
 import { useAccount, useBalance, usePublicClient } from "wagmi";
 
 import { Button } from "@kleros/ui-components-library";
@@ -17,6 +17,7 @@ import {
 import { isUndefined } from "utils/index";
 import { parseWagmiError } from "utils/parseWagmiError";
 import { prepareArbitratorExtradata } from "utils/prepareArbitratorExtradata";
+import { retrieveDisputeIdFromLogs } from "utils/retrieveDisputeId";
 import { wrapWithToast } from "utils/wrapWithToast";
 
 import { EnsureChain } from "components/EnsureChain";
@@ -27,6 +28,7 @@ import ClosedCircleIcon from "components/StyledIcons/ClosedCircleIcon";
 const StyledButton = styled(Button)``;
 
 const SubmitDisputeButton: React.FC = () => {
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const publicClient = usePublicClient();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
@@ -103,10 +105,16 @@ const SubmitDisputeButton: React.FC = () => {
                 wrapWithToast(async () => await submitCase(submitCaseConfig.request), publicClient)
                   .then((res) => {
                     if (res.status && !isUndefined(res.result)) {
-                      const id = retrieveDisputeId(res.result.logs[1]);
-                      setDisputeId(Number(id));
-                      setCourtId(disputeData.courtId ?? "1");
-                      setIsPopupOpen(true);
+                      const id = retrieveDisputeIdFromLogs(res.result.logs);
+                      if (id) {
+                        setDisputeId(Number(id));
+                        setCourtId(disputeData.courtId ?? "1");
+                        setIsPopupOpen(true);
+                      } else {
+                        // if unable to retrieve dispute id, just navigate to cases page
+                        navigate("/cases/display/1/desc/all");
+                      }
+
                       resetDisputeData();
                     }
                   })
@@ -147,12 +155,5 @@ export const isTemplateValid = (disputeTemplate: IDisputeTemplate) => {
     disputeTemplate.policyURI &&
     areVotingOptionsFilled) as boolean;
 };
-
-const retrieveDisputeId = (eventLog: Log) =>
-  decodeEventLog({
-    abi: parseAbi(["event DisputeCreation(uint256 indexed, address indexed)"]),
-    data: eventLog.data,
-    topics: eventLog.topics,
-  }).args[0];
 
 export default SubmitDisputeButton;

--- a/web/src/tests/e2e/fixtures/atlas.ts
+++ b/web/src/tests/e2e/fixtures/atlas.ts
@@ -1,6 +1,7 @@
 import { test as base } from "@playwright/test";
 import { Hex, recoverMessageAddress } from "viem";
 
+import { MOCK_IPFS_HASH } from "../utils/dispute";
 import { createTestJwt } from "../utils/jwt";
 
 // mocking atlas apis
@@ -110,7 +111,7 @@ export const test = base.extend<{
         return route.fulfill({
           status: 200,
           contentType: "text/plain",
-          body: "QmVDEj29zAvoBzSPkJMDx7B1Rb5CR8sGNrwei8DDULvDWp",
+          body: MOCK_IPFS_HASH,
         });
       });
       await use(async () => {});

--- a/web/src/tests/e2e/fixtures/hardhat.ts
+++ b/web/src/tests/e2e/fixtures/hardhat.ts
@@ -10,7 +10,9 @@ const client = createTestClient({
   .extend(publicActions)
   .extend(walletActions);
 
-export const test = base.extend<{ hardhat: typeof client }>({
+export type HardhatClient = typeof client;
+
+export const test = base.extend<{ hardhat: HardhatClient }>({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hardhat: async ({ page }, use) => {
     await use(client);

--- a/web/src/tests/e2e/fixtures/index.ts
+++ b/web/src/tests/e2e/fixtures/index.ts
@@ -1,11 +1,14 @@
 import { mergeTests } from "@playwright/test";
 
 import { test as atlasTest } from "./atlas";
-import { test as hardhatTest } from "./hardhat";
+import { test as timeTest } from "./time";
 import { test as walletTest } from "./wallet";
 
 export * from "@playwright/test";
+export { TimeFixture } from "./time";
+export type { HardhatClient } from "./hardhat";
 
 // merge our custom fixtures, making them available for tests.
 // We will re-use `test` from this file
-export const test = mergeTests(walletTest, hardhatTest, atlasTest);
+// Note: timeTest already extends hardhatTest, so we don't need to include hardhatTest separately
+export const test = mergeTests(walletTest, atlasTest, timeTest);

--- a/web/src/tests/e2e/fixtures/time.ts
+++ b/web/src/tests/e2e/fixtures/time.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+
+import { test as hardhatTest, type HardhatClient } from "./hardhat";
+
+/**
+ * TimeFixture provides methods to control and sync time between
+ * the browser and the Hardhat chain.
+ */
+export class TimeFixture {
+  private page: Page;
+  private hardhat: HardhatClient;
+  private initialized = false;
+
+  constructor({ page, hardhat }: { page: Page; hardhat: HardhatClient }) {
+    this.page = page;
+    this.hardhat = hardhat;
+  }
+
+  /**
+   * Initialize the clock with the current hardhat block timestamp.
+   * Must be called before navigating to pages that depend on time.
+   * This installs Playwright's fake timers and syncs with hardhat.
+   */
+  async install() {
+    const hardhatTime = (await this.getHardhatTime()) * 1000;
+
+    await this.page.clock.install({ time: hardhatTime });
+    this.initialized = true;
+  }
+
+  /**
+   * Set both browser and hardhat time to a specific timestamp.
+   * @param timestamp - Unix timestamp in seconds (same as hardhat)
+   */
+  async setTime(timestamp: number) {
+    await this.hardhat.setNextBlockTimestamp({ timestamp: BigInt(timestamp) });
+    // The node currently is set to auto mine on an interval, but we intentionally mine to sync time.
+    await this.hardhat.mine({ blocks: 1 });
+
+    // setting browser time
+    const timeMs = timestamp * 1000;
+    if (this.initialized) {
+      await this.page.clock.setFixedTime(timeMs);
+    } else {
+      await this.page.clock.install({ time: timeMs });
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Advance both browser and hardhat time by the specified duration.
+   * @param seconds - Number of seconds to advance
+   */
+  async advanceTime(seconds: number) {
+    await this.hardhat.increaseTime({ seconds });
+    await this.hardhat.mine({ blocks: 1 });
+
+    const newTimeMs = (await this.getHardhatTime()) * 1000;
+
+    if (this.initialized) {
+      await this.page.clock.setFixedTime(newTimeMs);
+    } else {
+      await this.page.clock.install({ time: newTimeMs });
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Sync browser time with current hardhat block timestamp.
+   * Useful after external hardhat time changes.
+   */
+  async sync() {
+    const hardhatTimeMs = (await this.getHardhatTime()) * 1000;
+
+    if (this.initialized) {
+      await this.page.clock.setFixedTime(hardhatTimeMs);
+    } else {
+      await this.page.clock.install({ time: hardhatTimeMs });
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Fast-forward browser time by the specified milliseconds.
+   * This runs pending timers but doesn't affect hardhat time.
+   * Use advanceTime() to advance both.
+   * @param ms - Milliseconds to fast-forward
+   */
+  async fastForwardBrowser(ms: number) {
+    if (!this.initialized) {
+      await this.install();
+    }
+    await this.page.clock.fastForward(ms);
+  }
+
+  /**
+   * Get current hardhat block timestamp in seconds.
+   */
+  async getHardhatTime() {
+    const block = await this.hardhat.getBlock();
+    return Number(block.timestamp);
+  }
+
+  /**
+   * Mine a specified number of blocks on hardhat and sync browser time.
+   * @param blocks - Number of blocks to mine
+   */
+  async mineBlocks(blocks: number) {
+    await this.hardhat.mine({ blocks });
+    await this.sync();
+  }
+}
+
+// Extend the hardhat test to include the time fixture
+// This way the time fixture has access to the hardhat client from the hardhat fixture
+export const test = hardhatTest.extend<{ time: TimeFixture }>({
+  time: async ({ page, hardhat }, use) => {
+    await use(new TimeFixture({ page, hardhat }));
+  },
+});

--- a/web/src/tests/e2e/utils/accounts.ts
+++ b/web/src/tests/e2e/utils/accounts.ts
@@ -1,0 +1,10 @@
+// First account in hardhat already has PNK
+// ⚠️ WARNING: hardhat account private keys, not to be used in prod
+export const ACCOUNT_PKEYS = {
+  // 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  alice: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+  // 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  bob: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+} as const;
+
+export type AccountKey = keyof typeof ACCOUNT_PKEYS;

--- a/web/src/tests/e2e/utils/contracts.ts
+++ b/web/src/tests/e2e/utils/contracts.ts
@@ -1,0 +1,46 @@
+import { Abi, Address } from "viem";
+
+import {
+  disputeResolverAbi,
+  disputeResolverAddress,
+  klerosCoreAbi,
+  klerosCoreAddress,
+  pnkAbi,
+  pnkAddress,
+  sortitionModuleAbi,
+  sortitionModuleAddress,
+} from "hooks/contracts/generated";
+
+import { DEFAULT_CHAIN } from ".";
+
+// Contract addresses for default chain
+// for future , if we want to add devnet facing tests , will need changes
+export const DISPUTE_RESOLVER_ADDRESS = disputeResolverAddress[DEFAULT_CHAIN.id];
+export const KLEROS_CORE_ADDRESS = klerosCoreAddress[DEFAULT_CHAIN.id];
+export const SORTITION_MODULE_ADDRESS = sortitionModuleAddress[DEFAULT_CHAIN.id];
+export const PNK_ADDRESS = pnkAddress[DEFAULT_CHAIN.id];
+
+type ContractConfig<T extends Abi> = {
+  address: Address;
+  abi: T;
+};
+
+export const sortitionModuleContractConfig = {
+  address: SORTITION_MODULE_ADDRESS,
+  abi: sortitionModuleAbi,
+} satisfies ContractConfig<typeof sortitionModuleAbi>;
+
+export const klerosCoreContractConfig = {
+  address: KLEROS_CORE_ADDRESS,
+  abi: klerosCoreAbi,
+} satisfies ContractConfig<typeof klerosCoreAbi>;
+
+export const disputeResolverContractConfig = {
+  address: DISPUTE_RESOLVER_ADDRESS,
+  abi: disputeResolverAbi,
+} satisfies ContractConfig<typeof disputeResolverAbi>;
+
+export const pnkTokenContractConfig = {
+  address: PNK_ADDRESS,
+  abi: pnkAbi,
+} satisfies ContractConfig<typeof pnkAbi>;

--- a/web/src/tests/e2e/utils/dispute/drawJurors.ts
+++ b/web/src/tests/e2e/utils/dispute/drawJurors.ts
@@ -1,0 +1,51 @@
+import { Address, getContract } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import type { HardhatClient } from "../../fixtures/hardhat";
+import { ACCOUNT_PKEYS } from "../accounts";
+import { klerosCoreContractConfig } from "../contracts";
+
+/**
+ * Draws juror for the provided dispute.
+ *
+ * @note This function only draws the juror, the phase must be passed separately with `passToPhase`.
+ * @dev Currently the implementation is simple,
+ *      if tweaks are required to cater for specific dispute kits, can be added, or abstracted into per DK draw ritual
+ */
+export async function drawJurors(hardhat: HardhatClient, disputeId: bigint): Promise<ReadonlyArray<Address>> {
+  const maxDrawAttempts = 10;
+
+  const klerosCore = getContract({
+    ...klerosCoreContractConfig,
+    client: hardhat,
+  });
+
+  const account = privateKeyToAccount(ACCOUNT_PKEYS.alice);
+
+  const numberOfRounds = await klerosCore.read.getNumberOfRounds([disputeId]);
+
+  const getLatestRoundInfo = () => klerosCore.read.getRoundInfo([disputeId, numberOfRounds - 1n]);
+
+  const callDraw = async (iterations: bigint) => {
+    const hash = await hardhat.writeContract({
+      ...klerosCoreContractConfig,
+      functionName: "draw",
+      args: [disputeId, iterations],
+      account,
+    });
+    await hardhat.waitForTransactionReceipt({ hash });
+  };
+
+  for (let attempt = 0; attempt < maxDrawAttempts; attempt++) {
+    const roundInfo = await getLatestRoundInfo();
+    // jurors were drawn
+    if (roundInfo.drawnJurors.length === Number(roundInfo.nbVotes)) return roundInfo.drawnJurors;
+
+    // multiplying by 100 since this is local, no need to optimize for gas in this call
+    // NOTE: might change if we do test on mainnet, to save gas
+    const iterations = roundInfo.nbVotes * 10n;
+
+    await callDraw(iterations);
+  }
+  throw new Error(`drawJurors: Failed to draw jurors for dispute ${disputeId} after ${maxDrawAttempts}`);
+}

--- a/web/src/tests/e2e/utils/dispute/executeRulingForDispute.ts
+++ b/web/src/tests/e2e/utils/dispute/executeRulingForDispute.ts
@@ -15,6 +15,7 @@ export const executeRulingForDispute = async (hardhat: HardhatClient, disputeId:
   });
   const receipt = await hardhat.waitForTransactionReceipt({ hash });
 
-  if (receipt.status === "reverted")
+  if (receipt.status === "reverted") {
     throw new Error(`executeRulingForDispute: Failed to execute for dispute ${disputeId}`);
+  }
 };

--- a/web/src/tests/e2e/utils/dispute/executeRulingForDispute.ts
+++ b/web/src/tests/e2e/utils/dispute/executeRulingForDispute.ts
@@ -1,0 +1,20 @@
+import { privateKeyToAccount } from "viem/accounts";
+
+import { HardhatClient } from "../../fixtures";
+import { ACCOUNT_PKEYS } from "../accounts";
+import { klerosCoreContractConfig } from "../contracts";
+
+/** Enforces the ruling for a dispute */
+export const executeRulingForDispute = async (hardhat: HardhatClient, disputeId: bigint) => {
+  const account = privateKeyToAccount(ACCOUNT_PKEYS.alice);
+  const hash = await hardhat.writeContract({
+    ...klerosCoreContractConfig,
+    functionName: "executeRuling",
+    args: [disputeId],
+    account,
+  });
+  const receipt = await hardhat.waitForTransactionReceipt({ hash });
+
+  if (receipt.status === "reverted")
+    throw new Error(`executeRulingForDispute: Failed to execute for dispute ${disputeId}`);
+};

--- a/web/src/tests/e2e/utils/dispute/getDisputeInfo.ts
+++ b/web/src/tests/e2e/utils/dispute/getDisputeInfo.ts
@@ -1,0 +1,26 @@
+import { getContract } from "viem";
+
+import { HardhatClient } from "../../fixtures";
+import { klerosCoreContractConfig } from "../contracts";
+
+/**
+ *  Get dispute specific info, including latest round info
+ *
+ * @dev meant to make it easy to get disputeInfo in test files,
+ *     for utilities it's fine to call contract directly for specific info
+ */
+export const getDisputeInfo = async (hardhat: HardhatClient, disputeId: bigint) => {
+  const klerosCore = getContract({
+    ...klerosCoreContractConfig,
+    client: hardhat,
+  });
+
+  // NOTE: This is fragile and may break with any changes to KlerosCore.Dispute struct
+  const [courtID, arbitrated, period, ruled, executed, lastPeriodChange] = await klerosCore.read.disputes([disputeId]);
+
+  const numberOfRounds = await klerosCore.read.getNumberOfRounds([disputeId]);
+
+  const latestRoundInfo = await klerosCore.read.getRoundInfo([disputeId, numberOfRounds - 1n]);
+
+  return { courtID, arbitrated, period, ruled, executed, lastPeriodChange, latestRoundInfo };
+};

--- a/web/src/tests/e2e/utils/dispute/index.ts
+++ b/web/src/tests/e2e/utils/dispute/index.ts
@@ -1,0 +1,123 @@
+import { isHex, numberToHex } from "viem";
+
+import type { Answer } from "@kleros/kleros-sdk";
+
+import { disputeResolverContractConfig, klerosCoreContractConfig } from "../contracts";
+import { DEFAULT_CHAIN, GENERAL_COURT_ID } from "../index";
+
+export const MOCK_IPFS_HASH = "QmVDEj29zAvoBzSPkJMDx7B1Rb5CR8sGNrwei8DDULvDWp";
+export const CLASSIC_DISPUTE_KIT_ID = 1;
+
+export interface DisputeData {
+  courtId: string;
+  numberOfJurors: number;
+  disputeKitId: number;
+  title: string;
+  description: string;
+  question: string;
+  answers: Answer[];
+  policyURI: string;
+}
+
+/**
+ * Default answers for disputes
+ * @note RTA will be added by sdk
+ */
+export const DEFAULT_ANSWERS: Answer[] = [
+  { id: "0x1", title: "Option 1", description: "First option" },
+  { id: "0x2", title: "Option 2", description: "Second option" },
+];
+
+/**
+ * Default dispute data for e2e tests
+ */
+export const DEFAULT_DISPUTE_DATA: DisputeData = {
+  courtId: GENERAL_COURT_ID.toString(),
+  numberOfJurors: 3,
+  disputeKitId: CLASSIC_DISPUTE_KIT_ID,
+  title: "E2E Test Case",
+  description: "Test case created for e2e testing",
+  question: "Which option should win?",
+  answers: DEFAULT_ANSWERS,
+  policyURI: MOCK_IPFS_HASH,
+};
+
+/**
+ * Creates dispute data by merging defaults with custom options
+ */
+export function createDisputeData(options: Partial<DisputeData> = {}): DisputeData {
+  return {
+    ...DEFAULT_DISPUTE_DATA,
+    ...options,
+    answers: options.answers ?? DEFAULT_DISPUTE_DATA.answers,
+  };
+}
+
+/**
+ * Formats answers with proper hex IDs for the dispute template
+ * @todo Extract to a util and write unit tests, should be used by code under test too
+ */
+export function formatAnswersForTemplate(answers: Answer[]): Answer[] {
+  return answers.map((a) => ({
+    id: isHex(a.id) ? a.id : numberToHex(BigInt(a.id)),
+    title: a.title,
+    description: a.description,
+  }));
+}
+
+/**
+ * Creates a dispute template JSON string from dispute data
+ */
+export function createDisputeTemplate(data: DisputeData): string {
+  return JSON.stringify({
+    title: data.title,
+    description: data.description,
+    question: data.question,
+    answers: formatAnswersForTemplate(data.answers),
+    policyURI: `/ipfs/${data.policyURI}`,
+    arbitratorAddress: klerosCoreContractConfig.address,
+    arbitratorChainID: DEFAULT_CHAIN.id.toString(),
+    arbitrableAddress: disputeResolverContractConfig.address,
+    arbitrableChainID: DEFAULT_CHAIN.id.toString(),
+    version: "1.0",
+  });
+}
+
+/**
+ * Pre built dispute data for common test scenarios
+ * @todo add scenarios for dispute kits
+ */
+export const DISPUTE_SCENARIOS = {
+  simple: DEFAULT_DISPUTE_DATA,
+
+  multipleOptions: createDisputeData({
+    title: "Multi-Option Dispute",
+    question: "Select the best option",
+    answers: [
+      { id: "0x1", title: "Option A", description: "First choice" },
+      { id: "0x2", title: "Option B", description: "Second choice" },
+      { id: "0x3", title: "Option C", description: "Third choice" },
+      { id: "0x4", title: "Option D", description: "Fourth choice" },
+    ],
+  }),
+
+  singleJuror: createDisputeData({
+    numberOfJurors: 1,
+    title: "Single Juror Test",
+  }),
+
+  manyJurors: createDisputeData({
+    numberOfJurors: 5,
+    title: "Many Jurors Test",
+  }),
+
+  classicKit: createDisputeData({
+    disputeKitId: CLASSIC_DISPUTE_KIT_ID,
+    title: "Classic Kit Dispute",
+  }),
+} as const;
+
+export { getDisputeInfo } from "./getDisputeInfo";
+export { executeRulingForDispute } from "./executeRulingForDispute";
+export { drawJurors } from "./drawJurors";
+export { passPeriod } from "./passPeriod";

--- a/web/src/tests/e2e/utils/dispute/passPeriod.ts
+++ b/web/src/tests/e2e/utils/dispute/passPeriod.ts
@@ -1,0 +1,44 @@
+import { privateKeyToAccount } from "viem/accounts";
+
+import { TimeFixture } from "../../fixtures";
+import type { HardhatClient } from "../../fixtures/hardhat";
+import { ACCOUNT_PKEYS } from "../accounts";
+import { klerosCoreContractConfig } from "../contracts";
+
+import { getDisputeInfo } from ".";
+
+/**
+ * Passes period for the provided dispute.
+ *
+ * @note This function just tries to pass the period,
+ *       the requirements for the period to pass must be fulfilled separately beforehand
+ */
+export async function passPeriod(hardhat: HardhatClient, time: TimeFixture, disputeId: bigint) {
+  const account = privateKeyToAccount(ACCOUNT_PKEYS.alice);
+
+  const { lastPeriodChange, latestRoundInfo, period: currentPeriod } = await getDisputeInfo(hardhat, disputeId);
+
+  // NOTE: to be changed after devnet redeploy with meta audit changes
+  const timesPerPeriod = latestRoundInfo.timesPerPeriod;
+
+  const currentPeriodTime = timesPerPeriod[currentPeriod];
+  const blockTime = await time.getHardhatTime();
+
+  const elapsed = blockTime - Number(lastPeriodChange);
+  const periodDuration = Number(currentPeriodTime);
+
+  if (elapsed < periodDuration) {
+    const timeToAdvance = periodDuration - elapsed + 1;
+    await time.advanceTime(timeToAdvance);
+  }
+
+  const hash = await hardhat.writeContract({
+    ...klerosCoreContractConfig,
+    functionName: "passPeriod",
+    args: [disputeId],
+    account,
+  });
+  const receipt = await hardhat.waitForTransactionReceipt({ hash });
+
+  if (receipt.status === "reverted") throw new Error(`passPeriod: Failed to pass period for dispute ${disputeId}`);
+}

--- a/web/src/tests/e2e/utils/dispute/passPeriod.ts
+++ b/web/src/tests/e2e/utils/dispute/passPeriod.ts
@@ -39,6 +39,9 @@ export async function passPeriod(hardhat: HardhatClient, time: TimeFixture, disp
     account,
   });
   const receipt = await hardhat.waitForTransactionReceipt({ hash });
+  await time.sync();
 
-  if (receipt.status === "reverted") throw new Error(`passPeriod: Failed to pass period for dispute ${disputeId}`);
+  if (receipt.status === "reverted") {
+    throw new Error(`passPeriod: Failed to pass period for dispute ${disputeId}`);
+  }
 }

--- a/web/src/tests/e2e/utils/index.ts
+++ b/web/src/tests/e2e/utils/index.ts
@@ -1,8 +1,24 @@
-// First account in hardhat already has PNK
-// NOTE: hardhat account private keys, not to be used in prod
-export const ACCOUNT_PKEYS = {
-  // 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-  alice: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-  // 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
-  bob: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-} as const;
+import { hardhat } from "viem/chains";
+
+export { ACCOUNT_PKEYS, type AccountKey } from "./accounts";
+
+export const ONE_THOUSAND_PNK = 1000n;
+export const PNK_DECIMALS = 18;
+export const GENERAL_COURT_ID = 1n;
+
+export const ONE_MINUTE = 60;
+// We might want to configure this through the cmd arguments/ config ltr when we support tenderly or other chain testing
+export const DEFAULT_CHAIN = hardhat;
+
+export {
+  DEFAULT_ANSWERS,
+  DEFAULT_DISPUTE_DATA,
+  DISPUTE_SCENARIOS,
+  createDisputeData,
+  createDisputeTemplate,
+  formatAnswersForTemplate,
+} from "./dispute";
+
+export { setupCase, type SetupCaseOptions, type SetupCaseResult } from "./setupCase";
+export { passToPhase, SortitionPhase } from "./passToPhase";
+export { setupStake, type SetupStakeOptions } from "./setupStake";

--- a/web/src/tests/e2e/utils/passToPhase.ts
+++ b/web/src/tests/e2e/utils/passToPhase.ts
@@ -1,0 +1,101 @@
+import { getContract } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import type { HardhatClient } from "../fixtures/hardhat";
+import type { TimeFixture } from "../fixtures/time";
+
+import { ACCOUNT_PKEYS } from "./accounts";
+import { sortitionModuleContractConfig } from "./contracts";
+
+import { ONE_MINUTE } from ".";
+
+export enum SortitionPhase {
+  Staking,
+  Generating,
+  Drawing,
+}
+
+const PHASE_NAMES = ["staking", "generating", "drawing"] as const;
+
+/**
+ * Advance the sortition phase to a target phase (staking, generating, drawing).
+ *
+ * @example
+ * ```ts
+ * await passToPhase(hardhat, timeFixture, SortitionPhase.Drawing); // Advance to drawing phase
+ * await passToPhase(hardhat, timeFixture, SortitionPhase.Staking); // Advance to staking phase
+ * ```
+ */
+export async function passToPhase(hardhat: HardhatClient, time: TimeFixture, targetPhase: SortitionPhase) {
+  const maxAttempts = 10;
+
+  const sortitionModule = getContract({
+    ...sortitionModuleContractConfig,
+    client: hardhat,
+  });
+
+  const getPhase = () => sortitionModule.read.phase().then((p) => Number(p) as SortitionPhase);
+  const getLastPhaseChange = () => sortitionModule.read.lastPhaseChange();
+  const getMinStakingTime = () => sortitionModule.read.minStakingTime();
+  const getMaxDrawingTime = () => sortitionModule.read.maxDrawingTime();
+  const getDisputesWithoutJurors = () => sortitionModule.read.disputesWithoutJurors();
+
+  const account = privateKeyToAccount(ACCOUNT_PKEYS.alice);
+
+  const callPassPhase = async () => {
+    const hash = await hardhat.writeContract({
+      ...sortitionModuleContractConfig,
+      functionName: "passPhase",
+      account,
+    });
+    await hardhat.waitForTransactionReceipt({ hash });
+    await time.sync();
+  };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const currentPhase = await getPhase();
+    // we go through the loop and once we reach the target phase we return
+    if (currentPhase === targetPhase) return;
+
+    const blockTime = await time.getHardhatTime();
+    const lastPhaseChange = Number(await getLastPhaseChange());
+    const minStakingTime = Number(await getMinStakingTime());
+    const maxDrawingTime = Number(await getMaxDrawingTime());
+    // if there's no disputes that need jurors, the phase wont pass
+    const disputesWithoutJurors = await getDisputesWithoutJurors();
+
+    if (currentPhase === SortitionPhase.Staking) {
+      const elapsed = blockTime - lastPhaseChange;
+      if (elapsed < minStakingTime) {
+        const timeToAdvance = minStakingTime - elapsed + 1;
+        await time.advanceTime(timeToAdvance);
+      }
+      if (disputesWithoutJurors === 0n) {
+        throw new Error(`passToPhase: Cannot pass from staking to generating - no disputes need jurors`);
+      }
+    } else if (currentPhase === SortitionPhase.Drawing) {
+      const elapsed = blockTime - lastPhaseChange;
+      if (disputesWithoutJurors > 0n && elapsed < maxDrawingTime) {
+        const timeToAdvance = maxDrawingTime - elapsed + 1;
+        await time.advanceTime(timeToAdvance);
+      }
+    }
+
+    try {
+      await callPassPhase();
+    } catch (err) {
+      if (currentPhase === SortitionPhase.Generating) {
+        // rng could be stuck, advancing by a significant time to trigger fallback
+        await time.advanceTime(10 * ONE_MINUTE);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const finalPhase = await getPhase();
+  throw new Error(
+    `passToPhase: Failed to reach phase ${PHASE_NAMES[targetPhase]} 
+     after ${maxAttempts} attempts, stuck at ${PHASE_NAMES[finalPhase]}`
+  );
+}

--- a/web/src/tests/e2e/utils/setupCase.ts
+++ b/web/src/tests/e2e/utils/setupCase.ts
@@ -1,0 +1,94 @@
+import { getContract } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { prepareArbitratorExtradata } from "utils/prepareArbitratorExtradata";
+
+import type { HardhatClient } from "../fixtures/hardhat";
+
+import { disputeResolverContractConfig, klerosCoreContractConfig } from "./contracts";
+import { createDisputeTemplate, createDisputeData, type DisputeData } from "./dispute";
+
+import { ACCOUNT_PKEYS, AccountKey } from "./index";
+
+/** Options for setupCase - can override any field from DisputeData */
+export type SetupCaseOptions = Partial<DisputeData>;
+
+export interface SetupCaseResult {
+  /** The created dispute ID */
+  disputeId: bigint;
+  /** Dispute data used to create the case */
+  disputeData: DisputeData;
+}
+
+/**
+ * Sets up a dispute case for e2e testing.
+ *
+ * @param hardhat - The hardhat client from the fixture
+ * @param accountKey - Key of the account to use from ACCOUNT_PKEYS ("alice", "bob")
+ * @param options - Optional case configuration (overrides defaults from DEFAULT_DISPUTE_DATA)
+ *
+ * @returns Object containing the dispute ID and the dispute data used to create the case
+ *
+ * @note The disputeId returned is incremental, if called multiple times it will increment
+ *       since we cannot reset hardhat without subgraph failing for now
+ *
+ * @example
+ * ```ts
+ * const { disputeId, disputeData } = await setupCase(hardhat, "alice", {
+ *   courtId: "1",
+ *   numberOfJurors: 3,
+ *   title: "Test Dispute",
+ *   description: "A test dispute for e2e testing",
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { DISPUTE_SCENARIOS } from "./dispute";
+ * const { disputeId } = await setupCase(hardhat, "alice", DISPUTE_SCENARIOS.classicKit);
+ * ```
+ */
+export async function setupCase(
+  hardhat: HardhatClient,
+  accountKey: AccountKey,
+  options: SetupCaseOptions = {}
+): Promise<SetupCaseResult> {
+  const disputeData = createDisputeData(options);
+  const { courtId, numberOfJurors, disputeKitId, answers } = disputeData;
+
+  const privateKey = ACCOUNT_PKEYS[accountKey];
+  const account = privateKeyToAccount(privateKey);
+
+  const extraData = prepareArbitratorExtradata(courtId, numberOfJurors, disputeKitId);
+
+  // Create dispute template
+  const disputeTemplate = createDisputeTemplate(disputeData);
+
+  const klerosCore = getContract({
+    ...klerosCoreContractConfig,
+    client: hardhat,
+  });
+
+  const arbitrationCost = await klerosCore.read.arbitrationCost([extraData]);
+
+  // dispute through disputeResolver
+  const { request, result: disputeId } = await hardhat.simulateContract({
+    ...disputeResolverContractConfig,
+    functionName: "createDisputeForTemplate",
+    args: [extraData, disputeTemplate, "", BigInt(answers.length)],
+    value: arbitrationCost,
+    account,
+  });
+
+  const hash = await hardhat.writeContract(request);
+  await hardhat.waitForTransactionReceipt({ hash });
+
+  // I could have used isUndefined here, but it creates issues with package resolution
+  if (disputeId === undefined || disputeId === null) {
+    throw new Error("setupCase: Unable to retrieve dispute id");
+  }
+
+  return { disputeId, disputeData };
+}
+
+export default setupCase;

--- a/web/src/tests/e2e/utils/setupCase.ts
+++ b/web/src/tests/e2e/utils/setupCase.ts
@@ -81,7 +81,11 @@ export async function setupCase(
   });
 
   const hash = await hardhat.writeContract(request);
-  await hardhat.waitForTransactionReceipt({ hash });
+  const receipt = await hardhat.waitForTransactionReceipt({ hash });
+
+  if (receipt.status === "reverted") {
+    throw new Error(`setupCase: Failed to setup case - 'createDisputeForTemplate' reverted`);
+  }
 
   // I could have used isUndefined here, but it creates issues with package resolution
   if (disputeId === undefined || disputeId === null) {

--- a/web/src/tests/e2e/utils/setupStake.ts
+++ b/web/src/tests/e2e/utils/setupStake.ts
@@ -1,0 +1,76 @@
+import { parseUnits } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { NumberString } from "utils/types";
+
+import { TimeFixture } from "../fixtures";
+import type { HardhatClient } from "../fixtures/hardhat";
+
+import { klerosCoreContractConfig, pnkTokenContractConfig } from "./contracts";
+
+import { ACCOUNT_PKEYS, AccountKey, GENERAL_COURT_ID, passToPhase, PNK_DECIMALS, SortitionPhase } from "./index";
+
+export type SetupStakeOptions = Partial<{
+  /** Amount to stake in number string (not parsed, e.g. 1, 10 etc)  */
+  amount: NumberString;
+  courtId: bigint;
+}>;
+
+/**
+ * Sets up stake in the mentioned court for the specified account.
+ * Stakes 1000 PNK by default, can be overridden through `options`
+ *
+ * @param hardhat - The hardhat client from the fixture
+ * @param time - Time fixture used by passToPhase
+ * @param accountKey - Key of the account to use from ACCOUNT_PKEYS ("alice", "bob")
+ * @param options - Optional stake configuration (overrides defaults)
+ *
+ * @note The phase passing is handled by this function itself
+ *
+ * @example
+ * ```ts
+ * setupStake(hardhatClient, timeFixture, "alice", {
+ *   courtId: 1n,
+ *   amount: "1000",
+ * });
+ * ```
+ */
+export async function setupStake(
+  hardhat: HardhatClient,
+  time: TimeFixture,
+  accountKey: AccountKey,
+  options: SetupStakeOptions = {}
+) {
+  const stakeOptions = { amount: "1000", courtId: GENERAL_COURT_ID, ...options };
+  const { courtId, amount } = stakeOptions;
+
+  const parsedStakeAmount = parseUnits(amount, PNK_DECIMALS);
+
+  const privateKey = ACCOUNT_PKEYS[accountKey];
+  const account = privateKeyToAccount(privateKey);
+
+  // check for phase and pass it to staking
+  await passToPhase(hardhat, time, SortitionPhase.Staking);
+
+  const approvalHash = await hardhat.writeContract({
+    ...pnkTokenContractConfig,
+    functionName: "approve",
+    args: [klerosCoreContractConfig.address, parsedStakeAmount],
+    account,
+  });
+  await hardhat.waitForTransactionReceipt({ hash: approvalHash });
+
+  const hash = await hardhat.writeContract({
+    ...klerosCoreContractConfig,
+    functionName: "setStake",
+    args: [courtId, parsedStakeAmount],
+    account,
+  });
+
+  const receipt = await hardhat.waitForTransactionReceipt({ hash });
+
+  if (receipt.status === "reverted")
+    throw new Error(`setupStake: Failed to set stake for ${accountKey} in court ${courtId}`);
+}
+
+export default setupStake;

--- a/web/src/tests/e2e/utils/setupStake.ts
+++ b/web/src/tests/e2e/utils/setupStake.ts
@@ -58,7 +58,11 @@ export async function setupStake(
     args: [klerosCoreContractConfig.address, parsedStakeAmount],
     account,
   });
-  await hardhat.waitForTransactionReceipt({ hash: approvalHash });
+  const approvalReceipt = await hardhat.waitForTransactionReceipt({ hash: approvalHash });
+
+  if (approvalReceipt.status === "reverted") {
+    throw new Error(`setupStake: Failed to approve stake for ${accountKey} in court ${courtId}`);
+  }
 
   const hash = await hardhat.writeContract({
     ...klerosCoreContractConfig,
@@ -69,8 +73,9 @@ export async function setupStake(
 
   const receipt = await hardhat.waitForTransactionReceipt({ hash });
 
-  if (receipt.status === "reverted")
+  if (receipt.status === "reverted") {
     throw new Error(`setupStake: Failed to set stake for ${accountKey} in court ${courtId}`);
+  }
 }
 
 export default setupStake;

--- a/web/src/tests/e2e/voting.spec.ts
+++ b/web/src/tests/e2e/voting.spec.ts
@@ -1,0 +1,80 @@
+import { RefuseToArbitrateAnswer } from "@kleros/kleros-sdk";
+
+import { expect, test } from "./fixtures";
+import { DISPUTE_SCENARIOS, passToPhase, setupCase, setupStake, SortitionPhase } from "./utils";
+import { executeRulingForDispute, drawJurors, passPeriod } from "./utils/dispute";
+
+// TODO: add support for DK specific flow and support for hiddenVotes
+test.describe("Voting tests", () => {
+  let disputeId: bigint | null = null;
+
+  test.beforeEach(async ({ page, wallet, hardhat, time }) => {
+    await page.goto("/");
+    // note that alice being the first account and deployer already has the PNK
+    await wallet.connect("alice");
+
+    // Alice stakes in general court
+    await setupStake(hardhat, time, "alice");
+
+    const disputeRes = await setupCase(hardhat, "alice", DISPUTE_SCENARIOS.simple);
+    disputeId = disputeRes.disputeId;
+
+    expect(disputeId).toBeDefined();
+
+    await passToPhase(hardhat, time, SortitionPhase.Drawing);
+
+    // Alice staked above, will be drawn with this
+    await drawJurors(hardhat, disputeId!);
+
+    // pass period to commit/voting
+    await passPeriod(hardhat, time, disputeId!);
+  });
+
+  test("should allow alice to vote", async ({ page, hardhat, time }) => {
+    // making sure the case was created
+    expect(disputeId).toBeDefined();
+
+    await page.goto(`/#/cases/${disputeId}/overview`);
+
+    await expect(page.getByText(`Case #${disputeId}`)).toBeVisible({ timeout: 30_000 });
+
+    // go to Votes Tab
+    await page.getByRole("button", { name: "Votes" }).click();
+
+    const optionOneName = DISPUTE_SCENARIOS.simple.answers[0].title;
+    const optionTwoName = DISPUTE_SCENARIOS.simple.answers[1].title;
+
+    // checking that options are available
+    await expect(page.getByRole("button", { name: optionOneName })).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: optionTwoName })).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: RefuseToArbitrateAnswer.title })).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole("button", { name: optionOneName }).click();
+
+    // popup after committing
+    await expect(page.getByText("Thanks for voting")).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+
+    // passing to vote period
+    await passPeriod(hardhat, time, disputeId!);
+
+    // vote/ reveal vote
+    await page.getByLabel("editable markdown").fill("Test description");
+    // NOTE: this will ask for signature to reveal and then reveal/vote
+    await page.getByRole("button", { name: "Justify & Reveal" }).click();
+
+    // passing to appeal period
+    await passPeriod(hardhat, time, disputeId!);
+
+    // passing to execution period
+    await passPeriod(hardhat, time, disputeId!);
+
+    await executeRulingForDispute(hardhat, disputeId!);
+
+    // going to Overview Tab
+    await page.getByRole("button", { name: "Overview" }).click();
+
+    await expect(page.getByText("Case Closed")).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/web/src/utils/retrieveDisputeId.ts
+++ b/web/src/utils/retrieveDisputeId.ts
@@ -1,0 +1,38 @@
+import { decodeEventLog, getAbiItem, Log, Address, toEventSelector } from "viem";
+
+import { DEFAULT_CHAIN } from "consts/chains";
+import { klerosCoreAbi, klerosCoreAddress } from "hooks/contracts/generated";
+
+/**
+ * Extracts the dispute ID from DisputeCreation event emitted by Kleros core.
+ *
+ * @param logs - Logs array from dispute transaction receipt
+ * @param coreAddress - kleros core address (optional)
+ * @returns The dispute ID if found, otherwise `undefined`
+ * @todo Write unit test
+ */
+export function retrieveDisputeIdFromLogs(
+  logs: readonly Log[],
+  coreAddress: Address = klerosCoreAddress[DEFAULT_CHAIN.id]
+) {
+  const eventAbi = getAbiItem({
+    abi: klerosCoreAbi,
+    name: "DisputeCreation",
+  });
+
+  const disputeCreationEventTopic = toEventSelector(eventAbi);
+
+  const log = logs.find(
+    (l) => l.address.toLowerCase() === coreAddress.toLowerCase() && l.topics[0] === disputeCreationEventTopic
+  );
+
+  if (!log) return undefined;
+
+  const { args } = decodeEventLog({
+    abi: [eventAbi],
+    data: log.data,
+    topics: log.topics,
+  });
+
+  return args._disputeID;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the dispute handling and voting mechanisms in the project. It introduces new utility functions, refines existing ones, and updates configurations for better integration with the Kleros dispute resolution framework.

### Detailed summary
- Added error logging in `usePopulatedDisputeData.ts`.
- Updated `05-dispute-kit-acp.ts` with new court configurations.
- Introduced `HardhatClient` type in `hardhat.ts`.
- Mocked IPFS hash in `atlas.ts`.
- Exported `RefuseToArbitrateAnswer` in `disputeDetailsTypes.ts`.
- Defined `ACCOUNT_PKEYS` for hardhat accounts in `accounts.ts`.
- Updated test fixture imports in `index.ts`.
- Implemented `executeRulingForDispute` and `getDisputeInfo` functions.
- Enhanced dispute data handling in `dispute/index.ts`.
- Configured dispute kits in `deployments/hardhat.viem.ts`.
- Added juror management functions in the dispute kit ABI.

> The following files were skipped due to too many changes: `contracts/deployments/hardhat.viem.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redirect to cases listing when dispute ID cannot be retrieved; added warning logs for dispute data errors.

* **New Features**
  * Voting now exposes a "Refuse to Arbitrate" option in the voting flow.

* **Tests**
  * Expanded end-to-end test suite and utilities covering staking, case setup, juror drawing, time control, phase transitions, voting, and ruling execution.

* **Chores**
  * Updated local configuration and start script to include Argentina Consumer Protection dispute kit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->