### PR TITLE
feat: partial coherence DK

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -993,12 +993,12 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             coherence = ONE_BASIS_POINT;
         }
 
+        // Unlock all the PNKs for this draw.
+        address account = round.drawnJurors[_params.repartition];
+        sortitionModule.unlockStake(account, round.pnkAtStakePerJuror);
+
         // Fully coherent jurors won't be penalized.
         uint256 penalty = (round.pnkAtStakePerJuror * (ONE_BASIS_POINT - coherence)) / ONE_BASIS_POINT;
-
-        // Unlock the PNKs affected by the penalty
-        address account = round.drawnJurors[_params.repartition];
-        sortitionModule.unlockStake(account, penalty);
 
         // Apply the penalty to the staked PNKs.
         uint96 penalizedInCourtID = round.drawnJurorFromCourtIDs[_params.repartition];
@@ -1069,12 +1069,6 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             feeCoherence = ONE_BASIS_POINT;
         }
 
-        address account = round.drawnJurors[repartition];
-        uint256 pnkLocked = (round.pnkAtStakePerJuror * pnkCoherence) / ONE_BASIS_POINT;
-
-        // Release the rest of the PNKs of the juror for this round.
-        sortitionModule.unlockStake(account, pnkLocked);
-
         // Compute the rewards
         (uint256 pnkReward, uint256 feeReward) = disputeKit.getRewards(
             _params.disputeID,
@@ -1095,6 +1089,8 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             feeReward = round.totalFeesForJurors - round.sumFeeRewardPaid;
         }
         round.sumFeeRewardPaid += feeReward;
+
+        address account = round.drawnJurors[repartition];
 
         if (feeReward != 0) {
             // Transfer the fee reward

--- a/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
@@ -12,7 +12,7 @@ import {ONE_BASIS_POINT} from "../../libraries/Constants.sol";
 
 /// @title DisputeKitAsymmetricPlurality
 /// @notice Dispute kit implementation adapted from DisputeKitClassic
-/// - a drawing system: at most 1 vote per juror registered on Proof of Humanity,
+/// - a drawing system: proportional to staked PNK,
 /// - a vote aggregation system: asymmetric plurality. The coherence differentiates between choices,
 /// - an incentive system: equal split between coherent votes,
 /// - an appeal system: fund 2 choices only, vote on any choice.

--- a/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
@@ -35,12 +35,12 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     }
 
     struct Round {
-        Vote[] votes; // Former votes[_appeal][].
+        Vote[] votes; // Stores the votes cast in this round. Former votes[_appeal][].
         uint256 winningChoice; // The choice with the most votes. Note that in the case of a tie, it is the choice that reached the tied number of votes first.
         mapping(uint256 => uint256) counts; // The sum of votes for each choice in the form `counts[choice]`.
         bool tied; // True if there is a tie, false otherwise.
-        uint256 totalVoted; // Former uint[_appeal] votesInEachRound.
-        uint256 totalCommitted; // Former commitsInRound.
+        uint256 totalVoted; // A counter of votes made in the current round. Former uint[_appeal] votesInEachRound.
+        uint256 totalCommitted; // A counter of commits made in the current round. Former commitsInRound.
         mapping(uint256 choiceId => uint256) paidFees; // Tracks the fees paid for each choice in this round.
         mapping(uint256 choiceId => bool) hasPaid; // True if this choice was fully funded, false otherwise.
         mapping(address account => mapping(uint256 choiceId => uint256)) contributions; // Maps contributors to their contributions for each choice.
@@ -87,7 +87,6 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     mapping(uint96 currentCourtID => NextRoundSettings) public courtIDToNextRoundSettings; // The settings for the next round.
     mapping(uint256 choice => uint256 winningCoherence) public winningCoherences; // Specifies different coherence for certain winning choices (affects rewards). If not specified coherence will default to 1.
     mapping(uint256 choice => uint256 losingCoherence) public losingCoherences; // Specifies different coherence for certain losing choices (affects penalties). If not specified coherence will default to 0.
-    bool public singleDrawPerJuror; // Whether each juror can only draw once per round, false by default.
     address public wNative; // The wrapped native token for safeSend().
 
     uint256[50] private __gap; // Reserved slots for future upgrades.
@@ -224,14 +223,14 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     /// @param _destination The destination of the call.
     /// @param _amount The value sent with the call.
     /// @param _data The data sent with the call.
-    function executeOwnerProposal(address _destination, uint256 _amount, bytes memory _data) external onlyByOwner {
+    function executeOwnerProposal(address _destination, uint256 _amount, bytes calldata _data) external onlyByOwner {
         (bool success, ) = _destination.call{value: _amount}(_data);
         require(success, UnsuccessfulCall());
     }
 
     /// @notice Changes the `owner` storage variable.
     /// @param _owner The new value for the `owner` storage variable.
-    function changeOwner(address payable _owner) external onlyByOwner {
+    function changeOwner(address _owner) external onlyByOwner {
         owner = _owner;
     }
 
@@ -313,9 +312,9 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
             localDisputeID = disputes.length;
             dispute = disputes.push();
             coreDisputeIDToLocal[_coreDisputeID] = localDisputeID;
+            active.dispute = true;
         }
 
-        active.dispute = true;
         active.currentRound = true;
         dispute.numberOfChoices = _numberOfChoices;
         dispute.extraData = _extraData;
@@ -352,13 +351,9 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
             return (drawnAddress, fromSubcourtID);
         }
 
-        if (_postDrawCheck(_coreDisputeID, drawnAddress)) {
-            Vote storage vote = round.votes.push();
-            vote.account = drawnAddress;
-            round.alreadyDrawn[drawnAddress] = true;
-        } else {
-            drawnAddress = address(0);
-        }
+        Vote storage vote = round.votes.push();
+        vote.account = drawnAddress;
+        round.alreadyDrawn[drawnAddress] = true;
     }
 
     /// @notice Sets the caller's commit for the specified votes.
@@ -381,7 +376,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
 
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
-        // Introduce a counter so we don't count a re-commited votes.
+        // Introduce a counter so we don't count a re-committed votes.
         uint256 commitCount;
         for (uint256 i = 0; i < _voteIDs.length; i++) {
             require(round.votes[_voteIDs[i]].account == msg.sender, JurorHasToOwnTheVote());
@@ -473,7 +468,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
         require(block.timestamp >= appealPeriodStart && block.timestamp < appealPeriodEnd, NotAppealPeriod());
 
         uint256 multiplier;
-        (uint256 ruling, , ) = this.currentRuling(_coreDisputeID);
+        (uint256 ruling, , ) = currentRuling(_coreDisputeID);
         if (ruling == _choice) {
             multiplier = WINNER_STAKE_MULTIPLIER;
         } else {
@@ -607,7 +602,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     /// @return overridden Whether the ruling was overridden by appeal funding or not.
     function currentRuling(
         uint256 _coreDisputeID
-    ) external view override returns (uint256 ruling, bool tied, bool overridden) {
+    ) public view override returns (uint256 ruling, bool tied, bool overridden) {
         Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
         tied = round.tied;
@@ -625,6 +620,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     }
 
     /// @notice Gets the degree of coherence of a particular voter.
+    /// @notice Intended to be called by KlerosCore. External callers must validate inputs beforehand.
     /// @dev This function is called by Kleros Core in order to determine the amount of the reward.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
@@ -655,13 +651,14 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     }
 
     /// @notice Gets the degree of coherence of a particular voter.
+    /// @notice Intended to be called by KlerosCore. External callers must validate inputs beforehand.
     /// @dev This function is called by Kleros Core in order to determine the amount of the penalty.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
     /// @param _voteID The ID of the vote.
     /// @param - feePerJuror The fee per juror. Unused, required by interface.
     /// @param - pnkAtStakePerJuror The PNK at stake per juror. Unused, required by interface.
-    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK penalty.
     function getDegreeOfCoherencePenalty(
         uint256 _coreDisputeID,
         uint256 _coreRoundID,
@@ -684,6 +681,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     }
 
     /// @notice Gets the number of jurors who are eligible to a reward in this round.
+    /// @notice Intended to be called by KlerosCore. External callers must validate inputs beforehand.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
     /// @return The number of coherent jurors.
@@ -702,6 +700,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
     }
 
     /// @notice Gets the rewards for PNK and fees based on coherence and total reward pool.
+    /// @notice Intended to be called by KlerosCore. External callers must validate inputs beforehand.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
     /// @param - voteID The ID of the vote. Unused, required by interface.
@@ -833,7 +832,7 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
         return vote.voted;
     }
 
-    /// @notice Returns the info of the specified round in the core contract.
+    /// @notice Returns the info of the specified round in the Dispute kit.
     /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
     /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
     /// @param _choice The choice to query.
@@ -933,27 +932,6 @@ contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxia
                 disputes[_localDisputeID].rounds[_localRoundID].votes[_voteIDs[i]].commit == actualVoteHash,
                 ChoiceCommitmentMismatch()
             );
-        }
-    }
-
-    /// @notice Checks that the chosen address satisfies certain conditions for being drawn.
-    ///
-    /// @dev No need to check the minStake requirement here because of the implicit staking in parent courts.
-    /// minStake is checked directly during staking process however it's possible for the juror to get drawn
-    /// while having < minStake if it is later increased by governance.
-    /// This issue is expected and harmless.
-    ///
-    /// @param _coreDisputeID ID of the dispute in the core contract.
-    /// @param _juror Chosen address.
-    /// @return Whether the address passes the check or not.
-    function _postDrawCheck(uint256 _coreDisputeID, address _juror) internal view returns (bool) {
-        if (singleDrawPerJuror) {
-            uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
-            Dispute storage dispute = disputes[localDisputeID];
-            Round storage round = dispute.rounds[dispute.rounds.length - 1];
-            return !round.alreadyDrawn[_juror];
-        } else {
-            return true;
         }
     }
 

--- a/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitAsymmetricPlurality.sol
@@ -1,0 +1,985 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {KlerosCore} from "../KlerosCore.sol";
+import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
+import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
+import {Initializable} from "../../proxy/Initializable.sol";
+import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
+import {SafeSend} from "../../libraries/SafeSend.sol";
+import {ONE_BASIS_POINT} from "../../libraries/Constants.sol";
+
+/// @title DisputeKitAsymmetricPlurality
+/// @notice Dispute kit implementation adapted from DisputeKitClassic
+/// - a drawing system: at most 1 vote per juror registered on Proof of Humanity,
+/// - a vote aggregation system: asymmetric plurality. The coherence differentiates between choices,
+/// - an incentive system: equal split between coherent votes,
+/// - an appeal system: fund 2 choices only, vote on any choice.
+/// Note that if coherence is not specified it defaults to standard values: 1 for winning choices and 0 for losing choices.
+contract DisputeKitAsymmetricPlurality is IDisputeKit, Initializable, UUPSProxiable {
+    string public constant override version = "2.0.0";
+
+    using SafeSend for address payable;
+
+    // ************************************* //
+    // *             Structs               * //
+    // ************************************* //
+
+    struct Dispute {
+        Round[] rounds; // Rounds of the dispute. 0 is the default round, and [1, ..n] are the appeal rounds.
+        uint256 numberOfChoices; // The number of choices jurors have when voting. This does not include choice `0` which is reserved for "refuse to arbitrate".
+        mapping(uint256 => uint256) coreRoundIDToLocal; // Maps id of the round in the core contract to the index of the round of related local dispute.
+        bytes extraData; // Extradata for the dispute.
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    struct Round {
+        Vote[] votes; // Former votes[_appeal][].
+        uint256 winningChoice; // The choice with the most votes. Note that in the case of a tie, it is the choice that reached the tied number of votes first.
+        mapping(uint256 => uint256) counts; // The sum of votes for each choice in the form `counts[choice]`.
+        bool tied; // True if there is a tie, false otherwise.
+        uint256 totalVoted; // Former uint[_appeal] votesInEachRound.
+        uint256 totalCommitted; // Former commitsInRound.
+        mapping(uint256 choiceId => uint256) paidFees; // Tracks the fees paid for each choice in this round.
+        mapping(uint256 choiceId => bool) hasPaid; // True if this choice was fully funded, false otherwise.
+        mapping(address account => mapping(uint256 choiceId => uint256)) contributions; // Maps contributors to their contributions for each choice.
+        uint256 feeRewards; // Sum of reimbursable appeal fees available to the parties that made contributions to the ruling that ultimately wins a dispute.
+        uint256[] fundedChoices; // Stores the choices that are fully funded.
+        mapping(address drawnAddress => bool) alreadyDrawn; // True if the address has already been drawn, false by default.
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    struct Vote {
+        bool voted; // True if the vote has been cast.
+        address account; // The address of the juror.
+        bytes32 commit; // The commit of the juror. For courts with hidden votes.
+        uint256 choice; // The choice of the juror.
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    struct Active {
+        bool dispute; // True if at least one round in the dispute has been active on this Dispute Kit. False if the dispute is unknown to this Dispute Kit.
+        bool currentRound; // True if the dispute's current round is active on this Dispute Kit. False if the dispute has jumped to another Dispute Kit.
+    }
+
+    struct NextRoundSettings {
+        bool enabled; // True if the settings are enabled, false otherwise.
+        uint96 jumpCourtID; // A non-zero value makes the next round use this court ID. Zero is considered as undefined.
+        uint256 jumpDisputeKitID; // A non-zero value makes the next round use this dispute kit ID. Zero is considered as undefined.
+        uint256 jumpDisputeKitIDOnCourtJump; // A non-zero value makes the next round use this dispute kit ID ONLY IF the court jumps and `jumpDisputeKitID` is undefined. Zero is considered as undefined.
+        uint256 nbVotes; // A non-zero value makes the next round use this number of votes. Zero is considered as undefined.
+    }
+
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    uint256 public constant WINNER_STAKE_MULTIPLIER = 10000; // Multiplier of the appeal cost that the winner has to pay as fee stake for a round in basis points. Default is 1x of appeal fee.
+    uint256 public constant LOSER_STAKE_MULTIPLIER = 20000; // Multiplier of the appeal cost that the loser has to pay as fee stake for a round in basis points. Default is 2x of appeal fee.
+    uint256 public constant LOSER_APPEAL_PERIOD_MULTIPLIER = 5000; // Multiplier of the appeal period for the choice that wasn't voted for in the previous round, in basis points. Default is 1/2 of original appeal period.
+
+    address public owner; // The owner of the contract.
+    KlerosCore public core; // The Kleros Core arbitrator
+    Dispute[] public disputes; // Array of the locally created disputes.
+    mapping(uint256 coreDisputeID => uint256 localDisputeID) public coreDisputeIDToLocal; // Maps the dispute ID in Kleros Core to the local dispute ID.
+    mapping(uint256 coreDisputeID => Active) public coreDisputeIDToActive; // Active status of the dispute and the current round.
+    mapping(uint96 currentCourtID => NextRoundSettings) public courtIDToNextRoundSettings; // The settings for the next round.
+    mapping(uint256 choice => uint256 winningCoherence) public winningCoherences; // Specifies different coherence for certain winning choices (affects rewards). If not specified coherence will default to 1.
+    mapping(uint256 choice => uint256 losingCoherence) public losingCoherences; // Specifies different coherence for certain losing choices (affects penalties). If not specified coherence will default to 0.
+    bool public singleDrawPerJuror; // Whether each juror can only draw once per round, false by default.
+    address public wNative; // The wrapped native token for safeSend().
+
+    uint256[50] private __gap; // Reserved slots for future upgrades.
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @notice To be emitted when a dispute is created.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _numberOfChoices The number of choices available in the dispute.
+    /// @param _extraData The extra data for the dispute.
+    event DisputeCreation(uint256 indexed _coreDisputeID, uint256 _numberOfChoices, bytes _extraData);
+
+    /// @notice To be emitted when a vote commitment is cast.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _juror The address of the juror casting the vote commitment.
+    /// @param _voteIDs The identifiers of the votes in the dispute.
+    /// @param _commit The commitment of the juror.
+    event CommitCast(uint256 indexed _coreDisputeID, address indexed _juror, uint256[] _voteIDs, bytes32 _commit);
+
+    /// @notice To be emitted when a funding contribution is made.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount contributed.
+    event Contribution(
+        uint256 indexed _coreDisputeID,
+        uint256 indexed _coreRoundID,
+        uint256 _choice,
+        address indexed _contributor,
+        uint256 _amount
+    );
+
+    /// @notice To be emitted when the contributed funds are withdrawn.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    /// @param _contributor The address of the contributor.
+    /// @param _amount The amount withdrawn.
+    event Withdrawal(uint256 indexed _coreDisputeID, uint256 _choice, address indexed _contributor, uint256 _amount);
+
+    /// @notice To be emitted when a choice is fully funded for an appeal.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _coreRoundID The identifier of the round in the Arbitrator contract.
+    /// @param _choice The choice that is being funded.
+    event ChoiceFunded(uint256 indexed _coreDisputeID, uint256 indexed _coreRoundID, uint256 indexed _choice);
+
+    /// @notice To be emitted when the next round settings are changed.
+    /// @param _courtID The ID of the court that the settings are changed for.
+    /// @param _nextRoundSettings The settings for the next round.
+    event NextRoundSettingsChanged(uint96 indexed _courtID, NextRoundSettings _nextRoundSettings);
+
+    // ************************************* //
+    // *              Modifiers            * //
+    // ************************************* //
+
+    modifier onlyByOwner() {
+        require(owner == msg.sender, OwnerOnly());
+        _;
+    }
+
+    modifier onlyByCore() {
+        require(address(core) == msg.sender, KlerosCoreOnly());
+        _;
+    }
+
+    modifier isActive(uint256 _coreDisputeID) {
+        require(coreDisputeIDToActive[_coreDisputeID].dispute, DisputeUnknownInThisDisputeKit());
+        require(coreDisputeIDToActive[_coreDisputeID].currentRound, DisputeJumpedToAnotherDisputeKit());
+        _;
+    }
+
+    modifier whenArbitrationNotPaused() {
+        require(!core.arbitrationPaused(), WhenArbitrationNotPausedOnly());
+        _;
+    }
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializer.
+    /// @param _owner The owner's address.
+    /// @param _core The KlerosCore arbitrator.
+    /// @param _wNative The wrapped native token address, typically wETH.
+    /// @param _asymmetricalWinningChoices Array of choices that will have their winning coherence specified.
+    /// @param _winningCoherences Array of respective coherence values for winning choices.
+    /// @param _asymmetricalLosingChoices Array of choices that will have their losing coherence specified
+    /// @param _losingCoherences Array of respective coherence values for losing choices.
+    function initialize(
+        address _owner,
+        KlerosCore _core,
+        address _wNative,
+        uint256[] memory _asymmetricalWinningChoices,
+        uint256[] memory _winningCoherences,
+        uint256[] memory _asymmetricalLosingChoices,
+        uint256[] memory _losingCoherences
+    ) external initializer {
+        owner = _owner;
+        core = _core;
+        wNative = _wNative;
+
+        require(_asymmetricalWinningChoices.length == _winningCoherences.length, CoherenceArrayLengthMismatch());
+        require(_asymmetricalLosingChoices.length == _losingCoherences.length, CoherenceArrayLengthMismatch());
+
+        for (uint256 i = 0; i < _asymmetricalWinningChoices.length; i++) {
+            require(_winningCoherences[i] <= ONE_BASIS_POINT, CoherenceOutOfScope());
+            winningCoherences[_asymmetricalWinningChoices[i]] = _winningCoherences[i];
+        }
+
+        for (uint256 i = 0; i < _asymmetricalLosingChoices.length; i++) {
+            require(_losingCoherences[i] <= ONE_BASIS_POINT, CoherenceOutOfScope());
+            losingCoherences[_asymmetricalLosingChoices[i]] = _losingCoherences[i];
+        }
+    }
+
+    // ************************ //
+    // *      Governance      * //
+    // ************************ //
+
+    /// @dev Access Control to perform implementation upgrades (UUPS Proxiable)
+    ///      Only the owner can perform upgrades (`onlyByOwner`)
+    function _authorizeUpgrade(address) internal view override onlyByOwner {
+        // NOP
+    }
+
+    /// @notice Allows the owner to call anything on behalf of the contract.
+    /// @param _destination The destination of the call.
+    /// @param _amount The value sent with the call.
+    /// @param _data The data sent with the call.
+    function executeOwnerProposal(address _destination, uint256 _amount, bytes memory _data) external onlyByOwner {
+        (bool success, ) = _destination.call{value: _amount}(_data);
+        require(success, UnsuccessfulCall());
+    }
+
+    /// @notice Changes the `owner` storage variable.
+    /// @param _owner The new value for the `owner` storage variable.
+    function changeOwner(address payable _owner) external onlyByOwner {
+        owner = _owner;
+    }
+
+    /// @notice Changes the `core` storage variable.
+    /// @param _core The new value for the `core` storage variable.
+    function changeCore(address _core) external onlyByOwner {
+        core = KlerosCore(_core);
+    }
+
+    /// @notice Changes the settings for the next round.
+    /// @param _courtID The ID of the court that the settings are changed for.
+    /// @param _nextRoundSettings The settings for the next round.
+    function changeNextRoundSettings(
+        uint96 _courtID,
+        NextRoundSettings memory _nextRoundSettings
+    ) external onlyByOwner {
+        courtIDToNextRoundSettings[_courtID] = _nextRoundSettings;
+        emit NextRoundSettingsChanged(_courtID, _nextRoundSettings);
+    }
+
+    /// @notice Changes winning coherences of specified choices.
+    /// @param _asymmetricalWinningChoices Array of choices that will have their winning coherence specified.
+    /// @param _winningCoherences Array of respective coherence values for winning choices.
+    function changeWinningCoherences(
+        uint256[] memory _asymmetricalWinningChoices,
+        uint256[] memory _winningCoherences
+    ) external onlyByOwner {
+        require(_asymmetricalWinningChoices.length == _winningCoherences.length, CoherenceArrayLengthMismatch());
+
+        for (uint256 i = 0; i < _asymmetricalWinningChoices.length; i++) {
+            require(_winningCoherences[i] <= ONE_BASIS_POINT, CoherenceOutOfScope());
+            winningCoherences[_asymmetricalWinningChoices[i]] = _winningCoherences[i];
+        }
+    }
+
+    /// @notice Changes losing coherences of specified choices.
+    /// @param _asymmetricalLosingChoices Array of choices that will have their losing coherence specified
+    /// @param _losingCoherences Array of respective coherence values for losing choices.
+    function changeLosingCoherences(
+        uint256[] memory _asymmetricalLosingChoices,
+        uint256[] memory _losingCoherences
+    ) external onlyByOwner {
+        require(_asymmetricalLosingChoices.length == _losingCoherences.length, CoherenceArrayLengthMismatch());
+
+        for (uint256 i = 0; i < _asymmetricalLosingChoices.length; i++) {
+            require(_losingCoherences[i] <= ONE_BASIS_POINT, CoherenceOutOfScope());
+            losingCoherences[_asymmetricalLosingChoices[i]] = _losingCoherences[i];
+        }
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /// @notice Creates a local dispute and maps it to the dispute ID in the Core contract.
+    /// @dev Access restricted to Kleros Core only.
+    /// @dev The new `KlerosCore.Round` must be created before calling this function.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _numberOfChoices Number of choices of the dispute
+    /// @param _extraData Additional info about the dispute, for possible use in future dispute kits.
+    /// @param - nbVotes Maximal number of votes this dispute can get. Added for future-proofing.
+    function createDispute(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _numberOfChoices,
+        bytes calldata _extraData,
+        uint256 /*_nbVotes*/
+    ) public override onlyByCore {
+        uint256 localDisputeID;
+        Dispute storage dispute;
+        Active storage active = coreDisputeIDToActive[_coreDisputeID];
+        if (active.dispute) {
+            // The dispute has already been created in this DK in a previous round. E.g. if DK1 jumps to DK2 and then back to DK1.
+            localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
+            dispute = disputes[localDisputeID];
+        } else {
+            // The dispute has not been created in this DK yet.
+            localDisputeID = disputes.length;
+            dispute = disputes.push();
+            coreDisputeIDToLocal[_coreDisputeID] = localDisputeID;
+        }
+
+        active.dispute = true;
+        active.currentRound = true;
+        dispute.numberOfChoices = _numberOfChoices;
+        dispute.extraData = _extraData;
+
+        // KlerosCore.Round must have been already created.
+        dispute.coreRoundIDToLocal[_coreRoundID] = dispute.rounds.length;
+        dispute.rounds.push().tied = true;
+
+        emit DisputeCreation(_coreDisputeID, _numberOfChoices, _extraData);
+    }
+
+    /// @notice Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core.
+    /// @dev Access restricted to Kleros Core only.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _nonce Nonce.
+    /// @param - The number of votes in the round (unused, required by interface).
+    /// @return drawnAddress The drawn address.
+    /// @return fromSubcourtID The subcourt ID from which the juror was drawn.
+    function draw(
+        uint256 _coreDisputeID,
+        uint256 _nonce,
+        uint256 /*_roundNbVotes*/
+    ) public override onlyByCore isActive(_coreDisputeID) returns (address drawnAddress, uint96 fromSubcourtID) {
+        uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
+        Dispute storage dispute = disputes[localDisputeID];
+        uint256 localRoundID = dispute.rounds.length - 1;
+        Round storage round = dispute.rounds[localRoundID];
+
+        ISortitionModule sortitionModule = core.sortitionModule();
+        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
+        (drawnAddress, fromSubcourtID) = sortitionModule.draw(courtID, _coreDisputeID, _nonce);
+        if (drawnAddress == address(0)) {
+            // Sortition can return 0 address if no one has staked yet.
+            return (drawnAddress, fromSubcourtID);
+        }
+
+        if (_postDrawCheck(_coreDisputeID, drawnAddress)) {
+            Vote storage vote = round.votes.push();
+            vote.account = drawnAddress;
+            round.alreadyDrawn[drawnAddress] = true;
+        } else {
+            drawnAddress = address(0);
+        }
+    }
+
+    /// @notice Sets the caller's commit for the specified votes.
+    ///
+    /// @dev It can be called multiple times during the commit period, each call overrides the commits of the previous one.
+    /// `O(n)` where `n` is the number of votes.
+    ///
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _voteIDs The IDs of the votes.
+    /// @param _commit The commitment hash.
+    function castCommit(
+        uint256 _coreDisputeID,
+        uint256[] calldata _voteIDs,
+        bytes32 _commit
+    ) external whenArbitrationNotPaused isActive(_coreDisputeID) {
+        (, , KlerosCore.Period period, , ) = core.disputes(_coreDisputeID);
+        require(period == KlerosCore.Period.commit, NotCommitPeriod());
+        require(_voteIDs.length > 0, EmptyVoteIDs());
+        require(_commit != bytes32(0), EmptyCommit());
+
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage round = dispute.rounds[dispute.rounds.length - 1];
+        // Introduce a counter so we don't count a re-commited votes.
+        uint256 commitCount;
+        for (uint256 i = 0; i < _voteIDs.length; i++) {
+            require(round.votes[_voteIDs[i]].account == msg.sender, JurorHasToOwnTheVote());
+            if (round.votes[_voteIDs[i]].commit == bytes32(0)) {
+                commitCount++;
+            }
+            round.votes[_voteIDs[i]].commit = _commit;
+        }
+        round.totalCommitted += commitCount;
+        emit CommitCast(_coreDisputeID, msg.sender, _voteIDs, _commit);
+    }
+
+    /// @notice Sets the caller's choices for the specified votes.
+    ///
+    /// @dev `O(n)` where `n` is the number of votes.
+    ///
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _voteIDs The IDs of the votes.
+    /// @param _choice The choice.
+    /// @param _salt The salt for the commit if the votes were hidden.
+    /// @param _justification Justification of the choice.
+    function castVote(
+        uint256 _coreDisputeID,
+        uint256[] calldata _voteIDs,
+        uint256 _choice,
+        uint256 _salt,
+        string memory _justification
+    ) external whenArbitrationNotPaused isActive(_coreDisputeID) {
+        (, , KlerosCore.Period period, , ) = core.disputes(_coreDisputeID);
+        require(period == KlerosCore.Period.vote, NotVotePeriod());
+        require(_voteIDs.length > 0, EmptyVoteIDs());
+
+        uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
+        Dispute storage dispute = disputes[localDisputeID];
+        require(_choice <= dispute.numberOfChoices, ChoiceOutOfBounds());
+
+        uint256 localRoundID = dispute.rounds.length - 1;
+        Round storage round = dispute.rounds[localRoundID];
+        {
+            uint256 coreRoundID = core.getNumberOfRounds(_coreDisputeID) - 1;
+            (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
+            uint256 courtParamsIndex = core.getCourtParametersIndex(_coreDisputeID, coreRoundID);
+            bool hiddenVotes = core.getAdditionalCourtParams(courtID, courtParamsIndex).hiddenVotes;
+            if (hiddenVotes) {
+                _verifyHiddenVoteCommitments(localDisputeID, localRoundID, _voteIDs, _choice, _salt);
+            }
+
+            //  Save the votes.
+            for (uint256 i = 0; i < _voteIDs.length; i++) {
+                require(round.votes[_voteIDs[i]].account == msg.sender, JurorHasToOwnTheVote());
+                require(!round.votes[_voteIDs[i]].voted, VoteAlreadyCast());
+                round.votes[_voteIDs[i]].choice = _choice;
+                round.votes[_voteIDs[i]].voted = true;
+            }
+        } // Workaround stack too deep
+
+        round.totalVoted += _voteIDs.length;
+
+        round.counts[_choice] += _voteIDs.length;
+
+        if (_choice == round.winningChoice) {
+            if (round.tied) round.tied = false;
+        } else {
+            // Voted for another choice.
+            if (round.counts[_choice] == round.counts[round.winningChoice]) {
+                // Tie.
+                if (!round.tied) round.tied = true;
+            } else if (round.counts[_choice] > round.counts[round.winningChoice]) {
+                // New winner.
+                round.winningChoice = _choice;
+                round.tied = false;
+            }
+        }
+        emit VoteCast(_coreDisputeID, msg.sender, _voteIDs, _choice, _justification);
+    }
+
+    /// @notice Manages contributions, and appeals a dispute if at least two choices are fully funded.
+    /// Note that the surplus deposit will be reimbursed.
+    /// @param _coreDisputeID Index of the dispute in Kleros Core.
+    /// @param _choice A choice that receives funding.
+    function fundAppeal(
+        uint256 _coreDisputeID,
+        uint256 _choice
+    ) external payable whenArbitrationNotPaused isActive(_coreDisputeID) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        require(_choice <= dispute.numberOfChoices, ChoiceOutOfBounds());
+
+        (uint256 appealPeriodStart, uint256 appealPeriodEnd) = core.appealPeriod(_coreDisputeID);
+        require(block.timestamp >= appealPeriodStart && block.timestamp < appealPeriodEnd, NotAppealPeriod());
+
+        uint256 multiplier;
+        (uint256 ruling, , ) = this.currentRuling(_coreDisputeID);
+        if (ruling == _choice) {
+            multiplier = WINNER_STAKE_MULTIPLIER;
+        } else {
+            require(
+                block.timestamp - appealPeriodStart <
+                    ((appealPeriodEnd - appealPeriodStart) * LOSER_APPEAL_PERIOD_MULTIPLIER) / ONE_BASIS_POINT,
+                NotAppealPeriodForLoser()
+            );
+            multiplier = LOSER_STAKE_MULTIPLIER;
+        }
+
+        Round storage round = dispute.rounds[dispute.rounds.length - 1];
+        uint256 coreRoundID = core.getNumberOfRounds(_coreDisputeID) - 1;
+
+        require(!round.hasPaid[_choice], AppealFeeIsAlreadyPaid());
+        uint256 appealCost = core.appealCost(_coreDisputeID);
+        uint256 totalCost = appealCost + (appealCost * multiplier) / ONE_BASIS_POINT;
+
+        // Take up to the amount necessary to fund the current round at the current costs.
+        uint256 contribution;
+        if (totalCost > round.paidFees[_choice]) {
+            contribution = totalCost - round.paidFees[_choice] > msg.value // Overflows and underflows will be managed on the compiler level.
+                ? msg.value
+                : totalCost - round.paidFees[_choice];
+            emit Contribution(_coreDisputeID, coreRoundID, _choice, msg.sender, contribution);
+        }
+
+        round.contributions[msg.sender][_choice] += contribution;
+        round.paidFees[_choice] += contribution;
+        if (round.paidFees[_choice] >= totalCost) {
+            round.feeRewards += round.paidFees[_choice];
+            round.fundedChoices.push(_choice);
+            round.hasPaid[_choice] = true;
+            emit ChoiceFunded(_coreDisputeID, coreRoundID, _choice);
+        }
+
+        if (round.fundedChoices.length > 1) {
+            // At least two sides are fully funded.
+            round.feeRewards = round.feeRewards - appealCost;
+
+            (, , , , bool isDisputeKitJumping) = core.getCourtAndDisputeKitJumps(_coreDisputeID);
+            if (isDisputeKitJumping) {
+                // Don't create a new round in case of a jump, and remove local dispute from the flow.
+                coreDisputeIDToActive[_coreDisputeID].currentRound = false;
+            } else {
+                // Don't subtract 1 from length since both round arrays haven't been updated yet.
+                dispute.coreRoundIDToLocal[coreRoundID + 1] = dispute.rounds.length;
+                Round storage newRound = dispute.rounds.push();
+                newRound.tied = true;
+            }
+            core.appeal{value: appealCost}(_coreDisputeID, dispute.numberOfChoices, dispute.extraData);
+        }
+
+        if (msg.value > contribution) payable(msg.sender).safeSend(msg.value - contribution, wNative);
+    }
+
+    /// @notice Allows those contributors who attempted to fund an appeal round to withdraw any reimbursable fees or rewards after the dispute gets resolved.
+    /// @dev Withdrawals are not possible if the core contract is paused.
+    /// @dev It can be called after the dispute has jumped to another dispute kit.
+    /// @param _coreDisputeID Index of the dispute in Kleros Core contract.
+    /// @param _beneficiary The address whose rewards to withdraw.
+    /// @param _choice The ruling option that the caller wants to withdraw from.
+    /// @return amount The withdrawn amount.
+    function withdrawFeesAndRewards(
+        uint256 _coreDisputeID,
+        address payable _beneficiary,
+        uint256 _choice
+    ) external returns (uint256 amount) {
+        (, , KlerosCore.Period period, , ) = core.disputes(_coreDisputeID);
+        require(period == KlerosCore.Period.execution, DisputeNotResolved());
+        require(!core.paused(), CoreIsPaused());
+        require(coreDisputeIDToActive[_coreDisputeID].dispute, DisputeUnknownInThisDisputeKit());
+
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        (uint256 finalRuling, , ) = core.currentRuling(_coreDisputeID);
+
+        for (uint256 i = 0; i < dispute.rounds.length; i++) {
+            Round storage round = dispute.rounds[i];
+
+            if (!round.hasPaid[_choice]) {
+                // Allow to reimburse if funding was unsuccessful for this ruling option.
+                amount += round.contributions[_beneficiary][_choice];
+            } else {
+                // Funding was successful for this ruling option.
+                if (_choice == finalRuling) {
+                    // This ruling option is the ultimate winner.
+                    amount += round.paidFees[_choice] > 0
+                        ? (round.contributions[_beneficiary][_choice] * round.feeRewards) / round.paidFees[_choice]
+                        : 0;
+                } else if (!round.hasPaid[finalRuling]) {
+                    // The ultimate winner was not funded in this round. In this case funded ruling option(s) are reimbursed.
+                    amount +=
+                        (round.contributions[_beneficiary][_choice] * round.feeRewards) /
+                        (round.paidFees[round.fundedChoices[0]] + round.paidFees[round.fundedChoices[1]]);
+                }
+            }
+            round.contributions[_beneficiary][_choice] = 0;
+        }
+
+        if (amount != 0) {
+            _beneficiary.safeSend(amount, wNative);
+            emit Withdrawal(_coreDisputeID, _choice, _beneficiary, amount);
+        }
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @notice Computes the hash of a vote using ABI encoding
+    /// @param _choice The choice being voted for
+    /// @param _salt A random salt for commitment
+    /// @return bytes32 The hash of the encoded vote parameters
+    function hashVote(uint256 _choice, uint256 _salt) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_choice, _salt));
+    }
+
+    /// @notice Returns the rulings that were fully funded in the latest appeal round.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @return fundedChoices Fully funded rulings.
+    function getFundedChoices(uint256 _coreDisputeID) public view returns (uint256[] memory fundedChoices) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage lastRound = dispute.rounds[dispute.rounds.length - 1];
+        return lastRound.fundedChoices;
+    }
+
+    /// @notice Gets the current ruling of a specified dispute.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return ruling The current ruling.
+    /// @return tied Whether it's a tie or not.
+    /// @return overridden Whether the ruling was overridden by appeal funding or not.
+    function currentRuling(
+        uint256 _coreDisputeID
+    ) external view override returns (uint256 ruling, bool tied, bool overridden) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage round = dispute.rounds[dispute.rounds.length - 1];
+        tied = round.tied;
+        ruling = tied ? 0 : round.winningChoice;
+        (, , KlerosCore.Period period, , ) = core.disputes(_coreDisputeID);
+        // Override the final ruling if only one side funded the appeals.
+        if (period == KlerosCore.Period.execution) {
+            uint256[] memory fundedChoices = getFundedChoices(_coreDisputeID);
+            if (fundedChoices.length == 1) {
+                ruling = fundedChoices[0];
+                tied = false;
+                overridden = true;
+            }
+        }
+    }
+
+    /// @notice Gets the degree of coherence of a particular voter.
+    /// @dev This function is called by Kleros Core in order to determine the amount of the reward.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the vote.
+    /// @param - feePerJuror The fee per juror. Unused, required by interface.
+    /// @param - pnkAtStakePerJuror The PNK at stake per juror. Unused, required by interface.
+    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    /// @return feeCoherence The degree of coherence in basis points for the dispute fee reward.
+    function getDegreeOfCoherenceReward(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
+    ) external view override returns (uint256 pnkCoherence, uint256 feeCoherence) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Vote storage vote = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]].votes[_voteID];
+        (uint256 winningChoice, bool tied, ) = core.currentRuling(_coreDisputeID);
+        uint256 coherence;
+        if (vote.voted) {
+            if (vote.choice == winningChoice) {
+                coherence = winningCoherences[vote.choice] != 0 ? winningCoherences[vote.choice] : ONE_BASIS_POINT;
+            } else if (tied) {
+                coherence = ONE_BASIS_POINT;
+            }
+        }
+        return (coherence, coherence);
+    }
+
+    /// @notice Gets the degree of coherence of a particular voter.
+    /// @dev This function is called by Kleros Core in order to determine the amount of the penalty.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the vote.
+    /// @param - feePerJuror The fee per juror. Unused, required by interface.
+    /// @param - pnkAtStakePerJuror The PNK at stake per juror. Unused, required by interface.
+    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    function getDegreeOfCoherencePenalty(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
+    ) external view override returns (uint256 pnkCoherence) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Vote storage vote = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]].votes[_voteID];
+        (uint256 winningChoice, bool tied, ) = core.currentRuling(_coreDisputeID);
+
+        if (vote.voted) {
+            if (vote.choice == winningChoice || tied) {
+                pnkCoherence = ONE_BASIS_POINT;
+            } else {
+                // 0 is a default return value for losing choice, so it's fine if nothing is stored in the mapping.
+                pnkCoherence = losingCoherences[vote.choice];
+            }
+        }
+    }
+
+    /// @notice Gets the number of jurors who are eligible to a reward in this round.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @return The number of coherent jurors.
+    function getCoherentCount(uint256 _coreDisputeID, uint256 _coreRoundID) external view override returns (uint256) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage currentRound = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]];
+        (uint256 winningChoice, bool tied, ) = core.currentRuling(_coreDisputeID);
+
+        if (currentRound.totalVoted == 0 || (!tied && currentRound.counts[winningChoice] == 0)) {
+            return 0;
+        } else if (tied) {
+            return currentRound.totalVoted;
+        } else {
+            return currentRound.counts[winningChoice];
+        }
+    }
+
+    /// @notice Gets the rewards for PNK and fees based on coherence and total reward pool.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param - voteID The ID of the vote. Unused, required by interface.
+    /// @param _coherentCount The number of jurors eligible for reward.
+    /// @param _pnkRewardPool Total amount of PNK available for rewards to all coherent jurors.
+    /// @param _pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    /// @param _feeCoherence The degree of coherence in basis points for the dispute fee reward.
+    /// @return pnkReward The pnk reward the juror is eligible to.
+    /// @return feeReward The fee reward the juror is eligible to.
+    function getRewards(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 /*_voteID*/,
+        uint256 _coherentCount,
+        uint256 _pnkRewardPool,
+        uint256 _pnkCoherence,
+        uint256 _feeCoherence
+    ) external view virtual override returns (uint256 pnkReward, uint256 feeReward) {
+        uint256 feeRewardPool = core.getTotalFeesForJurors(_coreDisputeID, _coreRoundID);
+
+        uint256 availablePnkAmount = _pnkRewardPool / _coherentCount;
+        pnkReward = (availablePnkAmount * _pnkCoherence) / ONE_BASIS_POINT;
+
+        uint256 availableFeeAmount = feeRewardPool / _coherentCount;
+        feeReward = (availableFeeAmount * _feeCoherence) / ONE_BASIS_POINT;
+    }
+
+    /// @notice Returns true if all of the jurors have cast their commits for the last round.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether all of the jurors have cast their commits for the last round.
+    function areCommitsAllCast(uint256 _coreDisputeID) external view override returns (bool) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage round = dispute.rounds[dispute.rounds.length - 1];
+        return round.totalCommitted == round.votes.length;
+    }
+
+    /// @notice Returns true if all of the jurors have cast their votes for the last round.
+    /// @dev This function is to be called directly by the core contract and is not for off-chain usage.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether all of the jurors have cast their votes for the last round.
+    function areVotesAllCast(uint256 _coreDisputeID) external view override returns (bool) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage round = dispute.rounds[dispute.rounds.length - 1];
+
+        (uint96 courtID, , , , ) = core.disputes(_coreDisputeID);
+        uint256 courtParamsIndex = core.getCourtParametersIndex(
+            _coreDisputeID,
+            core.getNumberOfRounds(_coreDisputeID) - 1
+        );
+        bool hiddenVotes = core.getAdditionalCourtParams(courtID, courtParamsIndex).hiddenVotes;
+        uint256 expectedTotalVoted = hiddenVotes ? round.totalCommitted : round.votes.length;
+
+        return round.totalVoted == expectedTotalVoted;
+    }
+
+    /// @notice Returns true if the appeal funding is finished prematurely (e.g. when losing side didn't fund).
+    /// @dev This function is to be called directly by the core contract and is not for off-chain usage.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether the appeal funding is finished.
+    function isAppealFunded(uint256 _coreDisputeID) external view override returns (bool) {
+        (uint256 appealPeriodStart, uint256 appealPeriodEnd) = core.appealPeriod(_coreDisputeID);
+
+        uint256[] memory fundedChoices = getFundedChoices(_coreDisputeID);
+        // Uses block.timestamp from the current tx when called by the core contract.
+        return (fundedChoices.length == 0 &&
+            block.timestamp - appealPeriodStart >=
+            ((appealPeriodEnd - appealPeriodStart) * LOSER_APPEAL_PERIOD_MULTIPLIER) / ONE_BASIS_POINT);
+    }
+
+    /// @notice Returns the next round settings for a given dispute.
+    /// @dev This function does not check for compatibility between `newDisputeKitID` and `newCourtID`, this is the Core's responsibility.
+    /// @param - coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit. Unused, required by interface.
+    /// @param _currentCourtID The ID of the current court.
+    /// @param _parentCourtID The ID of the parent court.
+    /// @param _currentCourtJurorsForJump The court jump threshold defined by the current court.
+    /// @param _currentDisputeKitID The ID of the current dispute kit.
+    /// @param _currentRoundNbVotes The number of votes in the current round.
+    /// @return newCourtID Court ID after jump.
+    /// @return newDisputeKitID Dispute kit ID after jump.
+    /// @return newRoundNbVotes The number of votes in the new round.
+    function getNextRoundSettings(
+        uint256 /* _coreDisputeID */,
+        uint96 _currentCourtID,
+        uint96 _parentCourtID,
+        uint256 _currentCourtJurorsForJump,
+        uint256 _currentDisputeKitID,
+        uint256 _currentRoundNbVotes
+    ) public view virtual override returns (uint96 newCourtID, uint256 newDisputeKitID, uint256 newRoundNbVotes) {
+        NextRoundSettings storage nextRoundSettings = courtIDToNextRoundSettings[_currentCourtID];
+        uint256 jumpDisputeKitIDOnCourtJump;
+        if (nextRoundSettings.enabled) {
+            newRoundNbVotes = nextRoundSettings.nbVotes;
+            newCourtID = nextRoundSettings.jumpCourtID;
+            newDisputeKitID = nextRoundSettings.jumpDisputeKitID; // Takes precedence over jumpDisputeKitIDOnCourtJump
+            jumpDisputeKitIDOnCourtJump = nextRoundSettings.jumpDisputeKitIDOnCourtJump;
+        }
+        if (newCourtID == 0) {
+            // Default court jump logic, unaffected by the newRoundNbVotes override
+            newCourtID = _currentRoundNbVotes >= _currentCourtJurorsForJump ? _parentCourtID : _currentCourtID;
+        }
+        if (newDisputeKitID == 0) {
+            // jumpDisputeKitID is undefined for next round
+            if (newCourtID != _currentCourtID && jumpDisputeKitIDOnCourtJump != 0) {
+                // Override on court jump
+                newDisputeKitID = jumpDisputeKitIDOnCourtJump;
+            } else {
+                // Default dispute kit jump logic
+                newDisputeKitID = _currentDisputeKitID;
+            }
+        }
+        if (newRoundNbVotes == 0) {
+            // Default nbVotes logic
+            newRoundNbVotes = (_currentRoundNbVotes * 2) + 1;
+        }
+    }
+
+    /// @notice Returns true if the specified voter was active in this round.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the voter.
+    /// @return Whether the voter was active or not.
+    function isVoteActive(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID
+    ) external view override returns (bool) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Vote storage vote = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]].votes[_voteID];
+        return vote.voted;
+    }
+
+    /// @notice Returns the info of the specified round in the core contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _choice The choice to query.
+    /// @return winningChoice The winning choice of this round.
+    /// @return tied Whether it's a tie or not.
+    /// @return totalVoted Number of jurors who cast the vote already.
+    /// @return totalCommitted Number of jurors who cast the commit already (only relevant for hidden votes).
+    /// @return nbVoters Total number of voters in this round.
+    /// @return choiceCount Number of votes cast for the queried choice.
+    function getRoundInfo(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _choice
+    )
+        external
+        view
+        override
+        returns (
+            uint256 winningChoice,
+            bool tied,
+            uint256 totalVoted,
+            uint256 totalCommitted,
+            uint256 nbVoters,
+            uint256 choiceCount
+        )
+    {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Round storage round = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]];
+        return (
+            round.winningChoice,
+            round.tied,
+            round.totalVoted,
+            round.totalCommitted,
+            round.votes.length,
+            round.counts[_choice]
+        );
+    }
+
+    /// @notice Returns the number of rounds in a dispute.
+    /// @param _localDisputeID The ID of the dispute in the Dispute Kit.
+    /// @return The number of rounds in the dispute.
+    function getNumberOfRounds(uint256 _localDisputeID) external view returns (uint256) {
+        return disputes[_localDisputeID].rounds.length;
+    }
+
+    /// @notice Returns the local dispute ID and round ID for a given core dispute ID and core round ID.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _coreRoundID The ID of the round in Kleros Core.
+    /// @return localDisputeID The ID of the dispute in the Dispute Kit.
+    /// @return localRoundID The ID of the round in the Dispute Kit.
+    function getLocalDisputeRoundID(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID
+    ) external view returns (uint256 localDisputeID, uint256 localRoundID) {
+        localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
+        localRoundID = disputes[localDisputeID].coreRoundIDToLocal[_coreRoundID];
+    }
+
+    /// @notice Returns the vote information for a given vote ID.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _coreRoundID The ID of the round in Kleros Core.
+    /// @param _voteID The ID of the vote.
+    /// @return account The address of the juror who cast the vote.
+    /// @return commit The commit of the vote.
+    /// @return choice The choice that got the vote.
+    /// @return voted Whether the vote was cast or not.
+    function getVoteInfo(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID
+    ) external view override returns (address account, bytes32 commit, uint256 choice, bool voted) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        Vote storage vote = dispute.rounds[dispute.coreRoundIDToLocal[_coreRoundID]].votes[_voteID];
+        return (vote.account, vote.commit, vote.choice, vote.voted);
+    }
+
+    // ************************************* //
+    // *            Internal               * //
+    // ************************************* //
+
+    /// @notice Verifies that revealed choice matches the hidden vote commitments.
+    /// @param _localDisputeID The ID of the dispute in the Dispute Kit.
+    /// @param _localRoundID The ID of the round in the Dispute Kit.
+    /// @param _voteIDs The IDs of the votes.
+    /// @param _choice The choice.
+    /// @param _salt The salt.
+    function _verifyHiddenVoteCommitments(
+        uint256 _localDisputeID,
+        uint256 _localRoundID,
+        uint256[] calldata _voteIDs,
+        uint256 _choice,
+        uint256 _salt
+    ) internal view {
+        bytes32 actualVoteHash = hashVote(_choice, _salt);
+        for (uint256 i = 0; i < _voteIDs.length; i++) {
+            require(
+                disputes[_localDisputeID].rounds[_localRoundID].votes[_voteIDs[i]].commit == actualVoteHash,
+                ChoiceCommitmentMismatch()
+            );
+        }
+    }
+
+    /// @notice Checks that the chosen address satisfies certain conditions for being drawn.
+    ///
+    /// @dev No need to check the minStake requirement here because of the implicit staking in parent courts.
+    /// minStake is checked directly during staking process however it's possible for the juror to get drawn
+    /// while having < minStake if it is later increased by governance.
+    /// This issue is expected and harmless.
+    ///
+    /// @param _coreDisputeID ID of the dispute in the core contract.
+    /// @param _juror Chosen address.
+    /// @return Whether the address passes the check or not.
+    function _postDrawCheck(uint256 _coreDisputeID, address _juror) internal view returns (bool) {
+        if (singleDrawPerJuror) {
+            uint256 localDisputeID = coreDisputeIDToLocal[_coreDisputeID];
+            Dispute storage dispute = disputes[localDisputeID];
+            Round storage round = dispute.rounds[dispute.rounds.length - 1];
+            return !round.alreadyDrawn[_juror];
+        } else {
+            return true;
+        }
+    }
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
+
+    error OwnerOnly();
+    error KlerosCoreOnly();
+    error DisputeJumpedToAnotherDisputeKit();
+    error DisputeUnknownInThisDisputeKit();
+    error UnsuccessfulCall();
+    error NotCommitPeriod();
+    error EmptyCommit();
+    error JurorHasToOwnTheVote();
+    error NotVotePeriod();
+    error EmptyVoteIDs();
+    error ChoiceOutOfBounds();
+    error ChoiceCommitmentMismatch();
+    error VoteAlreadyCast();
+    error NotAppealPeriod();
+    error NotAppealPeriodForLoser();
+    error AppealFeeIsAlreadyPaid();
+    error DisputeNotResolved();
+    error CoreIsPaused();
+    error WhenArbitrationNotPausedOnly();
+    error CoherenceArrayLengthMismatch();
+    error CoherenceOutOfScope();
+}

--- a/contracts/src/test/DisputeKitAsymmetricPlurality.sol
+++ b/contracts/src/test/DisputeKitAsymmetricPlurality.sol
@@ -2,15 +2,16 @@
 
 pragma solidity ^0.8.28;
 
-import {KlerosCore} from "../KlerosCore.sol";
-import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
-import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
-import {Initializable} from "../../proxy/Initializable.sol";
-import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
-import {SafeSend} from "../../libraries/SafeSend.sol";
-import {ONE_BASIS_POINT} from "../../libraries/Constants.sol";
+import {KlerosCore} from "../arbitration/KlerosCore.sol";
+import {IDisputeKit} from "../arbitration//interfaces/IDisputeKit.sol";
+import {ISortitionModule} from "../arbitration//interfaces/ISortitionModule.sol";
+import {Initializable} from "../proxy/Initializable.sol";
+import {UUPSProxiable} from "../proxy/UUPSProxiable.sol";
+import {SafeSend} from "../libraries/SafeSend.sol";
+import {ONE_BASIS_POINT} from "../libraries/Constants.sol";
 
 /// @title DisputeKitAsymmetricPlurality
+/// @notice This is a test dispute kit for evaluating partial coherence handling. Not intended for production use.
 /// @notice Dispute kit implementation adapted from DisputeKitClassic
 /// - a drawing system: proportional to staked PNK,
 /// - a vote aggregation system: asymmetric plurality. The coherence differentiates between choices,

--- a/contracts/test/foundry/KlerosCore_Execution.t.sol
+++ b/contracts/test/foundry/KlerosCore_Execution.t.sol
@@ -109,34 +109,27 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
         emit KlerosCore.JurorRewardPenalty(staker1, disputeID, 0, 0, 0, -int256(1000), 0, IERC20(address(0))); // penalties
         // Check iterations for the winning staker to see the shifts
         vm.expectEmit(true, true, true, true);
-        emit SortitionModule.StakeLocked(staker2, 0, true);
+        emit SortitionModule.StakeLocked(staker2, 1000, true);
+        vm.expectEmit(true, true, true, true);
+        emit SortitionModule.StakeLocked(staker2, 1000, true);
         core.execute(disputeID, 0, 3); // Do 3 iterations to check penalties first
 
         (uint256 totalStaked, uint256 totalLocked, , ) = sortitionModule.getJurorBalance(staker1, GENERAL_COURT);
         assertEq(totalStaked, 1000, "totalStaked should be penalized"); // 2000 - 1000
         assertEq(totalLocked, 0, "Tokens should be released for staker1");
         (, totalLocked, , ) = sortitionModule.getJurorBalance(staker2, GENERAL_COURT);
-        assertEq(totalLocked, 2000, "Tokens should still be locked for staker2");
+        assertEq(totalLocked, 0, "Tokens should be unlocked for staker2");
 
         KlerosCore.Round memory round = core.getRoundInfo(disputeID, 0);
         assertEq(round.repartitions, 3, "Wrong repartitions");
         assertEq(round.pnkPenalties, 1000, "Wrong pnkPenalties");
 
-        vm.expectEmit(true, true, true, true);
-        emit SortitionModule.StakeLocked(staker1, 0, true);
         // Check iterations for the winning staker to see the shifts
         vm.expectEmit(true, true, true, true);
-        emit SortitionModule.StakeLocked(staker2, 1000, true);
-        vm.expectEmit(true, true, true, true);
         emit KlerosCore.JurorRewardPenalty(staker2, disputeID, 0, 10000, 10000, 500, 0.045 ether, IERC20(address(0))); // rewards
-        vm.expectEmit(true, true, true, true);
-        emit SortitionModule.StakeLocked(staker2, 1000, true);
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.JurorRewardPenalty(staker2, disputeID, 0, 10000, 10000, 500, 0.045 ether, IERC20(address(0))); // rewards
         core.execute(disputeID, 0, 10); // Finish the iterations. We need only 3 but check that it corrects the count.
-
-        (, totalLocked, , ) = sortitionModule.getJurorBalance(staker2, GENERAL_COURT);
-        assertEq(totalLocked, 0, "Tokens should be unlocked for staker2");
 
         round = core.getRoundInfo(disputeID, 0);
         assertEq(round.repartitions, 6, "Wrong repartitions");
@@ -374,7 +367,7 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
         assertEq(totalStaked, 0, "totalStaked should be 0 for the first staker");
         assertEq(totalLocked, 0, "Tokens should be released for staker1");
         (, totalLocked, , ) = sortitionModule.getJurorBalance(staker2, GENERAL_COURT);
-        assertEq(totalLocked, 2000, "Tokens should still be locked for staker2");
+        assertEq(totalLocked, 0, "Tokens should still be released for staker2");
 
         round = core.getRoundInfo(disputeID, 0);
         assertEq(round.repartitions, 4, "Wrong repartitions");
@@ -395,9 +388,6 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
         // The next iteration should deplete the whole reward pool since malicious DK doubles the amount of rewards.
         core.execute(disputeID, 0, 1);
 
-        (, totalLocked, , ) = sortitionModule.getJurorBalance(staker2, GENERAL_COURT);
-        assertEq(totalLocked, 1000, "Tokens should still be locked for staker2");
-
         round = core.getRoundInfo(disputeID, 0);
         assertEq(round.repartitions, 5, "Wrong repartitions");
         assertEq(round.pnkPenalties, 1000, "Wrong pnkPenalties");
@@ -416,9 +406,6 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
 
         // Do the final iteration to check that no extra money was spent and balances stayed the same.
         core.execute(disputeID, 0, 1);
-
-        (, totalLocked, , ) = sortitionModule.getJurorBalance(staker2, GENERAL_COURT);
-        assertEq(totalLocked, 0, "Tokens should be released for staker2");
 
         round = core.getRoundInfo(disputeID, 0);
         assertEq(round.repartitions, 6, "Wrong repartitions");
@@ -1283,7 +1270,7 @@ contract KlerosCore_ExecutionTest is KlerosCore_TestBase {
         );
 
         uint256 pnkAtStake = (minStake * alpha) / ONE_BASIS_POINT;
-        uint256 unlockedTokens = iterationsCount < nbJurors ? 0 : (iterationsCount - nbJurors) * pnkAtStake;
+        uint256 unlockedTokens = iterationsCount >= nbJurors ? nbJurors * pnkAtStake : iterationsCount * pnkAtStake;
         assertEq(totalStaked, 2000, "Wrong amount total staked");
         assertEq(totalLocked, (pnkAtStake * nbJurors) - unlockedTokens, "Wrong amount locked");
         assertEq(stakedInCourt, 2000, "Wrong amount staked in court");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces changes to the `KlerosCore` contract and its related test files, focusing on unlocking PNK tokens for jurors based on their coherence and adjusting penalty calculations. It also introduces a new contract, `DisputeKitAsymmetricPlurality`, for handling disputes.

### Detailed summary
- Added logic to unlock all PNKs for jurors in a draw while ensuring fully coherent jurors are not penalized.
- Removed redundant unlocking of PNKs affected by penalties.
- Adjusted calculations for penalties and rewards based on juror coherence.
- Updated tests to reflect changes in PNK unlocking and penalty handling.
- Introduced `DisputeKitAsymmetricPlurality` contract for asymmetric plurality handling in disputes, including new data structures and event emissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an asymmetric-plurality dispute kit with multi-choice appeal funding, commit/reveal voting, coherence-weighted rewards/penalties, and contributor withdrawal support.

* **Bug Fixes**
  * Adjusted token unlock and reward sequencing so juror stakes and penalties are unlocked and distributed more consistently during reward/penalty execution.

* **Tests**
  * Updated tests and fuzz logic to reflect the revised unlock behavior and new unlock calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->