### PR TITLE
Fix/security fixes beta mainnet

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@bigmi/react": "^0.1.0",
+    "@braintree/sanitize-url": "^7.1.2",
     "@coinbase/wallet-sdk": "^4.3.2",
     "@cyntler/react-doc-viewer": "^1.17.0",
     "@graphql-tools/batch-execute": "^9.0.11",

--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -16,6 +16,7 @@ import { responsiveSize } from "styles/responsiveSize";
 
 import ReactMarkdown from "components/ReactMarkdown";
 import { StyledSkeleton } from "components/StyledSkeleton";
+import WithHelpTooltip from "components/WithHelpTooltip";
 
 import CardLabel from "../DisputeView/CardLabels";
 import { Divider } from "../Divider";
@@ -86,6 +87,27 @@ const RulingAndRewardsAndLabels = styled.div`
   gap: 8px;
 `;
 
+const FrontendUrlSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 100%;
+`;
+
+const FrontendUrlLabel = styled.small`
+  color: ${({ theme }) => theme.primaryText};
+  font-weight: 600;
+`;
+
+const FlaggedFrontendUrl = styled.small`
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.secondaryText};
+  font-size: 14px;
+`;
+
 interface IDisputeContext {
   disputeDetails?: DisputeDetails;
   isRpcError?: boolean;
@@ -107,10 +129,10 @@ export const DisputeContext: React.FC<IDisputeContext> = ({
   const rounds = votingHistory?.dispute?.rounds;
   const jurorRewardsDispersed = useMemo(() => Boolean(rounds?.every((round) => round.jurorRewardsDispersed)), [rounds]);
 
+  const frontendUrl = disputeDetails?.frontendUrl;
   const safeFrontendUrl = useMemo(() => {
-    const url = disputeDetails?.frontendUrl;
-    return url ? getSafeNavigationUrl(url) : undefined;
-  }, [disputeDetails?.frontendUrl]);
+    return frontendUrl ? getSafeNavigationUrl(frontendUrl) : undefined;
+  }, [frontendUrl]);
 
   return (
     <>
@@ -155,6 +177,18 @@ export const DisputeContext: React.FC<IDisputeContext> = ({
         <ExternalLink to={safeFrontendUrl} target="_blank" rel="noreferrer">
           Go to arbitrable
         </ExternalLink>
+      ) : null}
+
+      {!isUndefined(frontendUrl) && isUndefined(safeFrontendUrl) ? (
+        <FrontendUrlSection>
+          <FrontendUrlLabel>Arbitrable URL:</FrontendUrlLabel>
+          <WithHelpTooltip
+            tooltipMsg={`This URL did not pass security validation and cannot be opened from here. 
+                         It is shown for your review only.`}
+          >
+            <FlaggedFrontendUrl title={frontendUrl}>{frontendUrl}</FlaggedFrontendUrl>
+          </WithHelpTooltip>
+        </FrontendUrlSection>
       ) : null}
       <VotingOptions>
         {isUndefined(disputeDetails) ? null : <AnswersHeader>Voting Options</AnswersHeader>}

--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -1,26 +1,28 @@
 import React, { useMemo } from "react";
 import styled from "styled-components";
 
-import { DisputeDetails } from "@kleros/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes";
 import { useAccount } from "wagmi";
+
+import { DisputeDetails } from "@kleros/kleros-sdk/src/dataMappings/utils/disputeDetailsTypes";
 
 import { INVALID_DISPUTE_DATA_ERROR, RPC_ERROR } from "consts/index";
 import { Answer as IAnswer } from "context/NewDisputeContext";
 import { isUndefined } from "utils/index";
-
-import { responsiveSize } from "styles/responsiveSize";
+import { getSafeNavigationUrl } from "utils/urlValidation";
 
 import { DisputeDetailsQuery, VotingHistoryQuery } from "src/graphql/graphql";
+
+import { responsiveSize } from "styles/responsiveSize";
 
 import ReactMarkdown from "components/ReactMarkdown";
 import { StyledSkeleton } from "components/StyledSkeleton";
 
+import CardLabel from "../DisputeView/CardLabels";
 import { Divider } from "../Divider";
 import { ExternalLink } from "../ExternalLink";
+import RulingAndRewardsIndicators from "../Verdict/RulingAndRewardsIndicators";
 
 import AliasDisplay from "./Alias";
-import RulingAndRewardsIndicators from "../Verdict/RulingAndRewardsIndicators";
-import CardLabel from "../DisputeView/CardLabels";
 
 const StyledH1 = styled.h1`
   margin: 0;
@@ -104,7 +106,11 @@ export const DisputeContext: React.FC<IDisputeContext> = ({
   const errMsg = isRpcError ? RPC_ERROR : INVALID_DISPUTE_DATA_ERROR;
   const rounds = votingHistory?.dispute?.rounds;
   const jurorRewardsDispersed = useMemo(() => Boolean(rounds?.every((round) => round.jurorRewardsDispersed)), [rounds]);
-  console.log({ jurorRewardsDispersed }, disputeDetails);
+
+  const safeFrontendUrl = useMemo(() => {
+    const url = disputeDetails?.frontendUrl;
+    return url ? getSafeNavigationUrl(url) : undefined;
+  }, [disputeDetails?.frontendUrl]);
 
   return (
     <>
@@ -145,11 +151,11 @@ export const DisputeContext: React.FC<IDisputeContext> = ({
         </div>
       ) : null}
 
-      {isUndefined(disputeDetails?.frontendUrl) ? null : (
-        <ExternalLink to={disputeDetails?.frontendUrl} target="_blank" rel="noreferrer">
+      {safeFrontendUrl ? (
+        <ExternalLink to={safeFrontendUrl} target="_blank" rel="noreferrer">
           Go to arbitrable
         </ExternalLink>
-      )}
+      ) : null}
       <VotingOptions>
         {isUndefined(disputeDetails) ? null : <AnswersHeader>Voting Options</AnswersHeader>}
         <AnswersContainer>

--- a/web/src/components/DisputePreview/DisputeContext.tsx
+++ b/web/src/components/DisputePreview/DisputeContext.tsx
@@ -129,7 +129,8 @@ export const DisputeContext: React.FC<IDisputeContext> = ({
   const rounds = votingHistory?.dispute?.rounds;
   const jurorRewardsDispersed = useMemo(() => Boolean(rounds?.every((round) => round.jurorRewardsDispersed)), [rounds]);
 
-  const frontendUrl = disputeDetails?.frontendUrl;
+  const frontendUrl = disputeDetails?.frontendUrl?.trim() || undefined;
+
   const safeFrontendUrl = useMemo(() => {
     return frontendUrl ? getSafeNavigationUrl(frontendUrl) : undefined;
   }, [frontendUrl]);

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "react-router-dom";
 
 import NewTabIcon from "svgs/icons/new-tab.svg";
 
-import { isAllowedAttachmentUrl } from "utils/urlValidation";
+import { getAllowedAttachmentUrl } from "utils/urlValidation";
 
 import { MAX_WIDTH_LANDSCAPE } from "styles/landscapeStyle";
 
@@ -56,7 +56,7 @@ const AttachmentDisplay: React.FC = () => {
   const [searchParams] = useSearchParams();
 
   const url = searchParams.get("url");
-  const safeUrl = url && isAllowedAttachmentUrl(url) ? url : null;
+  const safeUrl = url ? getAllowedAttachmentUrl(url) : null;
   const title = searchParams.get("title") ?? "Attachment";
   return (
     <Container>

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -5,6 +5,8 @@ import { useSearchParams } from "react-router-dom";
 
 import NewTabIcon from "svgs/icons/new-tab.svg";
 
+import { isAllowedAttachmentUrl } from "utils/urlValidation";
+
 import { MAX_WIDTH_LANDSCAPE } from "styles/landscapeStyle";
 
 import { ExternalLink } from "components/ExternalLink";
@@ -54,14 +56,15 @@ const AttachmentDisplay: React.FC = () => {
   const [searchParams] = useSearchParams();
 
   const url = searchParams.get("url");
+  const safeUrl = url && isAllowedAttachmentUrl(url) ? url : null;
   const title = searchParams.get("title") ?? "Attachment";
   return (
     <Container>
       <AttachmentContainer>
         <Header {...{ title }} />
-        {url ? (
+        {safeUrl ? (
           <>
-            <StyledExternalLink to={url} rel="noreferrer" target="_blank">
+            <StyledExternalLink to={safeUrl} rel="noreferrer" target="_blank">
               Open in new tab <StyledNewTabIcon />
             </StyledExternalLink>
             <Suspense
@@ -71,7 +74,7 @@ const AttachmentDisplay: React.FC = () => {
                 </LoaderContainer>
               }
             >
-              <FileViewer url={url} />
+              <FileViewer url={safeUrl} />
             </Suspense>
           </>
         ) : null}

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -52,6 +52,31 @@ const StyledNewTabIcon = styled(NewTabIcon)`
   }
 `;
 
+const UrlBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const UrlLabel = styled.small`
+  color: ${({ theme }) => theme.secondaryText};
+  font-weight: 600;
+`;
+
+const UrlContainer = styled.div`
+  background-color: ${({ theme }) => theme.lightGrey};
+  border: 1px solid ${({ theme }) => theme.stroke};
+  border-radius: 4px;
+  padding: 12px;
+  word-break: break-all;
+`;
+
+const Url = styled.code`
+  color: ${({ theme }) => theme.secondaryText};
+  font-size: 13px;
+  font-family: monospace;
+`;
+
 const AttachmentDisplay: React.FC = () => {
   const [searchParams] = useSearchParams();
 
@@ -77,6 +102,15 @@ const AttachmentDisplay: React.FC = () => {
               <FileViewer url={safeUrl} />
             </Suspense>
           </>
+        ) : null}
+
+        {url && !safeUrl ? (
+          <UrlBlock>
+            <UrlLabel>Invalid link</UrlLabel>
+            <UrlContainer>
+              <Url>{url}</Url>
+            </UrlContainer>
+          </UrlBlock>
         ) : null}
       </AttachmentContainer>
     </Container>

--- a/web/src/utils/urlValidation.ts
+++ b/web/src/utils/urlValidation.ts
@@ -29,16 +29,20 @@ export const getSafeNavigationUrl = (url: string) => {
   }
 };
 
-export const isAllowedAttachmentUrl = (url: string) => {
+export const getAllowedAttachmentUrl = (url: string) => {
   const safe = sanitizeHref(url);
   if (!safe) {
-    return false;
+    return undefined;
   }
 
   try {
     const parsed = new URL(safe);
-    return parsed.protocol === "https:" && parsed.origin === getGatewayOrigin() && parsed.pathname.startsWith("/ipfs/");
+    if (parsed.protocol !== "https:" || parsed.origin !== getGatewayOrigin() || !parsed.pathname.startsWith("/ipfs/")) {
+      return undefined;
+    }
+
+    return parsed.href;
   } catch {
-    return false;
+    return undefined;
   }
 };

--- a/web/src/utils/urlValidation.ts
+++ b/web/src/utils/urlValidation.ts
@@ -1,0 +1,44 @@
+import { sanitizeUrl } from "@braintree/sanitize-url";
+
+import { IPFS_GATEWAY } from "consts/index";
+
+const BLANK_URL = "about:blank";
+
+const getGatewayOrigin = () => new URL(IPFS_GATEWAY).origin;
+
+export const sanitizeHref = (url: string) => {
+  if (!url || typeof url !== "string") {
+    return "";
+  }
+
+  const sanitized = sanitizeUrl(url.trim());
+  return sanitized === BLANK_URL ? "" : sanitized;
+};
+
+export const getSafeNavigationUrl = (url: string) => {
+  const safe = sanitizeHref(url);
+  if (!safe) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(safe.startsWith("//") ? `https:${safe}` : safe);
+    return parsed.protocol === "https:" ? safe : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const isAllowedAttachmentUrl = (url: string) => {
+  const safe = sanitizeHref(url);
+  if (!safe) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(safe);
+    return parsed.protocol === "https:" && parsed.origin === getGatewayOrigin() && parsed.pathname.startsWith("/ipfs/");
+  } catch {
+    return false;
+  }
+};

--- a/web/src/utils/urlValidation.ts
+++ b/web/src/utils/urlValidation.ts
@@ -23,7 +23,7 @@ export const getSafeNavigationUrl = (url: string) => {
 
   try {
     const parsed = new URL(safe.startsWith("//") ? `https:${safe}` : safe);
-    return parsed.protocol === "https:" ? safe : undefined;
+    return parsed.protocol === "https:" ? parsed.href : undefined;
   } catch {
     return undefined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "@braintree/sanitize-url@npm:7.1.2"
+  checksum: 10/d9626ff8f8eb5e192cd055e6e743449c21102c76bb59e405b7028fe56230fa080bfcc80dfb1e21850a6876e75adda9f7b3c888cf0685942bb74da4d2866d6ec3
+  languageName: node
+  linkType: hard
+
 "@bytecodealliance/preview2-shim@npm:0.17.0":
   version: 0.17.0
   resolution: "@bytecodealliance/preview2-shim@npm:0.17.0"
@@ -6493,6 +6500,7 @@ __metadata:
   resolution: "@kleros/kleros-v2-web@workspace:web"
   dependencies:
     "@bigmi/react": "npm:^0.1.0"
+    "@braintree/sanitize-url": "npm:^7.1.2"
     "@coinbase/wallet-sdk": "npm:^4.3.2"
     "@cyntler/react-doc-viewer": "npm:^1.17.0"
     "@eslint/compat": "npm:^1.2.3"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `@braintree/sanitize-url` package to enhance URL validation and sanitization across the application. It adds functions to ensure safe navigation and attachment URLs, improving security and user experience.

### Detailed summary
- Added `@braintree/sanitize-url` dependency.
- Implemented `sanitizeHref`, `getSafeNavigationUrl`, and `getAllowedAttachmentUrl` functions in `web/src/utils/urlValidation.ts`.
- Updated `web/src/pages/AttachmentDisplay/index.tsx` to use sanitized URLs for external links and display invalid link warnings.
- Enhanced `web/src/components/DisputePreview/DisputeContext.tsx` to validate and display frontend URLs with safety checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pages now validate URLs before showing external links or file viewers, preventing navigation to unsafe or invalid addresses.
* **New Features**
  * When a provided URL fails validation, the UI displays the raw URL as a flagged, non-openable value with an explanatory tooltip and an "Invalid link" notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->