### PR TITLE
feat(contracts): forking mechanism TDD scaffold (skeletons + Foundry tests)

### DIFF
--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -118,6 +118,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     bool public arbitrableWhitelistEnabled; // Whether the arbitrable whitelist is enabled.
     IERC721 public jurorNft; // Eligible jurors NFT.
     IRatesConverter public ratesConverter; // Contract to convert ETH value to fee tokens.
+    address public forkSettlement; // The forking settlement contract authorized to capture/redistribute stakes. Appended last for upgrade-safety.
 
     // ************************************* //
     // *              Events               * //
@@ -271,6 +272,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _gracePeriodEnd Timestamp after which period transitions can resume.
     event ArbitrationUnpaused(uint256 _gracePeriodEnd);
 
+    /// @notice Emitted when a dispute jumps into the forking court and the terminal forking round opens.
+    /// @param _disputeID The dispute entering the forking court.
+    /// @param _roundID The forking round ID.
+    event ForkingRoundStarted(uint256 indexed _disputeID, uint256 _roundID);
+
     // ************************************* //
     // *        Function Modifiers         * //
     // ************************************* //
@@ -292,6 +298,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
 
     modifier whenNotPaused() {
         require(!paused, WhenNotPausedOnly());
+        _;
+    }
+
+    modifier onlyByForkSettlement() {
+        require(forkSettlement != address(0) && msg.sender == forkSettlement, ForkSettlementOnly());
         _;
     }
 
@@ -466,6 +477,12 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _ratesConverter The new value for the `ratesConverter` storage variable.
     function changeRatesConverter(IRatesConverter _ratesConverter) external onlyByOwner {
         ratesConverter = _ratesConverter;
+    }
+
+    /// @notice Sets the forking settlement contract authorized to capture and redistribute stakes.
+    /// @param _forkSettlement The new value for the `forkSettlement` storage variable.
+    function setForkSettlement(address _forkSettlement) external onlyByOwner {
+        forkSettlement = _forkSettlement;
     }
 
     /// @notice Changes the `_sortitionModule` storage variable.
@@ -685,6 +702,30 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         require(msg.sender == address(sortitionModule), SortitionModuleOnly());
         // Note eligibility is checked in SortitionModule.
         require(pinakion.safeTransfer(_account, _amount), TransferFailed());
+    }
+
+    /// @notice Captures a fork joiner's entire staked PNK for the main fork (G-7), surrendering it without
+    ///         refund. The PNK stays in this contract as the redistribution mass. Only callable by the
+    ///         forking settlement contract.
+    /// @dev TDD skeleton — reverts `NotImplemented()`. Implementation calls
+    ///      `sortitionModule.captureUnstakeAllCourts` and accumulates the captured pool.
+    /// @param _joiner The joiner whose stake to capture.
+    /// @return captured The amount of PNK captured.
+    function captureStakeForForking(address _joiner) external onlyByForkSettlement returns (uint256 captured) {
+        _joiner;
+        revert NotImplemented();
+    }
+
+    /// @notice Credits a main-fork stayer their supply-equalized share of the captured pool (G-5/G-7).
+    ///         No token transfer occurs (the PNK is already held here); the stayer's stake is scaled up.
+    ///         Only callable by the forking settlement contract; freeze-exempt (settlement-internal).
+    /// @dev TDD skeleton — reverts `NotImplemented()`.
+    /// @param _stayer The main-fork participant to credit.
+    /// @param _amount The PNK amount to credit to their main-fork stake.
+    function distributeForking(address _stayer, uint256 _amount) external onlyByForkSettlement {
+        _stayer;
+        _amount;
+        revert NotImplemented();
     }
 
     /// @notice Create a dispute and pay for the fees in the native currency, typically ETH.
@@ -1540,6 +1581,10 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     error GuardianOrOwnerOnly();
     error DisputeKitOnly();
     error SortitionModuleOnly();
+    error ForkSettlementOnly();
+    error AppealNotAllowed();
+    error NotForkingCourt();
+    error NotImplemented();
     error UnsuccessfulCall();
     error InvalidDisputeKitParent();
     error MinStakeLowerThanParentCourt();

--- a/contracts/src/arbitration/SortitionModule.sol
+++ b/contracts/src/arbitration/SortitionModule.sol
@@ -56,6 +56,7 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
     uint256 public maxStakePerJuror; // The maximum amount of PNK that a juror can stake across the courts. Accrued rewards do not count toward this limit.
     uint256 public maxTotalStaked; // The maximum amount of PNK that all the jurors can stake across the courts.
     uint256 public totalStaked; // The amount of PNK that is currently staked across the courts.
+    bool public stakingFrozen; // True while a forking round is live; blocks all staked-balance mutations (G-2). Appended last for upgrade-safety.
 
     // ************************************* //
     // *              Events               * //
@@ -95,6 +96,13 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
     /// @param _account The account of the juror withdrawing PNK.
     /// @param _amount The amount of PNK withdrawn.
     event LeftoverPNKWithdrawn(address indexed _account, uint256 _amount);
+
+    /// @notice Emitted when staking is frozen for a forking round.
+    /// @param _disputeID The forking dispute that triggered the freeze.
+    event StakingFreezeEngaged(uint256 indexed _disputeID);
+
+    /// @notice Emitted when staking is unfrozen after a forking round settles.
+    event StakingFreezeReleased();
 
     // ************************************* //
     // *            Constructor            * //
@@ -527,6 +535,39 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
         core.setStakeBySortitionModule(_account, _courtID, 0);
     }
 
+    // ************************************* //
+    // *         Forking (G-2 / G-7)       * //
+    // ************************************* //
+
+    /// @notice Freezes all staked-balance mutations for the duration of a forking round (G-2). Makes the
+    ///         live `stakedPnk` the vote snapshot. Stake locking/unlocking and drawing remain allowed.
+    /// @dev TDD skeleton — reverts `NotImplemented()`. Implementation sets `stakingFrozen = true`,
+    ///      records `_disputeID`, and emits `StakingFreezeEngaged`. The guard itself is added to
+    ///      `_setStake` / `executeDelayedStakes` / `validateStake` in the implementation pass.
+    /// @param _disputeID The forking dispute triggering the freeze.
+    function freeze(uint256 _disputeID) external override onlyByCore {
+        _disputeID;
+        revert NotImplemented();
+    }
+
+    /// @notice Releases the stake freeze once a forking round has settled.
+    /// @dev TDD skeleton — reverts `NotImplemented()`.
+    function unfreeze() external override onlyByCore {
+        revert NotImplemented();
+    }
+
+    /// @notice Surrenders a fork joiner's entire staked PNK to the main fork WITHOUT refunding them:
+    ///         zeroes their sortition-tree slots, `courtIDs` and `stakedPnk`, decrements `totalStaked`,
+    ///         and performs NO token transfer (the PNK stays in `KlerosCore`'s balance as the
+    ///         redistribution mass). Contrast `forcedUnstakeAllCourts`, which refunds the juror.
+    /// @dev TDD skeleton — reverts `NotImplemented()`.
+    /// @param _account The joiner to capture.
+    /// @return captured The amount of PNK surrendered (the joiner's former `stakedPnk`).
+    function captureUnstakeAllCourts(address _account) external override onlyByCore returns (uint256 captured) {
+        _account;
+        revert NotImplemented();
+    }
+
     /// @notice Gives back the locked PNKs in case the juror fully unstaked earlier.
     ///
     /// @dev that since locked and staked PNK are async it is possible for the juror to have positive staked PNK balance
@@ -662,4 +703,8 @@ contract SortitionModule is ISortitionModule, Initializable, UUPSProxiable {
     error NoDelayedStakeToExecute();
     error NotEligibleForWithdrawal();
     error NotDrawingPhase();
+    error NotImplemented();
+    error StakingFrozen();
+    error AlreadyFrozen();
+    error NotFrozen();
 }

--- a/contracts/src/arbitration/dispute-kits/DisputeKitForking.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitForking.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {KlerosCore} from "../KlerosCore.sol";
+import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
+import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
+import {Initializable} from "../../proxy/Initializable.sol";
+import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
+import {ForkMath} from "./ForkMath.sol";
+import {ForkSettlement} from "./ForkSettlement.sol";
+import {PNKHolderEscrow} from "./PNKHolderEscrow.sol";
+
+/// @title DisputeKitForking
+/// @notice The dispute kit hosting the single terminal forking round at the `KlerosCore` boundary
+///         (see `docs/layer-1-core/07-forking.md`). It runs hidden (commit/reveal) single-choice,
+///         single-threshold votes among all reachable PNK holders, determines the stake-weighted
+///         plurality winner as the final ruling (`a_main`, G-3), computes each minority fork's membership
+///         via `ForkMath`'s removal fixed point (G-4), and hands off to `ForkSettlement` for redistribution
+///         and minting. To `KlerosCore` it is just an `IDisputeKit`; everything forking-specific is composed
+///         beneath it (`ForkMath`, `ForkSettlement`, `PNKHolderEscrow`).
+///
+/// @dev TDD skeleton. The boilerplate (proxy, ownership, Core wiring) is real so the contract deploys and
+///      tests can bind to it; the forking logic and the meaningful `IDisputeKit` behaviors revert
+///      `NotImplemented()` or return inert defaults until the implementation pass.
+contract DisputeKitForking is IDisputeKit, Initializable, UUPSProxiable {
+    string public constant override version = "0.1.0";
+
+    // ************************************* //
+    // *             Structs               * //
+    // ************************************* //
+
+    /// @dev A revealed forking vote.
+    struct RevealedVote {
+        bool revealed; // True once the holder has revealed.
+        uint256 choice; // The chosen dispute option.
+        uint256 threshold; // The minimum fork size at which the holder joins the minority fork.
+        uint256 weight; // The holder's weight at reveal (frozen stake + escrow).
+    }
+
+    /// @dev Per-core-dispute forking round state.
+    struct ForkingRound {
+        uint256 numberOfChoices; // Number of dispute options (excluding the implicit refuse-to-arbitrate 0).
+        mapping(address voter => bytes32) commits; // keccak256(choice, threshold, salt) per voter.
+        mapping(address voter => RevealedVote) revealed; // Revealed votes per voter.
+        mapping(uint256 choice => ForkMath.OptionList) optionLists; // One threshold-sorted list per option.
+        mapping(uint256 choice => uint256) tallyWeight; // Total revealed weight per option.
+        uint256 winningChoice; // The plurality winner = `a_main`.
+        bool winnerDetermined; // True once the winner has been computed.
+        bool finalized; // True once all minority forks have been computed and settlement initiated.
+        uint256 finalizeChoiceCursor; // Pagination cursor across losing options during finalize.
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    address public owner; // The owner of the contract.
+    KlerosCore public core; // The Kleros Core arbitrator.
+    ForkSettlement public settlement; // The composed settlement unit.
+    PNKHolderEscrow public escrow; // The composed tier-2 escrow unit.
+    mapping(uint256 coreDisputeID => ForkingRound) internal forkingRounds; // Forking round state per dispute.
+    mapping(uint256 coreDisputeID => bool) public initialized; // True once `createDispute` ran for a dispute.
+
+    uint256[50] private __gap; // Reserved slots for future upgrades.
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @notice Emitted when a holder commits a hidden forking vote.
+    event VoteCommitted(uint256 indexed _coreDisputeID, address indexed _voter, bytes32 _commit);
+    /// @notice Emitted when a holder reveals a forking vote.
+    event VoteRevealed(
+        uint256 indexed _coreDisputeID,
+        address indexed _voter,
+        uint256 _choice,
+        uint256 _threshold,
+        uint256 _weight
+    );
+    /// @notice Emitted when the cut-off computation completes and the winner + fork membership are published.
+    event ForkFinalized(uint256 indexed _coreDisputeID, uint256 _winningChoice);
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
+
+    error NotImplemented();
+    error KlerosCoreOnly();
+    error OwnerOnly();
+    error UnsupportedOperation();
+    error ForkNotInitiated();
+    error ForkAlreadyInitiated();
+    error WrongPeriod();
+    error CommitMismatch();
+    error AlreadyRevealed();
+    error NothingToReveal();
+    error AlreadyFinalized();
+    error NotForkingCourt();
+
+    // ************************************* //
+    // *             Modifiers             * //
+    // ************************************* //
+
+    modifier onlyByCore() {
+        require(address(core) == msg.sender, KlerosCoreOnly());
+        _;
+    }
+
+    modifier onlyByOwner() {
+        require(owner == msg.sender, OwnerOnly());
+        _;
+    }
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializer.
+    /// @param _owner The owner's address.
+    /// @param _core The KlerosCore arbitrator.
+    function initialize(address _owner, KlerosCore _core) external initializer {
+        owner = _owner;
+        core = _core;
+    }
+
+    // ************************************* //
+    // *            Governance             * //
+    // ************************************* //
+
+    /// @dev Access control for UUPS upgrades; only the owner.
+    function _authorizeUpgrade(address) internal view override onlyByOwner {
+        // NOP
+    }
+
+    /// @notice Changes the `owner` storage variable.
+    function changeOwner(address _owner) external onlyByOwner {
+        owner = _owner;
+    }
+
+    /// @notice Wires the composed settlement and escrow units.
+    /// @param _settlement The `ForkSettlement` contract.
+    /// @param _escrow The `PNKHolderEscrow` contract.
+    function changeComposedUnits(ForkSettlement _settlement, PNKHolderEscrow _escrow) external onlyByOwner {
+        settlement = _settlement;
+        escrow = _escrow;
+    }
+
+    // ************************************* //
+    // *         Forking voting            * //
+    // ************************************* //
+
+    /// @notice Commits a hidden forking vote: keccak256(choice, threshold, salt). Commit period only.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _commit The commitment hash.
+    function commitVote(uint256 _coreDisputeID, bytes32 _commit) external {
+        _coreDisputeID;
+        _commit;
+        revert NotImplemented();
+    }
+
+    /// @notice Reveals a previously committed forking vote. Weight = frozen `stakedPnk` (incl. locked) +
+    ///         any `PNKHolderEscrow` deposit. Inserts the voter into the option's threshold-sorted list.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _choice The revealed choice.
+    /// @param _threshold The revealed forking threshold.
+    /// @param _salt The salt used in the commit.
+    function revealVote(uint256 _coreDisputeID, uint256 _choice, uint256 _threshold, uint256 _salt) external {
+        _coreDisputeID;
+        _choice;
+        _threshold;
+        _salt;
+        revert NotImplemented();
+    }
+
+    /// @notice Determines the winner then walks each losing option's removal fixed point (paginated).
+    ///         On completion, calls `ForkSettlement.initSettle`. Execution period only.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _maxIt The pagination bound for this call.
+    function finalize(uint256 _coreDisputeID, uint256 _maxIt) external {
+        _coreDisputeID;
+        _maxIt;
+        revert NotImplemented();
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @notice UI insertion-hint search into an option's threshold-sorted list.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _choice The option to search.
+    /// @param _threshold The threshold to place.
+    /// @param _searchStart The node to begin from.
+    /// @return nextID The node ID to insert before.
+    function search(
+        uint256 _coreDisputeID,
+        uint256 _choice,
+        uint256 _threshold,
+        uint256 _searchStart
+    ) external view returns (uint256 nextID) {
+        _coreDisputeID;
+        _choice;
+        _threshold;
+        _searchStart;
+        revert NotImplemented();
+    }
+
+    /// @notice Helper to compute a forking vote commitment off the same scheme used by `revealVote`.
+    /// @param _choice The choice.
+    /// @param _threshold The forking threshold.
+    /// @param _salt The salt.
+    /// @return The commitment hash.
+    function hashForkVote(uint256 _choice, uint256 _threshold, uint256 _salt) external pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_choice, _threshold, _salt));
+    }
+
+    // ************************************* //
+    // *         IDisputeKit surface       * //
+    // ************************************* //
+
+    /// @notice Initiates the forking round for a core dispute. The 3rd argument is the number of choices
+    ///         (per `IDisputeKit`); the winner is determined by the round, not passed in.
+    /// @param _coreDisputeID The dispute ID in Kleros Core.
+    /// @param _numberOfChoices The number of choices.
+    function createDispute(
+        uint256 _coreDisputeID,
+        uint256 /*_coreRoundID*/,
+        uint256 _numberOfChoices,
+        bytes calldata /*_extraData*/,
+        uint256 /*_nbVotes*/
+    ) external override onlyByCore {
+        require(!initialized[_coreDisputeID], ForkAlreadyInitiated());
+        initialized[_coreDisputeID] = true;
+        forkingRounds[_coreDisputeID].numberOfChoices = _numberOfChoices;
+    }
+
+    /// @notice No drawing happens in a forking round (nbVotes = 0). Returns zeros harmlessly; Core may call
+    ///         this and MUST NOT revert.
+    function draw(
+        uint256 /*_coreDisputeID*/,
+        uint256 /*_nonce*/,
+        uint256 /*_roundNbVotes*/
+    ) external override returns (address, uint96) {
+        return (address(0), 0);
+    }
+
+    /// @notice The final ruling: the plurality winner `a_main` once determined, else 0. Never tied/overridden.
+    function currentRuling(
+        uint256 _coreDisputeID
+    ) external view override returns (uint256 ruling, bool tied, bool overridden) {
+        ForkingRound storage round = forkingRounds[_coreDisputeID];
+        return (round.winnerDetermined ? round.winningChoice : 0, false, false);
+    }
+
+    // --- The following IDisputeKit functions are inert for the forking kit. --- //
+
+    /// @inheritdoc IDisputeKit
+    function getDegreeOfCoherenceReward(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getDegreeOfCoherencePenalty(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override returns (uint256) {
+        return 0;
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getCoherentCount(uint256, uint256) external pure override returns (uint256) {
+        return 0;
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getRewards(
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    /// @inheritdoc IDisputeKit
+    function areCommitsAllCast(uint256) external pure override returns (bool) {
+        return false; // Time-based progression, not commit-count based.
+    }
+
+    /// @inheritdoc IDisputeKit
+    function areVotesAllCast(uint256) external pure override returns (bool) {
+        return false; // Time-based progression, not vote-count based.
+    }
+
+    /// @inheritdoc IDisputeKit
+    function isAppealFunded(uint256) external pure override returns (bool) {
+        return false;
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getNextRoundSettings(
+        uint256,
+        uint96,
+        uint96,
+        uint256,
+        uint256,
+        uint256
+    ) external pure override returns (uint96, uint256, uint256) {
+        revert UnsupportedOperation(); // The forking round is terminal: no next round.
+    }
+
+    /// @inheritdoc IDisputeKit
+    function isVoteActive(uint256, uint256, uint256) external pure override returns (bool) {
+        return false;
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getRoundInfo(
+        uint256,
+        uint256,
+        uint256
+    ) external pure override returns (uint256, bool, uint256, uint256, uint256, uint256) {
+        return (0, false, 0, 0, 0, 0);
+    }
+
+    /// @inheritdoc IDisputeKit
+    function getVoteInfo(uint256, uint256, uint256) external pure override returns (address, bytes32, uint256, bool) {
+        return (address(0), bytes32(0), 0, false);
+    }
+}

--- a/contracts/src/arbitration/dispute-kits/ForkMath.sol
+++ b/contracts/src/arbitration/dispute-kits/ForkMath.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+/// @title ForkMath
+/// @notice Pure library implementing the forking "removal fixed point" (yellow paper Prop. 4,
+///         specialised to single-choice votes — see `docs/layer-1-core/07-forking.md`).
+///
+///         For each losing option, the voters who chose it form a threshold-sorted doubly-linked
+///         list. Finalization walks the list from the highest threshold downward, evicting any member
+///         whose forking threshold exceeds the current support `S` (subtracting their weight), and
+///         stops at the first satisfied member. The survivors are the maximal self-consistent set that
+///         materializes the minority fork; if every member is evicted the fork is empty.
+///
+/// @dev `internal`-only by design: with `via_ir = true` the compiler forbids public/external library
+///      functions (see `contracts/CLAUDE.md`). Tests exercise it through `src/test/ForkMathHarness.sol`.
+///      All bodies currently revert `NotImplemented()` — this is a TDD skeleton; the storage layout and
+///      function surface are final, the logic lands in the implementation pass.
+library ForkMath {
+    // ************************************* //
+    // *             Structs               * //
+    // ************************************* //
+
+    /// @dev A single voter's node in an option's threshold-sorted list.
+    struct VoterNode {
+        uint256 prev; // Previous node ID in the sorted list (lower threshold side).
+        uint256 next; // Next node ID in the sorted list (higher threshold side).
+        uint256 threshold; // The minimum fork size (in PNK weight) at which this voter joins.
+        uint256 weight; // The voter's weight (frozen stake + escrow).
+        address account; // The voter.
+        bool evicted; // True once finalization has cut this voter off (they stay on the main fork).
+        uint256[5] __gap; // Reserved slots for future upgrades.
+    }
+
+    /// @dev One per losing option. Holds the option's voter list and finalization state.
+    struct OptionList {
+        mapping(uint256 nodeID => VoterNode) nodes; // Nodes by ID. ID 0 is the HEAD sentinel.
+        uint256 lastNodeID; // The most recently inserted node ID; also the node count.
+        uint256 totalWeight; // Running sum of all (non-evicted) members' weight = current support `S`.
+        uint256 finalSupport; // The fork size after finalization (survivors' total weight).
+        uint256 cutOffNodeID; // The descending-walk cursor / last evicted boundary.
+        bool finalized; // True once the descending cut-off walk has completed.
+        uint256[5] __gap; // Reserved slots for future upgrades.
+    }
+
+    // ************************************* //
+    // *             Errors                * //
+    // ************************************* //
+
+    error NotImplemented();
+
+    // ************************************* //
+    // *            Functions              * //
+    // ************************************* //
+
+    /// @notice Finds the insertion point for a new node of the given threshold, starting the walk from
+    ///         `_searchStart`. Used as a UI gas hint so insertion amortizes to O(1) across reveals.
+    /// @param _list The option's list.
+    /// @param _threshold The threshold of the node to insert.
+    /// @param _searchStart The node ID to begin searching from.
+    /// @return nextID The node ID before which the new node should be inserted.
+    function search(
+        OptionList storage _list,
+        uint256 _threshold,
+        uint256 _searchStart
+    ) internal view returns (uint256 nextID) {
+        _list; // silence unused warnings in the skeleton
+        _threshold;
+        _searchStart;
+        revert NotImplemented();
+    }
+
+    /// @notice Inserts a voter into the option's threshold-sorted list and adds their weight to support.
+    /// @param _list The option's list.
+    /// @param _account The voter.
+    /// @param _threshold The voter's forking threshold.
+    /// @param _weight The voter's weight.
+    /// @param _hint The insertion hint from `search` (the node to insert before).
+    /// @return nodeID The newly created node ID.
+    function insert(
+        OptionList storage _list,
+        address _account,
+        uint256 _threshold,
+        uint256 _weight,
+        uint256 _hint
+    ) internal returns (uint256 nodeID) {
+        _list;
+        _account;
+        _threshold;
+        _weight;
+        _hint;
+        revert NotImplemented();
+    }
+
+    /// @notice Performs up to `_maxIt` steps of the descending cut-off walk. Evicts members whose
+    ///         threshold exceeds the current support; stops at the first satisfied member, sets
+    ///         `finalSupport`, and marks the list finalized.
+    /// @param _list The option's list.
+    /// @param _maxIt The maximum number of nodes to process this call (pagination bound).
+    /// @return done True once the walk has completed for this option.
+    function finalizeStep(OptionList storage _list, uint256 _maxIt) internal returns (bool done) {
+        _list;
+        _maxIt;
+        revert NotImplemented();
+    }
+
+    /// @notice Returns whether a node is a survivor of the finalized fork (not evicted).
+    /// @param _list The option's list.
+    /// @param _nodeID The node to query.
+    /// @return survivor True if the node survived the cut-off.
+    function isSurvivor(OptionList storage _list, uint256 _nodeID) internal view returns (bool survivor) {
+        _list;
+        _nodeID;
+        revert NotImplemented();
+    }
+}

--- a/contracts/src/arbitration/dispute-kits/ForkSettlement.sol
+++ b/contracts/src/arbitration/dispute-kits/ForkSettlement.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {KlerosCore} from "../KlerosCore.sol";
+import {ForkToken} from "../../token/ForkToken.sol";
+import {ISlashDestination} from "../interfaces/ISlashDestination.sol";
+
+/// @title ForkSettlement
+/// @notice Performs the settlement of a forking round (see `docs/layer-1-core/07-forking.md`):
+///         supply-equalized redistribution, fork-token genesis minting, joiner exit, slashing of the
+///         silent, and release of the stake freeze. Kept as a separate contract from `DisputeKitForking`
+///         (Q-007 baseline) to isolate the mint authority and stay under the 24 KB bytecode limit.
+///
+///         Settlement is a paginated phase machine:
+///           Capture     — surrender each joiner's main-chain PNK to Core (no refund).
+///           MainDistrib — credit each main-fork stayer a supply-equalized share of the captured pool.
+///           Mint        — deploy/mint each minority fork token, crediting joiners their genesis balance.
+///           Done        — release the freeze.
+///
+///         Supply-equalization (G-5): a holder's genesis on its fork = weight × originalTotalSupply / forkSize.
+///
+/// @dev TDD skeleton — every state-changing body reverts `NotImplemented()`. The DK computes the weight
+///      arrays before `initSettle`, so the genesis basis (Q-002 baseline: stake-snapshot pro-rata) is
+///      isolated to the DK and a later decision does not touch this contract.
+contract ForkSettlement {
+    // ************************************* //
+    // *         Enums / Structs           * //
+    // ************************************* //
+
+    enum Phase {
+        Capture, // Surrendering joiner stakes to the captured pool.
+        MainDistrib, // Crediting main-fork stayers.
+        Mint, // Minting minority fork tokens.
+        Done // Settlement complete, freeze released.
+    }
+
+    /// @dev Per-forking-dispute settlement state.
+    struct Settlement {
+        Phase phase; // The current settlement phase.
+        uint256 originalTotalSupply; // Snapshot of PNK total supply at settlement start (G-5 target).
+        uint256 mainForkSize; // Total weight staying on the main fork.
+        uint256 joinersTotal; // Running total of captured joiner PNK (+ absorbed slashes, Q-006 baseline).
+        uint256 captureCursor; // Pagination cursor into the flattened joiner list.
+        uint256 distribCursor; // Pagination cursor into the stayer list.
+        uint256 mintCursor; // Pagination cursor into the flattened joiner list (mint phase).
+        uint256 settleDeadline; // Timestamp after which `forceUnfreeze` may be called (relates to Q-008).
+        bool initialized; // True once `initSettle` has run.
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    address public owner; // The owner of the contract.
+    KlerosCore public core; // The Kleros Core arbitrator.
+    IERC20 public pinakion; // The PNK token.
+    address public disputeKit; // The DisputeKitForking allowed to call `initSettle`.
+    ISlashDestination public slashDestination; // Where slashed PNK goes (Q-006). May be self/absorb.
+
+    mapping(uint256 coreDisputeID => Settlement) public settlements;
+    // Per dispute: the deployed fork token for each minority option (0 if the option did not fork).
+    mapping(uint256 coreDisputeID => mapping(uint256 option => ForkToken)) public forkTokens;
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @notice Emitted when settlement begins for a forking dispute.
+    event SettlementStarted(uint256 indexed _coreDisputeID, uint256 _originalTotalSupply);
+    /// @notice Emitted when a minority fork token is created at genesis.
+    event ForkTokenCreated(uint256 indexed _coreDisputeID, uint256 indexed _option, address _token);
+    /// @notice Emitted when settlement completes and the freeze releases.
+    event ForkSettled(uint256 indexed _coreDisputeID);
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
+
+    error NotImplemented();
+    error DisputeKitOnly();
+    error AlreadyInitialized();
+    error AlreadySettled();
+    error NotPastDeadline();
+
+    // ************************************* //
+    // *             Modifiers             * //
+    // ************************************* //
+
+    modifier onlyByDK() {
+        require(msg.sender == disputeKit, DisputeKitOnly());
+        _;
+    }
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /// @notice Constructs the settlement contract.
+    /// @param _owner The owner address.
+    /// @param _core The Kleros Core arbitrator.
+    /// @param _disputeKit The DisputeKitForking authorized to start settlements.
+    constructor(address _owner, KlerosCore _core, address _disputeKit) {
+        owner = _owner;
+        core = _core;
+        pinakion = _core.pinakion();
+        disputeKit = _disputeKit;
+        slashDestination = ISlashDestination(address(this)); // Baseline Q-006: absorb into redistribution.
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /// @notice Initializes settlement for a finalized forking round. Snapshots total supply and deploys
+    ///         a fork token per non-empty minority option. Called by `DisputeKitForking.finalize`.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _mainStayers The accounts staying on the main fork (winners + cut-off losers).
+    /// @param _mainWeights The corresponding main-fork weights.
+    /// @param _options The losing options that formed a non-empty minority fork.
+    /// @param _joiners Per option, the joiner accounts.
+    /// @param _joinerWeights Per option, the joiner weights (parallel to `_joiners`).
+    function initSettle(
+        uint256 _coreDisputeID,
+        address[] calldata _mainStayers,
+        uint256[] calldata _mainWeights,
+        uint256[] calldata _options,
+        address[][] calldata _joiners,
+        uint256[][] calldata _joinerWeights
+    ) external onlyByDK {
+        _coreDisputeID;
+        _mainStayers;
+        _mainWeights;
+        _options;
+        _joiners;
+        _joinerWeights;
+        revert NotImplemented();
+    }
+
+    /// @notice Advances settlement by up to `_maxIt` steps across the Capture → MainDistrib → Mint → Done
+    ///         phases. Anyone may drive it; idempotent past `Done`.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _maxIt The pagination bound for this call.
+    function settle(uint256 _coreDisputeID, uint256 _maxIt) external {
+        _coreDisputeID;
+        _maxIt;
+        revert NotImplemented();
+    }
+
+    /// @notice Slashes a silent (non-revealing) staker/escrow holder (G-8). Routes the amount to
+    ///         `slashDestination` (baseline: absorbed into the stayer bonus).
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _account The silent holder.
+    /// @param _amount The amount to slash.
+    function slash(uint256 _coreDisputeID, address _account, uint256 _amount) external onlyByDK {
+        _coreDisputeID;
+        _account;
+        _amount;
+        revert NotImplemented();
+    }
+
+    /// @notice Emergency release of the stake freeze if settlement stalls past the deadline (Q-008 backstop).
+    /// @param _coreDisputeID The forking dispute.
+    function forceUnfreeze(uint256 _coreDisputeID) external {
+        _coreDisputeID;
+        revert NotImplemented();
+    }
+}

--- a/contracts/src/arbitration/dispute-kits/PNKHolderEscrow.sol
+++ b/contracts/src/arbitration/dispute-kits/PNKHolderEscrow.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {KlerosCore} from "../KlerosCore.sol";
+
+/// @title PNKHolderEscrow
+/// @notice The tier-2 forking participation path for PNK holders on the home chain who have no active
+///         stake. A holder deposits PNK here (the deposit is their forking vote weight, additive with
+///         any staked weight) and then commits/reveals like a staker. After settlement, stayers are
+///         refunded their deposit plus the redistribution bonus, joiners' deposits are forwarded to
+///         `ForkSettlement` (they receive fork tokens instead), and non-revealers are slashed (G-8).
+///
+/// @dev TDD skeleton — every state-changing body reverts `NotImplemented()`. The single PNK transfer
+///      back to a holder (in `settleEscrow`) MUST follow checks-effects-interactions and be guarded by
+///      `nonReentrant` in the implementation pass.
+contract PNKHolderEscrow {
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    /// @dev A holder's escrow participation for a single forking dispute.
+    struct EscrowVote {
+        uint256 deposit; // The escrowed PNK = the holder's tier-2 weight.
+        bytes32 commit; // keccak256(choice, threshold, salt).
+        uint256 choice; // Revealed choice (0 until revealed).
+        uint256 threshold; // Revealed forking threshold.
+        bool revealed; // True once the holder reveals.
+        bool settled; // True once the holder's escrow has been settled.
+        uint256[5] __gap; // Reserved slots for future upgrades.
+    }
+
+    address public owner; // The owner of the contract.
+    KlerosCore public core; // The Kleros Core arbitrator.
+    IERC20 public pinakion; // The PNK token.
+    address public forkSettlement; // The settlement contract that consumes joiner deposits.
+    mapping(uint256 coreDisputeID => mapping(address holder => EscrowVote)) public escrowVotes;
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @notice Emitted when a holder deposits PNK into escrow for a forking dispute.
+    event EscrowDeposited(uint256 indexed _coreDisputeID, address indexed _holder, uint256 _amount);
+    /// @notice Emitted when a holder commits an escrow vote.
+    event EscrowCommitted(uint256 indexed _coreDisputeID, address indexed _holder, bytes32 _commit);
+    /// @notice Emitted when a holder reveals an escrow vote.
+    event EscrowRevealed(uint256 indexed _coreDisputeID, address indexed _holder, uint256 _choice, uint256 _threshold);
+    /// @notice Emitted when a holder's escrow is settled.
+    event EscrowSettled(uint256 indexed _coreDisputeID, address indexed _holder, uint256 _payout);
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
+
+    error NotImplemented();
+    error KlerosCoreOnly();
+    error ForkSettlementOnly();
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /// @notice Constructs the escrow. Not upgradeable in the skeleton; the implementation pass decides
+    ///         whether to switch to the project's UUPS proxy pattern.
+    /// @param _owner The owner address.
+    /// @param _core The Kleros Core arbitrator.
+    constructor(address _owner, KlerosCore _core) {
+        owner = _owner;
+        core = _core;
+        pinakion = _core.pinakion();
+    }
+
+    /// @notice Sets the settlement contract allowed to pull joiner deposits.
+    /// @param _forkSettlement The `ForkSettlement` address.
+    function setForkSettlement(address _forkSettlement) external {
+        require(msg.sender == owner, NotImplemented());
+        forkSettlement = _forkSettlement;
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /// @notice Deposits PNK into escrow for a forking dispute. The deposit is the holder's tier-2 weight.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _amount The amount of PNK to escrow.
+    function deposit(uint256 _coreDisputeID, uint256 _amount) external {
+        _coreDisputeID;
+        _amount;
+        revert NotImplemented();
+    }
+
+    /// @notice Commits a hidden escrow vote: keccak256(choice, threshold, salt).
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _commit The commitment hash.
+    function commit(uint256 _coreDisputeID, bytes32 _commit) external {
+        _coreDisputeID;
+        _commit;
+        revert NotImplemented();
+    }
+
+    /// @notice Reveals a previously committed escrow vote.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _choice The revealed choice.
+    /// @param _threshold The revealed forking threshold.
+    /// @param _salt The salt used in the commit.
+    function reveal(uint256 _coreDisputeID, uint256 _choice, uint256 _threshold, uint256 _salt) external {
+        _coreDisputeID;
+        _choice;
+        _threshold;
+        _salt;
+        revert NotImplemented();
+    }
+
+    /// @notice Settles a holder's escrow after the forking round's settlement reaches `Done`.
+    ///         Stayers: refunded deposit + bonus. Joiners: deposit forwarded to settlement. Silent: slashed.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _holder The holder to settle.
+    function settleEscrow(uint256 _coreDisputeID, address _holder) external {
+        _coreDisputeID;
+        _holder;
+        revert NotImplemented();
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @notice Reads a holder's revealed tier-2 contribution, folded into the tally by `DisputeKitForking`.
+    /// @param _coreDisputeID The forking dispute.
+    /// @param _account The holder.
+    /// @return choice The revealed choice (0 if not revealed).
+    /// @return threshold The revealed threshold.
+    /// @return weight The escrow weight (the deposit) if revealed, else 0.
+    function revealOf(
+        uint256 _coreDisputeID,
+        address _account
+    ) external view returns (uint256 choice, uint256 threshold, uint256 weight) {
+        EscrowVote storage v = escrowVotes[_coreDisputeID][_account];
+        if (!v.revealed) return (0, 0, 0);
+        return (v.choice, v.threshold, v.deposit);
+    }
+}

--- a/contracts/src/arbitration/interfaces/ISlashDestination.sol
+++ b/contracts/src/arbitration/interfaces/ISlashDestination.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+/// @title ISlashDestination
+/// @notice Abstracts where slashed PNK goes when a staked/escrowed holder fails to reveal in a
+///         forking round (G-8). The baseline implementation absorbs the slash into the main-fork
+///         redistribution; an alternative routes it to the governor. Q-006 in the open-questions
+///         register is resolved by swapping the implementation, not by changing settlement logic.
+interface ISlashDestination {
+    /// @notice Receives `_amount` of slashed PNK belonging to `_account` for dispute `_coreDisputeID`.
+    /// @param _coreDisputeID The forking dispute the slash relates to.
+    /// @param _account The slashed holder.
+    /// @param _amount The slashed amount.
+    function receiveSlash(uint256 _coreDisputeID, address _account, uint256 _amount) external;
+}

--- a/contracts/src/arbitration/interfaces/ISortitionModule.sol
+++ b/contracts/src/arbitration/interfaces/ISortitionModule.sol
@@ -140,6 +140,20 @@ interface ISortitionModule {
     /// @param _courtID The ID of the court.
     function forcedUnstake(address _account, uint96 _courtID) external;
 
+    /// @notice Freezes all staked-balance mutations for the duration of a forking round (G-2).
+    /// @param _disputeID The forking dispute triggering the freeze.
+    function freeze(uint256 _disputeID) external;
+
+    /// @notice Releases the stake freeze once a forking round has settled.
+    function unfreeze() external;
+
+    /// @notice Surrenders a fork joiner's entire staked PNK to the main fork without refunding them.
+    /// @dev Zeroes the juror's stake and decrements totals but performs no token transfer; the PNK stays
+    ///      in `KlerosCore`'s balance as the main-fork redistribution mass.
+    /// @param _account The joiner to capture.
+    /// @return captured The amount of PNK surrendered (the joiner's former staked balance).
+    function captureUnstakeAllCourts(address _account) external returns (uint256 captured);
+
     /// @notice Locks the tokens of the drawn juror.
     /// @param _account The address of the juror.
     /// @param _relativeAmount The amount to lock.

--- a/contracts/src/proxy/KlerosProxies.sol
+++ b/contracts/src/proxy/KlerosProxies.sol
@@ -35,6 +35,10 @@ contract DisputeKitGatedArgentinaConsumerProtectionProxy is UUPSProxy {
     constructor(address _implementation, bytes memory _data) UUPSProxy(_implementation, _data) {}
 }
 
+contract DisputeKitForkingProxy is UUPSProxy {
+    constructor(address _implementation, bytes memory _data) UUPSProxy(_implementation, _data) {}
+}
+
 contract DisputeTemplateRegistryProxy is UUPSProxy {
     constructor(address _implementation, bytes memory _data) UUPSProxy(_implementation, _data) {}
 }

--- a/contracts/src/test/ForkMathHarness.sol
+++ b/contracts/src/test/ForkMathHarness.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {ForkMath} from "../arbitration/dispute-kits/ForkMath.sol";
+
+/// @title ForkMathHarness
+/// @notice Thin external wrapper around the `internal`-only `ForkMath` library so Foundry tests can
+///         exercise it directly. Owns a small set of `OptionList`s keyed by option ID, mirroring how
+///         `DisputeKitForking` will hold one list per losing option.
+/// @dev Test-only contract (lives under `src/test`, like the other `*Mock` harnesses).
+contract ForkMathHarness {
+    using ForkMath for ForkMath.OptionList;
+
+    mapping(uint256 optionID => ForkMath.OptionList) internal lists;
+
+    /// @notice Inserts a voter into an option's list, searching from `_searchStart` for the spot.
+    function insert(
+        uint256 _optionID,
+        address _account,
+        uint256 _threshold,
+        uint256 _weight,
+        uint256 _searchStart
+    ) external returns (uint256 nodeID) {
+        ForkMath.OptionList storage list = lists[_optionID];
+        uint256 hint = list.search(_threshold, _searchStart);
+        return list.insert(_account, _threshold, _weight, hint);
+    }
+
+    /// @notice Runs the paginated descending cut-off walk for an option.
+    function finalizeStep(uint256 _optionID, uint256 _maxIt) external returns (bool done) {
+        return lists[_optionID].finalizeStep(_maxIt);
+    }
+
+    /// @notice The fork size (survivors' total weight) after finalization.
+    function finalSupport(uint256 _optionID) external view returns (uint256) {
+        return lists[_optionID].finalSupport;
+    }
+
+    /// @notice The running support before/while finalizing.
+    function totalWeight(uint256 _optionID) external view returns (uint256) {
+        return lists[_optionID].totalWeight;
+    }
+
+    /// @notice Whether the option's walk has completed.
+    function finalized(uint256 _optionID) external view returns (bool) {
+        return lists[_optionID].finalized;
+    }
+
+    /// @notice Whether a given node survived the cut-off.
+    function isSurvivor(uint256 _optionID, uint256 _nodeID) external view returns (bool) {
+        return lists[_optionID].isSurvivor(_nodeID);
+    }
+
+    /// @notice Reads back a node's stored fields for assertions.
+    function getNode(
+        uint256 _optionID,
+        uint256 _nodeID
+    ) external view returns (uint256 threshold, uint256 weight, address account, bool evicted) {
+        ForkMath.VoterNode storage node = lists[_optionID].nodes[_nodeID];
+        return (node.threshold, node.weight, node.account, node.evicted);
+    }
+}

--- a/contracts/src/token/ForkToken.sol
+++ b/contracts/src/token/ForkToken.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title ForkToken
+/// @notice A minority-fork token (`PNK2 … PNKₙ`), one ERC-20 deployed per non-empty minority fork
+///         when a forking round settles. The owner (the `ForkSettlement` contract) is the sole
+///         mint authority and credits each fork joiner their genesis balance.
+/// @dev Modelled on `PinakionV2`: a mintable ERC-20 that re-adds the OZ-v5-dropped
+///      `increaseAllowance` / `decreaseAllowance` helpers for PNK-interface parity.
+contract ForkToken is ERC20, Ownable {
+    /// @param _name The token name, e.g. "Kleros Fork Token 2".
+    /// @param _symbol The token symbol, e.g. "PNK2".
+    /// @param _owner The owner and mint authority, typically the `ForkSettlement` contract.
+    constructor(string memory _name, string memory _symbol, address _owner) ERC20(_name, _symbol) Ownable(_owner) {}
+
+    /// @notice Mints `amount` fork tokens to `to`. Only callable by the owner (settlement).
+    /// @param to The genesis recipient.
+    /// @param amount The genesis balance.
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    /// @dev Re-added because OZ v5 removed it; expected by the PNK token interface.
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        address sender = _msgSender();
+        _approve(sender, spender, allowance(sender, spender) + addedValue);
+        return true;
+    }
+
+    /// @dev Re-added because OZ v5 removed it; expected by the PNK token interface.
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        address sender = _msgSender();
+        uint256 currentAllowance = allowance(sender, spender);
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        unchecked {
+            _approve(sender, spender, currentAllowance - subtractedValue);
+        }
+        return true;
+    }
+}

--- a/contracts/test/foundry/DisputeKitForking.t.sol
+++ b/contracts/test/foundry/DisputeKitForking.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ForkingTestBase} from "./ForkingTestBase.sol";
+import {DisputeKitForking} from "../../src/arbitration/dispute-kits/DisputeKitForking.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title DisputeKitForking_Test
+/// @notice Tests the forking dispute kit's `IDisputeKit` surface and its commit/reveal/finalize surface
+///         (G-3 winner, G-9 hidden votes). The inert `IDisputeKit` views are real and assert GREEN; the
+///         voting/finalization functions are skeletoned and assert RED via `NotImplemented()`.
+contract DisputeKitForking_Test is ForkingTestBase {
+    uint256 constant DISPUTE_ID = 0;
+
+    // --- IDisputeKit surface (real in the skeleton) --- //
+
+    function test_version() public view {
+        assertEq(forkingDK.version(), "0.1.0");
+    }
+
+    function test_createDispute_onlyByCore() public {
+        vm.expectRevert(DisputeKitForking.KlerosCoreOnly.selector);
+        vm.prank(other);
+        forkingDK.createDispute(DISPUTE_ID, 0, 3, "", 0);
+    }
+
+    function test_createDispute_storesNumberOfChoices() public {
+        vm.prank(address(core));
+        forkingDK.createDispute(DISPUTE_ID, 0, 3, "", 0);
+        assertTrue(forkingDK.initialized(DISPUTE_ID), "dispute must be marked initialized");
+
+        vm.expectRevert(DisputeKitForking.ForkAlreadyInitiated.selector);
+        vm.prank(address(core));
+        forkingDK.createDispute(DISPUTE_ID, 0, 3, "", 0);
+    }
+
+    function test_currentRuling_zeroBeforeFinalization() public view {
+        (uint256 ruling, bool tied, bool overridden) = forkingDK.currentRuling(DISPUTE_ID);
+        assertEq(ruling, 0, "no ruling before the winner is determined");
+        assertFalse(tied);
+        assertFalse(overridden);
+    }
+
+    function test_draw_returnsZeroAndDoesNotRevert() public {
+        // Core may call draw at nbVotes = 0; it MUST be a harmless no-op, not a revert.
+        (address drawn, uint96 court) = forkingDK.draw(DISPUTE_ID, 0, 0);
+        assertEq(drawn, address(0));
+        assertEq(court, 0);
+    }
+
+    function test_inertCoherenceViews() public view {
+        (uint256 r1, uint256 r2) = forkingDK.getDegreeOfCoherenceReward(0, 0, 0, 0, 0);
+        assertEq(r1, 0);
+        assertEq(r2, 0);
+        assertEq(forkingDK.getDegreeOfCoherencePenalty(0, 0, 0, 0, 0), 0);
+        assertEq(forkingDK.getCoherentCount(0, 0), 0);
+        assertFalse(forkingDK.areCommitsAllCast(0));
+        assertFalse(forkingDK.areVotesAllCast(0));
+        assertFalse(forkingDK.isAppealFunded(0));
+        assertFalse(forkingDK.isVoteActive(0, 0, 0));
+    }
+
+    function test_getNextRoundSettings_revertsTerminal() public {
+        vm.expectRevert(DisputeKitForking.UnsupportedOperation.selector);
+        forkingDK.getNextRoundSettings(0, 0, 0, 0, 0, 0);
+    }
+
+    function test_hashForkVote_matchesScheme() public view {
+        bytes32 expected = keccak256(abi.encodePacked(uint256(2), uint256(30), uint256(12345)));
+        assertEq(forkingDK.hashForkVote(2, 30, 12345), expected);
+    }
+
+    // --- Voting / finalization surface (RED until implemented) --- //
+
+    function test_commitVote_notImplemented() public {
+        vm.expectRevert(DisputeKitForking.NotImplemented.selector);
+        forkingDK.commitVote(DISPUTE_ID, bytes32(0));
+    }
+
+    function test_revealVote_notImplemented() public {
+        vm.expectRevert(DisputeKitForking.NotImplemented.selector);
+        forkingDK.revealVote(DISPUTE_ID, 2, 30, 12345);
+    }
+
+    function test_finalize_notImplemented() public {
+        vm.expectRevert(DisputeKitForking.NotImplemented.selector);
+        forkingDK.finalize(DISPUTE_ID, 10);
+    }
+}

--- a/contracts/test/foundry/ForkMath.t.sol
+++ b/contracts/test/foundry/ForkMath.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ForkMathHarness} from "../../src/test/ForkMathHarness.sol";
+
+/// @title ForkMath_Test
+/// @notice Tests the forking "removal fixed point" (G-4 / INV-2). The two worked examples in
+///         `docs/layer-1-core/07-forking.md` are the canonical fixtures.
+/// @dev RED until `ForkMath` is implemented (the library bodies currently revert `NotImplemented()`).
+///      The assertions encode the spec's expected fork sizes and survivor sets exactly.
+contract ForkMath_Test is Test {
+    ForkMathHarness harness;
+
+    // Sentinel for "start searching from the tail".
+    uint256 constant FROM_TAIL = type(uint256).max;
+
+    function setUp() public {
+        harness = new ForkMathHarness();
+    }
+
+    /// @dev Helper: insert a voter into option `opt` with no search hint (start from tail).
+    function _add(uint256 opt, address who, uint256 threshold, uint256 weight) internal returns (uint256) {
+        return harness.insert(opt, who, threshold, weight, FROM_TAIL);
+    }
+
+    /// @dev Helper: run the cut-off walk to completion with generous pagination.
+    function _finalize(uint256 opt) internal {
+        bool done;
+        for (uint256 i = 0; i < 32 && !done; i++) {
+            done = harness.finalizeStep(opt, 8);
+        }
+        assertTrue(done, "finalize did not complete");
+    }
+
+    // ********************************************************************** //
+    // *  Example 1 — binary, A wins. Option B: total 39, v5 (40) cut off. * //
+    // ********************************************************************** //
+
+    /// INV-2: B fork = 30, survivors {v3(12), v7(20), v4(30)}, v5(40) evicted (40 > 39 then 40 > 30).
+    function testRemovalFixedPointExample1() public {
+        uint256 B = 1;
+        // (threshold, weight) per the spec table.
+        uint256 v3 = _add(B, vm.addr(3), 12, 12);
+        uint256 v4 = _add(B, vm.addr(4), 30, 11);
+        uint256 v5 = _add(B, vm.addr(5), 40, 9);
+        uint256 v7 = _add(B, vm.addr(7), 20, 7);
+
+        assertEq(harness.totalWeight(B), 39, "initial B support");
+
+        _finalize(B);
+
+        assertEq(harness.finalSupport(B), 30, "B fork must settle at 30");
+        assertTrue(harness.isSurvivor(B, v3), "v3 survives");
+        assertTrue(harness.isSurvivor(B, v4), "v4 survives (threshold 30 == support 30)");
+        assertTrue(harness.isSurvivor(B, v7), "v7 survives");
+        assertFalse(harness.isSurvivor(B, v5), "v5 is cut off (40 > 39) and stays on the main fork");
+    }
+
+    // ********************************************************************** //
+    // *  Example 2 — four options, A wins. C forks at 23, B & D collapse.  * //
+    // ********************************************************************** //
+
+    /// INV-2: C fork = 23 (none evicted: 12<=12, 15<=16, 20<=23).
+    function testRemovalFixedPointExample2_C_forks() public {
+        uint256 C = 3;
+        uint256 v3 = _add(C, vm.addr(3), 12, 12);
+        uint256 v8 = _add(C, vm.addr(8), 15, 4);
+        uint256 v7 = _add(C, vm.addr(7), 20, 7);
+
+        assertEq(harness.totalWeight(C), 23, "initial C support");
+        _finalize(C);
+
+        assertEq(harness.finalSupport(C), 23, "C fork must settle at 23");
+        assertTrue(harness.isSurvivor(C, v3), "v3 survives");
+        assertTrue(harness.isSurvivor(C, v8), "v8 survives");
+        assertTrue(harness.isSurvivor(C, v7), "v7 survives");
+    }
+
+    /// INV-2: B collapses to empty (25 > 20 evict v4 → 15 > 9 evict v5).
+    function testRemovalFixedPointExample2_B_empty() public {
+        uint256 B = 2;
+        uint256 v5 = _add(B, vm.addr(15), 15, 9);
+        uint256 v4 = _add(B, vm.addr(14), 25, 11);
+
+        _finalize(B);
+
+        assertEq(harness.finalSupport(B), 0, "B fork must be empty");
+        assertFalse(harness.isSurvivor(B, v4), "v4 evicted");
+        assertFalse(harness.isSurvivor(B, v5), "v5 evicted");
+    }
+
+    /// INV-2: D collapses to empty (10 > 9 evict the lone voter).
+    function testRemovalFixedPointExample2_D_empty() public {
+        uint256 D = 4;
+        uint256 v6 = _add(D, vm.addr(16), 10, 9);
+
+        _finalize(D);
+
+        assertEq(harness.finalSupport(D), 0, "D fork must be empty");
+        assertFalse(harness.isSurvivor(D, v6), "lone voter below own threshold is evicted");
+    }
+
+    // ********************************************************************** //
+    // *                            Edge cases                             * //
+    // ********************************************************************** //
+
+    /// A lone voter whose threshold is satisfied by their own weight survives.
+    function testEdge_loneVoterSatisfied() public {
+        uint256 opt = 7;
+        uint256 n = _add(opt, vm.addr(50), 5, 9);
+        _finalize(opt);
+        assertEq(harness.finalSupport(opt), 9);
+        assertTrue(harness.isSurvivor(opt, n));
+    }
+
+    /// All members satisfied at full support → no eviction, fork = total.
+    function testEdge_allJoin() public {
+        uint256 opt = 8;
+        _add(opt, vm.addr(60), 5, 10);
+        _add(opt, vm.addr(61), 10, 10);
+        _add(opt, vm.addr(62), 20, 10);
+        _finalize(opt);
+        assertEq(harness.finalSupport(opt), 30, "all thresholds <= 30 so everyone joins");
+    }
+
+    /// Empty option finalizes to zero support without reverting.
+    function testEdge_emptyOption() public {
+        uint256 opt = 9;
+        _finalize(opt);
+        assertEq(harness.finalSupport(opt), 0);
+    }
+
+    /// Threshold ties: members with equal thresholds are handled deterministically.
+    function testEdge_thresholdTies() public {
+        uint256 opt = 10;
+        uint256 a = _add(opt, vm.addr(70), 20, 10);
+        uint256 b = _add(opt, vm.addr(71), 20, 10);
+        uint256 c = _add(opt, vm.addr(72), 20, 10);
+        _finalize(opt);
+        // total 30 >= 20, all satisfied.
+        assertEq(harness.finalSupport(opt), 30);
+        assertTrue(harness.isSurvivor(opt, a));
+        assertTrue(harness.isSurvivor(opt, b));
+        assertTrue(harness.isSurvivor(opt, c));
+    }
+}

--- a/contracts/test/foundry/ForkSettlement.t.sol
+++ b/contracts/test/foundry/ForkSettlement.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ForkingTestBase} from "./ForkingTestBase.sol";
+import {ForkSettlement} from "../../src/arbitration/dispute-kits/ForkSettlement.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title ForkSettlement_Test
+/// @notice Tests settlement: supply equalization (G-5 / INV-4), joiner exit + mint (G-7 / INV-5), PNK
+///         conservation, capture-without-refund, and the baseline open-question answers (Q-006 slash
+///         absorbed, Q-016 locked-PNK joiner).
+/// @dev Wiring assertions are GREEN; the settlement flow is skeletoned and asserts RED via
+///      `NotImplemented()`. The implementation pass fills in `initSettle`/`settle`/`slash`.
+contract ForkSettlement_Test is ForkingTestBase {
+    uint256 constant DISPUTE_ID = 0;
+
+    // --- Wiring (real in the skeleton) --- //
+
+    function test_wiring() public view {
+        assertEq(address(forkSettlement.core()), address(core));
+        assertEq(address(forkSettlement.pinakion()), address(pinakion));
+        assertEq(forkSettlement.disputeKit(), address(forkingDK));
+        assertEq(address(forkSettlement.slashDestination()), address(forkSettlement), "Q-006 baseline: absorb");
+        assertEq(address(core.forkSettlement()), address(forkSettlement));
+    }
+
+    // --- Access control --- //
+
+    function test_initSettle_onlyByDK() public {
+        address[] memory stayers = new address[](0);
+        uint256[] memory weights = new uint256[](0);
+        uint256[] memory options = new uint256[](0);
+        address[][] memory joiners = new address[][](0);
+        uint256[][] memory joinerWeights = new uint256[][](0);
+
+        vm.expectRevert(ForkSettlement.DisputeKitOnly.selector);
+        vm.prank(other);
+        forkSettlement.initSettle(DISPUTE_ID, stayers, weights, options, joiners, joinerWeights);
+    }
+
+    function test_slash_onlyByDK() public {
+        vm.expectRevert(ForkSettlement.DisputeKitOnly.selector);
+        vm.prank(other);
+        forkSettlement.slash(DISPUTE_ID, staker1, 100);
+    }
+
+    // --- Settlement flow (RED until implemented) --- //
+
+    function test_initSettle_notImplemented() public {
+        address[] memory stayers = new address[](0);
+        uint256[] memory weights = new uint256[](0);
+        uint256[] memory options = new uint256[](0);
+        address[][] memory joiners = new address[][](0);
+        uint256[][] memory joinerWeights = new uint256[][](0);
+
+        vm.expectRevert(ForkSettlement.NotImplemented.selector);
+        vm.prank(address(forkingDK));
+        forkSettlement.initSettle(DISPUTE_ID, stayers, weights, options, joiners, joinerWeights);
+    }
+
+    function test_settle_notImplemented() public {
+        vm.expectRevert(ForkSettlement.NotImplemented.selector);
+        forkSettlement.settle(DISPUTE_ID, 10);
+    }
+
+    function test_forceUnfreeze_notImplemented() public {
+        vm.expectRevert(ForkSettlement.NotImplemented.selector);
+        forkSettlement.forceUnfreeze(DISPUTE_ID);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Specification of the settlement invariants for the GREEN pass.    //
+    //  Encoded against the spec's Example 1 (option B forks at 30) so the //
+    //  implementer has executable acceptance criteria. Currently RED.    //
+    // ------------------------------------------------------------------ //
+    //
+    //  Given original total supply S and a fork of size `forkSize`, a holder of weight `w` on that fork
+    //  receives genesis `w * S / forkSize` (supply equalization, G-5). After settlement:
+    //   - each fork token's totalSupply == S            (INV-4)
+    //   - every joiner's main-chain stakedPnk == 0       (INV-5)
+    //   - sum(captured) + sum(stayer face value) == Core PNK balance at settle start (conservation)
+    //   - a silent staker's PNK is absorbed into the stayer bonus (Q-006 baseline)
+    //   - a joiner's full frozen stake (incl. locked) is captured (Q-016 baseline)
+    //
+    //  These become concrete assertions in `Forking_Integration.t.sol::test_fullLifecycle` once the
+    //  end-to-end flow lands, and in dedicated unit tests here once `settle` is implemented.
+}

--- a/contracts/test/foundry/ForkToken.t.sol
+++ b/contracts/test/foundry/ForkToken.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ForkToken} from "../../src/token/ForkToken.sol";
+
+/// @title ForkToken_Test
+/// @notice Unit tests for the minority-fork ERC-20. `ForkToken` is fully implemented (no spec ambiguity),
+///         so this suite is GREEN from the start and acts as a TDD sanity anchor.
+contract ForkToken_Test is Test {
+    ForkToken token;
+    address settlement; // The owner / mint authority.
+    address alice;
+    address bob;
+
+    function setUp() public {
+        settlement = vm.addr(100);
+        alice = vm.addr(101);
+        bob = vm.addr(102);
+        token = new ForkToken("Kleros Fork Token 2", "PNK2", settlement);
+    }
+
+    function test_metadata() public view {
+        assertEq(token.name(), "Kleros Fork Token 2");
+        assertEq(token.symbol(), "PNK2");
+        assertEq(token.owner(), settlement);
+        assertEq(token.totalSupply(), 0);
+    }
+
+    function test_mint_onlyOwnerCanMint() public {
+        vm.prank(settlement);
+        token.mint(alice, 1000);
+        assertEq(token.balanceOf(alice), 1000);
+        assertEq(token.totalSupply(), 1000);
+    }
+
+    function test_mint_revertsForNonOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        token.mint(alice, 1000);
+    }
+
+    function test_mint_tracksSupplyAcrossHolders() public {
+        vm.startPrank(settlement);
+        token.mint(alice, 700);
+        token.mint(bob, 300);
+        vm.stopPrank();
+        assertEq(token.totalSupply(), 1000, "supply must equal the sum of genesis balances");
+    }
+
+    function test_allowanceParity_increaseDecrease() public {
+        vm.prank(alice);
+        token.increaseAllowance(bob, 500);
+        assertEq(token.allowance(alice, bob), 500);
+
+        vm.prank(alice);
+        token.decreaseAllowance(bob, 200);
+        assertEq(token.allowance(alice, bob), 300);
+    }
+
+    function test_decreaseAllowance_revertsBelowZero() public {
+        vm.prank(alice);
+        vm.expectRevert(bytes("ERC20: decreased allowance below zero"));
+        token.decreaseAllowance(bob, 1);
+    }
+}

--- a/contracts/test/foundry/ForkingTestBase.sol
+++ b/contracts/test/foundry/ForkingTestBase.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
+import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import {DisputeKitForking} from "../../src/arbitration/dispute-kits/DisputeKitForking.sol";
+import {DisputeKitClassic} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import {ForkSettlement} from "../../src/arbitration/dispute-kits/ForkSettlement.sol";
+import {PNKHolderEscrow} from "../../src/arbitration/dispute-kits/PNKHolderEscrow.sol";
+import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title ForkingTestBase
+/// @notice Shared fixture for the forking-mechanism test suites. Extends `KlerosCore_TestBase` and adds
+///         the forking dispute kit, settlement, and escrow, wiring the routing that makes a General Court
+///         appeal exhaustion jump into the forking court and switch to `DisputeKitForking`.
+/// @dev The routing requires BOTH (1) `enableDisputeKits(FORKING_COURT, [forkingDKID], true)` so the
+///      forking court supports the forking DK, and (2) `changeNextRoundSettings(GENERAL_COURT, {...
+///      jumpDisputeKitIDOnCourtJump: forkingDKID})` on the classic DK so the parent-court jump switches
+///      the dispute kit. Without (2) the jump keeps Classic and Core's compatibility fallback corrupts
+///      routing — see `docs/layer-1-core/07-forking.md` and the plan's "jump routing chain".
+abstract contract ForkingTestBase is KlerosCore_TestBase {
+    DisputeKitForking forkingDK;
+    ForkSettlement forkSettlement;
+    PNKHolderEscrow escrow;
+    uint256 forkingDKID;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy the forking dispute kit behind a proxy.
+        DisputeKitForking forkingLogic = new DisputeKitForking();
+        bytes memory initData = abi.encodeWithSignature("initialize(address,address)", owner, address(core));
+        UUPSProxy proxy = new UUPSProxy(address(forkingLogic), initData);
+        forkingDK = DisputeKitForking(address(proxy));
+
+        // Register and enable it on the forking court.
+        vm.startPrank(owner);
+        core.addNewDisputeKit(forkingDK);
+        forkingDKID = core.getDisputeKitsLength() - 1;
+        uint256[] memory dks = new uint256[](1);
+        dks[0] = forkingDKID;
+        core.enableDisputeKits(FORKING_COURT, dks, true);
+
+        // Route the General Court's court jump to the forking dispute kit.
+        DisputeKitClassic.NextRoundSettings memory settings = DisputeKitClassic.NextRoundSettings({
+            enabled: true,
+            jumpCourtID: 0, // undefined → default parent-jump logic targets FORKING_COURT
+            jumpDisputeKitID: 0, // undefined → use jumpDisputeKitIDOnCourtJump below
+            jumpDisputeKitIDOnCourtJump: forkingDKID,
+            nbVotes: 0
+        });
+        disputeKit.changeNextRoundSettings(GENERAL_COURT, settings);
+        vm.stopPrank();
+
+        // Deploy settlement + escrow and wire them.
+        forkSettlement = new ForkSettlement(owner, core, address(forkingDK));
+        escrow = new PNKHolderEscrow(owner, core);
+
+        vm.startPrank(owner);
+        core.setForkSettlement(address(forkSettlement));
+        forkingDK.changeComposedUnits(forkSettlement, escrow);
+        escrow.setForkSettlement(address(forkSettlement));
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/foundry/Forking_Integration.t.sol
+++ b/contracts/test/foundry/Forking_Integration.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ForkingTestBase} from "./ForkingTestBase.sol";
+import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import {DisputeKitClassic} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title Forking_Integration_Test
+/// @notice End-to-end lifecycle (G-1, G-2, G-3): a General Court dispute exhausts its appeals, jumps into
+///         the forking court, runs a commit/reveal forking round, finalizes, settles, and exposes
+///         `currentRuling == a_main` while the freeze is engaged then released.
+/// @dev Fully RED until the Core forking guards, the DK voting logic, and settlement all land. This test
+///      is the executable acceptance criterion for the whole mechanism; it drives the dispute to the
+///      forking-court jump and asserts the post-jump state.
+/// forge-lint: disable-next-item(erc20-unchecked-transfer)
+contract Forking_Integration_Test is ForkingTestBase {
+    uint256 constant DISPUTE_ID = 0;
+
+    function setUp() public override {
+        super.setUp();
+        // Make the General Court jump to its parent (the forking court) after a single small round.
+        vm.prank(owner);
+        core.changeCourtParameters(
+            GENERAL_COURT,
+            hiddenVotes,
+            minStake,
+            alpha,
+            feeForJuror,
+            DEFAULT_NB_OF_JURORS, // jurorsForCourtJump low so one appeal triggers the parent jump
+            timesPerPeriod,
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+    }
+
+    /// @dev Drives a dispute through its first General Court round and into the appeal period.
+    function _toAppealPeriod() internal {
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 20000);
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing
+
+        core.draw(DISPUTE_ID, DEFAULT_NB_OF_JURORS);
+        vm.warp(block.timestamp + timesPerPeriod[uint256(KlerosCore.Period.evidence)]);
+        core.passPeriod(DISPUTE_ID); // Vote
+
+        uint256[] memory voteIDs = new uint256[](3);
+        voteIDs[0] = 0;
+        voteIDs[1] = 1;
+        voteIDs[2] = 2;
+        vm.prank(staker1);
+        disputeKit.castVote(DISPUTE_ID, voteIDs, 2, 0, "XYZ");
+
+        core.passPeriod(DISPUTE_ID); // Appeal
+    }
+
+    /// G-1/G-2: appealing the last General Court round jumps into the forking court, engages the freeze,
+    /// and opens a zero-vote forking round routed to the forking dispute kit.
+    function test_jumpIntoForkingCourt() public {
+        _toAppealPeriod();
+
+        // Funding the appeal must route the court jump to the forking court (DK is jumping to forking).
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(DISPUTE_ID, 1);
+
+        // Post-jump expectations (RED until the Core forking branch + freeze land).
+        (uint96 courtID, , , , ) = core.disputes(DISPUTE_ID);
+        assertEq(courtID, FORKING_COURT, "dispute must be in the forking court");
+        assertTrue(sortitionModule.stakingFrozen(), "freeze must be engaged on jump (G-2)");
+
+        KlerosCore.Round memory round = core.getRoundInfo(DISPUTE_ID, 1);
+        assertEq(round.nbVotes, 0, "forking round has no drawn jurors");
+        assertEq(round.disputeKitID, forkingDKID, "round must be routed to the forking DK");
+    }
+
+    /// G-1: no further appeal is possible once in the forking court.
+    function test_noAppealAfterForking() public {
+        _toAppealPeriod();
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(DISPUTE_ID, 1);
+
+        // appealCost out of the forking court must be NON_PAYABLE; appealing must revert.
+        vm.expectRevert(KlerosCore.AppealNotAllowed.selector);
+        core.appeal(DISPUTE_ID, 3, arbitratorExtraData);
+    }
+
+    /// G-3: after commit/reveal/finalize/settle, the ruling is the plurality winner and the freeze releases.
+    /// Documented as the full acceptance flow; RED until the entire mechanism is implemented.
+    function test_fullLifecycle() public {
+        _toAppealPeriod();
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(DISPUTE_ID, 1);
+
+        // The dispute must actually be in the forking court for the lifecycle to be meaningful (G-1).
+        (uint96 courtID, , , , ) = core.disputes(DISPUTE_ID);
+        assertEq(courtID, FORKING_COURT, "lifecycle requires the forking-court jump");
+        assertEq(core.getRoundInfo(DISPUTE_ID, 1).disputeKitID, forkingDKID, "round routed to forking DK");
+
+        // commit → reveal → finalize → settle would proceed here against `forkingDK` and `forkSettlement`.
+        // Acceptance assertions for the GREEN pass:
+        //   - currentRuling(DISPUTE_ID) == a_main (the stake-weighted plurality winner)
+        //   - each minority fork token's totalSupply == original PNK supply (INV-4)
+        //   - every joiner's stakedPnk == 0 (INV-5)
+        //   - sortitionModule.stakingFrozen() == false after settlement
+        //   - disputesWithoutJurors is not wedged by the zero-vote round
+        (uint256 ruling, , ) = core.currentRuling(DISPUTE_ID);
+        assertGt(ruling, 0, "currentRuling must resolve to a_main once the forking round settles");
+    }
+}

--- a/contracts/test/foundry/KlerosCore_ForkingCourt.t.sol
+++ b/contracts/test/foundry/KlerosCore_ForkingCourt.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ForkingTestBase} from "./ForkingTestBase.sol";
+import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title KlerosCore_ForkingCourt_Test
+/// @notice Tests the forking-court configuration and the Core-side forking hooks' access control.
+/// @dev Access-control and "cannot stake" assertions are GREEN; the forking-court parameter
+///      configuration (set in `initialize` during the implementation pass) and the hook bodies are RED.
+contract KlerosCore_ForkingCourt_Test is ForkingTestBase {
+    // Spec: commit/reveal periods for the forking court (see plan 1.4-5 / 1.5).
+    uint256 constant COMMIT = 120;
+    uint256 constant REVEAL = 180;
+
+    // --- Already-enforced behavior (GREEN) --- //
+
+    function test_cannotStakeDirectlyIntoForkingCourt() public {
+        vm.expectRevert(KlerosCore.StakingNotPossibleInThisCourt.selector);
+        vm.prank(staker1);
+        core.setStake(FORKING_COURT, 1000);
+    }
+
+    function test_forkingDKRegistered() public view {
+        assertGt(forkingDKID, DISPUTE_KIT_CLASSIC, "forking DK must be registered after classic");
+        assertEq(address(core.forkSettlement()), address(forkSettlement));
+    }
+
+    // --- Access control on the new Core hooks (GREEN) --- //
+
+    function test_captureStakeForForking_onlyByForkSettlement() public {
+        vm.expectRevert(KlerosCore.ForkSettlementOnly.selector);
+        vm.prank(other);
+        core.captureStakeForForking(staker1);
+    }
+
+    function test_distributeForking_onlyByForkSettlement() public {
+        vm.expectRevert(KlerosCore.ForkSettlementOnly.selector);
+        vm.prank(other);
+        core.distributeForking(staker1, 100);
+    }
+
+    function test_setForkSettlement_onlyByOwner() public {
+        vm.expectRevert(KlerosCore.OwnerOnly.selector);
+        vm.prank(other);
+        core.setForkSettlement(other);
+    }
+
+    // --- RED until implemented --- //
+
+    function test_captureStakeForForking_notImplemented() public {
+        vm.expectRevert(KlerosCore.NotImplemented.selector);
+        vm.prank(address(forkSettlement));
+        core.captureStakeForForking(staker1);
+    }
+
+    function test_distributeForking_notImplemented() public {
+        vm.expectRevert(KlerosCore.NotImplemented.selector);
+        vm.prank(address(forkSettlement));
+        core.distributeForking(staker1, 100);
+    }
+
+    /// RED: the forking court must be configured with commit/reveal periods in `initialize`.
+    /// Currently `getTimesPerPeriod(FORKING_COURT)` reverts (no court params) — this fails until the
+    /// implementation pass configures court 0.
+    function test_forkingCourtConfigured() public view {
+        uint256[4] memory times = core.getTimesPerPeriod(FORKING_COURT);
+        assertEq(times[uint256(KlerosCore.Period.commit)], COMMIT, "commit period");
+        assertEq(times[uint256(KlerosCore.Period.vote)], REVEAL, "reveal period");
+    }
+}

--- a/contracts/test/foundry/SortitionModule_Freeze.t.sol
+++ b/contracts/test/foundry/SortitionModule_Freeze.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
+import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
+import {SortitionModule} from "../../src/arbitration/SortitionModule.sol";
+import "../../src/libraries/Constants.sol";
+
+/// @title SortitionModule_Freeze_Test
+/// @notice Tests the stake freeze (G-2 / INV-1) and the capture-without-refund path (G-7).
+/// @dev RED until `freeze`/`unfreeze`/`captureUnstakeAllCourts` and the `_setStake` guard are implemented
+///      (they currently revert `NotImplemented()`). The assertions pin the spec's required behavior.
+/// forge-lint: disable-next-item(erc20-unchecked-transfer)
+contract SortitionModule_Freeze_Test is KlerosCore_TestBase {
+    uint256 constant STAKE = 1000;
+
+    function _stake(address who, uint256 amount) internal {
+        vm.prank(who);
+        core.setStake(GENERAL_COURT, amount);
+    }
+
+    function _freeze(uint256 disputeID) internal {
+        // The freeze is Core-only; tests drive it directly as if Core engaged it on a forking jump.
+        vm.prank(address(core));
+        sortitionModule.freeze(disputeID);
+    }
+
+    // INV-1: while frozen, staked-balance mutations revert.
+    function test_stakeMutationsRevertWhileFrozen() public {
+        _stake(staker1, STAKE);
+        _freeze(0);
+        assertTrue(sortitionModule.stakingFrozen(), "freeze flag must be set");
+
+        vm.expectRevert(SortitionModule.StakingFrozen.selector);
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, STAKE * 2); // increase blocked
+
+        vm.expectRevert(SortitionModule.StakingFrozen.selector);
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 0); // withdrawal blocked
+    }
+
+    // After unfreeze, mutations work again.
+    function test_unfreezeRestoresMutations() public {
+        _stake(staker1, STAKE);
+        _freeze(0);
+
+        vm.prank(address(core));
+        sortitionModule.unfreeze();
+        assertFalse(sortitionModule.stakingFrozen(), "freeze flag must be cleared");
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, STAKE * 2);
+        (uint256 total, , , ) = sortitionModule.getJurorBalance(staker1, GENERAL_COURT);
+        assertEq(total, STAKE * 2, "stake change must apply after unfreeze");
+    }
+
+    // Double-freeze and stray-unfreeze are rejected.
+    function test_freezeStateGuards() public {
+        _freeze(0);
+        vm.expectRevert(SortitionModule.AlreadyFrozen.selector);
+        vm.prank(address(core));
+        sortitionModule.freeze(0);
+
+        vm.prank(address(core));
+        sortitionModule.unfreeze();
+        vm.expectRevert(SortitionModule.NotFrozen.selector);
+        vm.prank(address(core));
+        sortitionModule.unfreeze();
+    }
+
+    // G-7: capture zeroes the joiner's stake but does NOT refund — PNK stays in Core's balance.
+    function test_captureUnstakeKeepsPNKInCore() public {
+        _stake(staker1, STAKE);
+        uint256 coreBalanceBefore = pinakion.balanceOf(address(core));
+        uint256 jurorBalanceBefore = pinakion.balanceOf(staker1);
+
+        _freeze(0);
+        vm.prank(address(core));
+        uint256 captured = sortitionModule.captureUnstakeAllCourts(staker1);
+
+        assertEq(captured, STAKE, "captured must equal former staked PNK");
+        (uint256 total, , , ) = sortitionModule.getJurorBalance(staker1, GENERAL_COURT);
+        assertEq(total, 0, "joiner stake must be zeroed (INV-5)");
+        assertEq(pinakion.balanceOf(staker1), jurorBalanceBefore, "joiner must NOT be refunded");
+        assertEq(pinakion.balanceOf(address(core)), coreBalanceBefore, "captured PNK stays in Core");
+    }
+
+    // Access control: only Core may freeze/unfreeze/capture.
+    function test_onlyCoreCanFreeze() public {
+        vm.expectRevert(SortitionModule.KlerosCoreOnly.selector);
+        vm.prank(other);
+        sortitionModule.freeze(0);
+
+        vm.expectRevert(SortitionModule.KlerosCoreOnly.selector);
+        vm.prank(other);
+        sortitionModule.captureUnstakeAllCourts(staker1);
+    }
+}


### PR DESCRIPTION
## What

Test-first scaffold for the **forking mechanism** (spec: `contracts/docs/layer-1-core/07-forking.md`, on `feat/forking-kit-specs`). Foundry suites encode the spec's guarantees / invariants / worked examples, and compile-ready contract skeletons let them run **red** until the implementation pass turns each suite green.

This deliberately ships **scaffolding, not finished logic** — skeleton bodies revert `NotImplemented()` or return inert defaults. The diff is small and the red/green line is clean.

## TDD state (current)

| Suite | State | Notes |
|---|---|---|
| `ForkToken.t.sol` | 🟢 green | `ForkToken` is fully implemented — the TDD sanity anchor |
| `DisputeKitForking.t.sol` | 🟢 green | the real inert `IDisputeKit` surface; voting stubs assert `NotImplemented` |
| `ForkSettlement.t.sol` | 🟢 green | wiring + access control + stub assertions |
| `ForkMath.t.sol` | 🔴 red | the two canonical worked examples (B fork=30, C fork=23) + edges |
| `SortitionModule_Freeze.t.sol` | 🔴 red | freeze / capture-without-refund (access control already green) |
| `KlerosCore_ForkingCourt.t.sol` | 🔴 red (1) | forking-court config (hooks' access control already green) |
| `Forking_Integration.t.sol` | 🔴 red | GC appeal exhaustion → forking-court jump → lifecycle |

Existing core suites (`KlerosCore_Staking/Initialization/Appeals`) still pass — changes to existing contracts are **additive only**.

## New contracts (skeletons)

- **`ForkMath`** — removal fixed point, one threshold-sorted list per losing option (`internal`-only; exercised via `ForkMathHarness`).
- **`DisputeKitForking`** — reworked `IDisputeKit` at the Core boundary. `createDispute`'s 3rd arg is `numberOfChoices` per the interface (the earlier draft misnamed it `finalRuling`).
- **`ForkSettlement`** — paginated `Capture → MainDistrib → Mint → Done` phase machine (separate contract per Q-007).
- **`ForkToken`** — fully-working mintable ERC-20, one per minority fork.
- **`PNKHolderEscrow`** — tier-2 participation path.
- **`ISlashDestination`** — isolates the slash-destination decision (Q-006).

## Additive changes to existing contracts

New surface only; **`appeal` / `execute` / `appealCost` / `initialize` behavior is untouched** (filled in the implementation pass):

- `SortitionModule`: `stakingFrozen` flag; `freeze` / `unfreeze` / `captureUnstakeAllCourts` (+ `ISortitionModule`).
- `KlerosCore`: `forkSettlement` storage + `setForkSettlement`; `captureStakeForForking` / `distributeForking` hooks (`onlyForkSettlement`); `ForkingRoundStarted` event; `AppealNotAllowed` / `NotForkingCourt` errors.
- `KlerosProxies`: `DisputeKitForkingProxy`.

## Implementation-pass map (what turns each red suite green)

1. `ForkMath` logic → `ForkMath.t.sol`.
2. `SortitionModule` freeze guard + `captureUnstakeAllCourts` → `SortitionModule_Freeze.t.sol`.
3. `KlerosCore` forking guards (`appeal`/`appealCost`/`_getCompatibleNextRoundSettings`/`execute`) + forking-court config in `initialize` → `KlerosCore_ForkingCourt.t.sol` + the jump in `Forking_Integration.t.sol`.
4. `DisputeKitForking` commit/reveal/finalize + `ForkSettlement` settle → integration lifecycle.

> ⚠️ Draft: several suites are intentionally red (they are the acceptance criteria for the follow-up implementation work). CI running `forge test` will report these failures by design.

> Note: the spec and `Q-016` (locked-PNK joiner baseline) live on `feat/forking-kit-specs`; the open-questions register entry will be added when those docs land on this branch.

https://claude.ai/code/session_01W7bRbuy6gnrpKX5VctbC9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7bRbuy6gnrpKX5VctbC9K)_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the implementation of a forking mechanism in the Kleros arbitration system, including new contracts for dispute handling, token minting, and stake management during forking rounds.

### Detailed summary
- Added `DisputeKitForkingProxy` and `DisputeTemplateRegistryProxy` contracts.
- Introduced `ISlashDestination` interface for handling slashed PNK.
- Enhanced `ISortitionModule` with `freeze` and `unfreeze` functions.
- Created `ForkToken` contract for minting tokens for minority forks.
- Implemented `ForkMath` library for handling voting mechanics.
- Developed `ForkSettlement` for managing the settlement process.
- Added `ForkMathHarness` for testing the `ForkMath` library.
- Established `SortitionModule` to manage stake freezing during forking.
- Created tests for various components, including `Forking_Integration_Test` and `SortitionModule_Freeze_Test`.

> The following files were skipped due to too many changes: `contracts/src/arbitration/dispute-kits/DisputeKitForking.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forking court support for disputes, enabling terminal forking rounds as an alternative resolution path.
  * Implemented stake freezing mechanism during forking periods to prevent staking mutations.
  * Added fork settlement process with staged phases for managing dispute outcomes.
  * Introduced fork tokens as ERC-20 assets for tracking forking outcomes.
  * Implemented PNK holder escrow voting for tier-2 participation in forking disputes.

* **Bug Fixes**
  * Disabled appeals after disputes enter forking court to prevent invalid appeal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->