### PR TITLE
feat(web): harden FileViewer against malicious file URLs

### DIFF
--- a/web/src/components/FileViewer/Viewers/MarkdownViewer.tsx
+++ b/web/src/components/FileViewer/Viewers/MarkdownViewer.tsx
@@ -9,16 +9,40 @@ const Container = styled.div`
   padding: 16px;
 `;
 
-const MarkdownDocRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
-  if (!currentDocument) return null;
-  const base64String = (currentDocument.fileData as string).split(",")[1];
+const decodeBase64Utf8 = (base64: string): string => {
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (char) => char.codePointAt(0) ?? 0);
+  return new TextDecoder("utf-8").decode(bytes);
+};
 
-  // Decode the base64 string
-  const decodedData = atob(base64String);
+const decodeFileData = (fileData: string | ArrayBuffer): string => {
+  if (fileData instanceof ArrayBuffer) {
+    return new TextDecoder("utf-8").decode(fileData);
+  }
+  if (!fileData.startsWith("data:")) {
+    return fileData;
+  }
+  // RFC 2397: `data:[<mediatype>][;base64],<payload>` — the payload is base64
+  // only when `;base64` is the last parameter before the comma; otherwise it's
+  // percent-encoded. Dispatching on the header (not on atob success) avoids
+  // mis-decoding payloads that happen to be valid base64 by coincidence.
+  const commaIdx = fileData.indexOf(",");
+  const header = commaIdx === -1 ? "" : fileData.slice("data:".length, commaIdx);
+  const payload = commaIdx === -1 ? "" : fileData.slice(commaIdx + 1);
+  const isBase64 = header.toLowerCase().endsWith(";base64");
+  try {
+    return isBase64 ? decodeBase64Utf8(payload) : decodeURIComponent(payload);
+  } catch {
+    return "";
+  }
+};
+
+const MarkdownDocRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
+  if (!currentDocument?.fileData) return null;
 
   return (
     <Container id="md-renderer">
-      <MarkdownRenderer content={decodedData} />
+      <MarkdownRenderer content={decodeFileData(currentDocument.fileData)} />
     </Container>
   );
 };

--- a/web/src/components/FileViewer/Viewers/SvgViewer.tsx
+++ b/web/src/components/FileViewer/Viewers/SvgViewer.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import styled from "styled-components";
+
+import { type DocRenderer } from "@cyntler/react-doc-viewer";
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Image = styled.img`
+  max-width: 100%;
+`;
+
+// Render SVG via `<img src>` rather than letting @cyntler/react-doc-viewer fall
+// back to its "open in new tab" link. `<img>`-loaded SVG runs in the W3C
+// "secure static" mode: scripts, event handlers, external `<image>`/`<use>`
+// references, CSS `url()`, and `<foreignObject>` are all disabled by the
+// browser (the same sandbox GitHub and Wikipedia use for user-uploaded SVGs).
+// Without this renderer, DocViewer has no SVG match and the fallback link
+// top-frame-navigates to the URL, executing any scripts in the SVG document.
+const SvgDocRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
+  if (!currentDocument?.uri) return null;
+  return (
+    <Container id="image-renderer">
+      <Image id="image-img" src={currentDocument.uri} alt={currentDocument.fileName ?? ""} />
+    </Container>
+  );
+};
+
+SvgDocRenderer.fileTypes = ["svg", "image/svg+xml"];
+SvgDocRenderer.weight = 1;
+
+export default SvgDocRenderer;

--- a/web/src/components/FileViewer/index.tsx
+++ b/web/src/components/FileViewer/index.tsx
@@ -1,12 +1,13 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 
-import DocViewer, { DocViewerRenderers } from "@cyntler/react-doc-viewer";
+import DocViewer, { DocViewerRenderers, type IConfig, type IDocument } from "@cyntler/react-doc-viewer";
 
 import "@cyntler/react-doc-viewer/dist/index.css";
 import { customScrollbar } from "styles/customScrollbar";
 
 import MarkdownRenderer from "./Viewers/MarkdownViewer";
+import SvgRenderer from "./Viewers/SvgViewer";
 
 const Wrapper = styled.div`
   background-color: ${({ theme }) => theme.whiteBackground};
@@ -30,32 +31,82 @@ const StyledDocViewer = styled(DocViewer)`
   }
 `;
 
+const Message = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px;
+  color: ${({ theme }) => theme.secondaryText};
+  font-size: 14px;
+
+  .url {
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+  }
+
+  a {
+    color: ${({ theme }) => theme.primaryBlue};
+    text-decoration: underline;
+  }
+`;
+
+const SAFE_URL_SCHEMES = new Set(["http:", "https:", "blob:", "data:"]);
+
+// `data:` URI MIMEs that execute script on top-frame navigation. Modern Chrome
+// and Firefox already block most of these via data:-navigation restrictions,
+// but coverage varies by version and type (XHTML and XML have historically
+// slipped through), so re-enforcing at the gate keeps the threat model
+// auditable. SVG is included because `<svg onload>` runs script when navigated
+// to (it does not when loaded via `<img src>`, which is how SvgViewer renders
+// it). XML/XHTML can execute script via xml-stylesheet processing instructions
+// or inline `<script>` once parsed as a document.
+const UNSAFE_DATA_MIMES = new Set([
+  "text/html",
+  "application/xhtml+xml",
+  "application/xml",
+  "text/xml",
+  "image/svg+xml",
+]);
+
 /**
- * @description this viewer supports loading multiple files, it can load urls, local files, etc
- * @param url The url of the file to be displayed
- * @returns renders the file
+ * Returns true if `raw` is a relative URL or uses an allowlisted scheme.
+ * Blocks `javascript:`, `vbscript:`, `file:`, `about:`, and anything else that
+ * could execute code or escape sandboxing when the underlying viewer (or its
+ * "open in new tab" fallback) navigates to it.
+ *
+ * `allowedDataMimes` is a consumer-supplied override for the default
+ * `UNSAFE_DATA_MIMES` blocklist — entries here pass even if blocklisted.
  */
-const FileViewer: React.FC<{ url: string }> = ({ url }) => {
-  const docs = [{ uri: url, fileName: fileNameIfIpfsUrl(url) }];
-  return (
-    <Wrapper className="file-viewer-wrapper">
-      <StyledDocViewer
-        documents={docs}
-        pluginRenderers={[...DocViewerRenderers, MarkdownRenderer]}
-        config={{
-          header: {
-            disableHeader: true,
-            disableFileName: true,
-          },
-          pdfZoom: {
-            defaultZoom: 0.8,
-            zoomJump: 0.1,
-          },
-          pdfVerticalScrollByDefault: true, // false as default
-        }}
-      />
-    </Wrapper>
-  );
+const isSafeUrl = (raw: string, allowedDataMimes: ReadonlySet<string>): boolean => {
+  if (typeof raw !== "string" || raw.length === 0) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // Relative URLs (e.g. "/foo", "./bar.pdf") throw — they resolve against the
+    // page origin and inherit its safety, so they're allowed.
+    return true;
+  }
+  const protocol = parsed.protocol.toLowerCase();
+  if (!SAFE_URL_SCHEMES.has(protocol)) return false;
+  if (protocol === "data:") {
+    const rawMime = parsed.pathname.split(/[,;]/)[0].trim().toLowerCase();
+    // Defense-in-depth: spec-compliant browsers do NOT percent-decode the
+    // data:-URL mediatype, so an encoded `text%2Fhtml` already fails MIME
+    // parsing and falls back to safe `text/plain`. We decode anyway to harden
+    // against legacy runtimes; reject if decoding throws so malformed inputs
+    // can't slip through.
+    let mime: string;
+    try {
+      mime = decodeURIComponent(rawMime);
+    } catch {
+      return false;
+    }
+    if (allowedDataMimes.has(mime)) return true;
+    if (UNSAFE_DATA_MIMES.has(mime)) return false;
+  }
+  return true;
 };
 
 const fileNameIfIpfsUrl = (url: string) => {
@@ -76,6 +127,68 @@ const fileNameIfIpfsUrl = (url: string) => {
   } else {
     return "document";
   }
+};
+
+const NoRendererFallback = ({ document, fileName }: { document: IDocument | undefined; fileName: string }) => (
+  <Message>
+    <p>This file type can&apos;t be previewed.</p>
+    <a href={document?.uri ?? ""} download={fileName} rel="noopener noreferrer" target="_blank">
+      Open in a new tab
+    </a>
+  </Message>
+);
+
+/**
+ * @description this viewer supports loading multiple files, it can load urls, local files, etc
+ * @param url The url of the file to be displayed
+ * @param allowedDataMimes Opt-in `data:` MIME types that bypass the script-execution gate (trusted sources only)
+ * @returns renders the file
+ *
+ * Security: rejects `javascript:`, `vbscript:`, `file:`, and other unlisted
+ * schemes up front so a hostile `url` can't deliver code execution through the
+ * underlying viewer or its fallback download link.
+ */
+const FileViewer: React.FC<{ url: string; allowedDataMimes?: readonly string[] }> = ({ url, allowedDataMimes }) => {
+  const allowedDataMimesSet = useMemo(
+    () => new Set((allowedDataMimes ?? []).map((m) => m.toLowerCase())),
+    [allowedDataMimes]
+  );
+  const safe = isSafeUrl(url, allowedDataMimesSet);
+
+  const fileName = fileNameIfIpfsUrl(url);
+  const docs = useMemo(() => [{ uri: url, fileName }], [url, fileName]);
+
+  const config: IConfig = {
+    header: {
+      disableHeader: true,
+      disableFileName: true,
+    },
+    pdfZoom: {
+      defaultZoom: 0.8,
+      zoomJump: 0.1,
+    },
+    pdfVerticalScrollByDefault: true, // false as default
+    noRenderer: {
+      overrideComponent: NoRendererFallback,
+    },
+  };
+
+  return (
+    <Wrapper className="file-viewer-wrapper">
+      {safe ? (
+        <StyledDocViewer
+          documents={docs}
+          pluginRenderers={[...DocViewerRenderers, MarkdownRenderer, SvgRenderer]}
+          config={config}
+        />
+      ) : (
+        <Message>
+          <p>Unable to display this file.</p>
+          <p className="url">{url}</p>
+        </Message>
+      )}
+    </Wrapper>
+  );
 };
 
 export default FileViewer;

--- a/web/src/components/FileViewer/index.tsx
+++ b/web/src/components/FileViewer/index.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import DocViewer, { DocViewerRenderers, type IConfig, type IDocument } from "@cyntler/react-doc-viewer";
 
 import "@cyntler/react-doc-viewer/dist/index.css";
+import { isValidUrl } from "utils/urlValidation";
+
 import { customScrollbar } from "styles/customScrollbar";
 
 import MarkdownRenderer from "./Viewers/MarkdownViewer";
@@ -51,35 +53,21 @@ const Message = styled.div`
   }
 `;
 
-const SAFE_URL_SCHEMES = new Set(["http:", "https:", "blob:", "data:"]);
-
-// `data:` URI MIMEs that execute script on top-frame navigation. Modern Chrome
-// and Firefox already block most of these via data:-navigation restrictions,
-// but coverage varies by version and type (XHTML and XML have historically
-// slipped through), so re-enforcing at the gate keeps the threat model
-// auditable. SVG is included because `<svg onload>` runs script when navigated
-// to (it does not when loaded via `<img src>`, which is how SvgViewer renders
-// it). XML/XHTML can execute script via xml-stylesheet processing instructions
-// or inline `<script>` once parsed as a document.
-const UNSAFE_DATA_MIMES = new Set([
-  "text/html",
-  "application/xhtml+xml",
-  "application/xml",
-  "text/xml",
-  "image/svg+xml",
-]);
+// Only http/https render. court v2 exclusively loads https IPFS attachments
+// (gated upstream by getAllowedAttachmentUrl in utils/urlValidation), so the
+// viewer stays strict: data:, blob:, file:, etc. are rejected until a real use
+// case requires them.
+const SAFE_URL_SCHEMES = new Set(["http:", "https:"]);
 
 /**
- * Returns true if `raw` is a relative URL or uses an allowlisted scheme.
- * Blocks `javascript:`, `vbscript:`, `file:`, `about:`, and anything else that
- * could execute code or escape sandboxing when the underlying viewer (or its
- * "open in new tab" fallback) navigates to it.
- *
- * `allowedDataMimes` is a consumer-supplied override for the default
- * `UNSAFE_DATA_MIMES` blocklist — entries here pass even if blocklisted.
+ * Returns true if `raw` is a relative URL, or an http/https URL that survives
+ * the shared sanitizer. `isValidUrl` (@braintree/sanitize-url) strips
+ * `javascript:`/`data:`/`vbscript:` plus control-character and HTML-entity
+ * obfuscation; the scheme allowlist additionally blocks `blob:`/`file:`/
+ * `about:` and custom schemes the sanitizer lets through.
  */
-const isSafeUrl = (raw: string, allowedDataMimes: ReadonlySet<string>): boolean => {
-  if (typeof raw !== "string" || raw.length === 0) return false;
+const isSafeUrl = (raw: string): boolean => {
+  if (!isValidUrl(raw)) return false;
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -88,25 +76,7 @@ const isSafeUrl = (raw: string, allowedDataMimes: ReadonlySet<string>): boolean 
     // page origin and inherit its safety, so they're allowed.
     return true;
   }
-  const protocol = parsed.protocol.toLowerCase();
-  if (!SAFE_URL_SCHEMES.has(protocol)) return false;
-  if (protocol === "data:") {
-    const rawMime = parsed.pathname.split(/[,;]/)[0].trim().toLowerCase();
-    // Defense-in-depth: spec-compliant browsers do NOT percent-decode the
-    // data:-URL mediatype, so an encoded `text%2Fhtml` already fails MIME
-    // parsing and falls back to safe `text/plain`. We decode anyway to harden
-    // against legacy runtimes; reject if decoding throws so malformed inputs
-    // can't slip through.
-    let mime: string;
-    try {
-      mime = decodeURIComponent(rawMime);
-    } catch {
-      return false;
-    }
-    if (allowedDataMimes.has(mime)) return true;
-    if (UNSAFE_DATA_MIMES.has(mime)) return false;
-  }
-  return true;
+  return SAFE_URL_SCHEMES.has(parsed.protocol.toLowerCase());
 };
 
 const fileNameIfIpfsUrl = (url: string) => {
@@ -132,28 +102,26 @@ const fileNameIfIpfsUrl = (url: string) => {
 const NoRendererFallback = ({ document, fileName }: { document: IDocument | undefined; fileName: string }) => (
   <Message>
     <p>This file type can&apos;t be previewed.</p>
-    <a href={document?.uri ?? ""} download={fileName} rel="noopener noreferrer" target="_blank">
-      Open in a new tab
-    </a>
+    {document?.uri ? (
+      <a href={document.uri} download={fileName} rel="noopener noreferrer" target="_blank">
+        Open in a new tab
+      </a>
+    ) : null}
   </Message>
 );
 
 /**
  * @description this viewer supports loading multiple files, it can load urls, local files, etc
  * @param url The url of the file to be displayed
- * @param allowedDataMimes Opt-in `data:` MIME types that bypass the script-execution gate (trusted sources only)
  * @returns renders the file
  *
- * Security: rejects `javascript:`, `vbscript:`, `file:`, and other unlisted
- * schemes up front so a hostile `url` can't deliver code execution through the
+ * Security: only http/https URLs that pass the shared sanitizer render;
+ * `data:`, `blob:`, `javascript:`, and other schemes show a fallback message
+ * instead, so a hostile `url` can't deliver code execution through the
  * underlying viewer or its fallback download link.
  */
-const FileViewer: React.FC<{ url: string; allowedDataMimes?: readonly string[] }> = ({ url, allowedDataMimes }) => {
-  const allowedDataMimesSet = useMemo(
-    () => new Set((allowedDataMimes ?? []).map((m) => m.toLowerCase())),
-    [allowedDataMimes]
-  );
-  const safe = isSafeUrl(url, allowedDataMimesSet);
+const FileViewer: React.FC<{ url: string }> = ({ url }) => {
+  const safe = isSafeUrl(url);
 
   const fileName = fileNameIfIpfsUrl(url);
   const docs = useMemo(() => [{ uri: url, fileName }], [url, fileName]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `FileViewer` component by adding support for rendering SVG files and improving base64 file data decoding in the `MarkdownViewer`. It introduces a new `SvgDocRenderer` and refines the logic for handling various file types securely.

### Detailed summary
- Added `SvgDocRenderer` for rendering SVG files using an `<img>` tag.
- Improved base64 decoding logic in `MarkdownDocRenderer` to handle both base64 and non-base64 encoded data.
- Introduced a `NoRendererFallback` component for unsupported file types.
- Updated `FileViewer` to utilize the new `SvgRenderer` and handle safe URL validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SVG file viewing support.
  * Improved URL safety checks by only allowing safe URL schemes and showing an error when a URL is unsafe.
  * Added an “Open in new tab” option when no renderer is available for a document type.

* **Bug Fixes**
  * Improved Markdown document handling by supporting additional file data formats and decoding both base64 and percent-encoded payloads; safely handles decode failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->