### PR TITLE
style(web): center language section and shrink disconnect button

### DIFF
--- a/web/src/components/LanguageSelector.tsx
+++ b/web/src/components/LanguageSelector.tsx
@@ -16,11 +16,13 @@ const Label = styled.label`
   font-size: 14px;
   font-weight: 600;
   color: ${({ theme }) => theme.primaryText};
+  text-align: center;
 `;
 
 const LanguageOptions = styled.div`
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 `;
 

--- a/web/src/layout/Header/navbar/Menu/Settings/General/index.tsx
+++ b/web/src/layout/Header/navbar/Menu/Settings/General/index.tsx
@@ -75,7 +75,7 @@ const LanguageSelectorContainer = styled.div`
 export const DisconnectWalletButton: React.FC = () => {
   const { t } = useTranslation();
   const { disconnect } = useDisconnect();
-  return <Button text={t("buttons.disconnect")} onClick={() => disconnect()} />;
+  return <Button small text={t("buttons.disconnect")} onClick={() => disconnect()} />;
 };
 
 const General: React.FC<ISettings> = ({ toggleIsSettingsOpen }) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the styling of the `LanguageSelector` component and modifying the `Button` in the `General` settings to be smaller.

### Detailed summary
- In `LanguageSelector.tsx`:
  - Added `text-align: center;` to the styled component.
  - Added `justify-content: center;` to the `LanguageOptions` styled component.
  
- In `index.tsx`:
  - Changed the `Button` to have a `small` prop for a smaller size.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced language selector component with improved layout including centered text alignment in labels and centered button arrangement for language options, providing better visual consistency and improved user interface organization.
  * Updated disconnect wallet button styling with refined component properties to enhance overall consistency across the account settings interface while maintaining the same functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->