### PR TITLE
feat: centralized DK

### DIFF
--- a/contracts/deploy/00-home-chain-arbitration-mainnet.ts
+++ b/contracts/deploy/00-home-chain-arbitration-mainnet.ts
@@ -90,11 +90,12 @@ const deployArbitration: DeployFunction = async (hre: HardhatRuntimeEnvironment)
       deployer,
       deployer,
       pnk.target,
-      ZeroAddress, // jurorProsecutionModule is not implemented yet
       disputeKit.address,
+      ZeroAddress, // Centralized kit
       false,
       [minStake, alpha, feeForJuror, jurorsForCourtJump],
       [0, 0, 0, 10], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
+      [0, 0, 0, 0], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
       ethers.toBeHex(5), // Extra data for sortition module will return the default value of K
       sortitionModule.address,
       weth.target,

--- a/contracts/deploy/00-home-chain-arbitration.ts
+++ b/contracts/deploy/00-home-chain-arbitration.ts
@@ -93,11 +93,12 @@ const deployArbitration: DeployFunction = async (hre: HardhatRuntimeEnvironment)
       deployer,
       deployer,
       pnk.target,
-      ZeroAddress, // KlerosCore is configured later
       disputeKit.address,
+      ZeroAddress, // Centralized dispute kit is configured later
       false,
       [minStake, alpha, feeForJuror, jurorsForCourtJump],
       [0, 0, 0, 10], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
+      [0, 0, 0, 0], // evidencePeriod, commitPeriod, votePeriod, appealPeriod
       ethers.toBeHex(5), // Extra data for sortition module will return the default value of K
       sortitionModule.address,
       weth.target,

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -103,7 +103,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     address payable public owner; // The owner of the contract.
     address public guardian; // The guardian able to pause asset withdrawals.
     IERC20 public pinakion; // The Pinakion token contract.
-    address public jurorProsecutionModule; // The module for juror's prosecution.
+    address public jurorProsecutionModule; // The module for juror's prosecution. TODO: remove
     ISortitionModule public sortitionModule; // Sortition module for drawing.
     Court[] public courts; // The courts.
     IDisputeKit[] public disputeKits; // Array of dispute kits.
@@ -308,11 +308,12 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _owner The owner's address.
     /// @param _guardian The guardian's address.
     /// @param _pinakion The address of the token contract.
-    /// @param _jurorProsecutionModule The address of the juror prosecution module.
     /// @param _disputeKit The address of the default dispute kit.
+    /// @param _forkingDisputeKit The address of the forking dispute kit.
     /// @param _hiddenVotes The `hiddenVotes` property value of the general court.
     /// @param _courtParameters Numeric parameters of General court (minStake, alpha, feeForJuror and jurorsForCourtJump respectively).
     /// @param _timesPerPeriod The `timesPerPeriod` property value of the general court.
+    /// @param _forkingTimesPerPeriod The `timesPerPeriod` property value of the forking court.
     /// @param _sortitionExtraData The extra data for sortition module.
     /// @param _sortitionModuleAddress The sortition module responsible for sortition of the jurors.
     /// @param _wNative The wrapped native token address, typically wETH.
@@ -322,11 +323,12 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         address payable _owner,
         address _guardian,
         IERC20 _pinakion,
-        address _jurorProsecutionModule,
         IDisputeKit _disputeKit,
+        IDisputeKit _forkingDisputeKit,
         bool _hiddenVotes,
         uint256[4] memory _courtParameters,
         uint256[4] memory _timesPerPeriod,
+        uint256[4] memory _forkingTimesPerPeriod,
         bytes memory _sortitionExtraData,
         ISortitionModule _sortitionModuleAddress,
         address _wNative,
@@ -336,14 +338,15 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         owner = _owner;
         guardian = _guardian;
         pinakion = _pinakion;
-        jurorProsecutionModule = _jurorProsecutionModule;
         sortitionModule = _sortitionModuleAddress;
         wNative = _wNative;
         jurorNft = _jurorNft;
         ratesConverter = _ratesConverter;
 
-        // NULL_DISPUTE_KIT: an empty element at index 0 to indicate when a dispute kit is not supported.
-        disputeKits.push();
+        // FORKING_DISPUTE_KIT.
+        disputeKits.push(_forkingDisputeKit);
+
+        emit DisputeKitCreated(FORKING_DISPUTE_KIT, _forkingDisputeKit);
 
         // DISPUTE_KIT_CLASSIC
         disputeKits.push(_disputeKit);
@@ -351,9 +354,35 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         emit DisputeKitCreated(DISPUTE_KIT_CLASSIC, _disputeKit);
 
         // FORKING_COURT
-        // TODO: Fill the properties for the Forking court, emit CourtCreated.
-        courts.push();
+        Court storage forkingCourt = courts.push();
+        forkingCourt.parent = FORKING_COURT;
+        forkingCourt.children = new uint256[](1);
+        forkingCourt.minStake = type(uint256).max;
+        forkingCourt.alpha = 0;
+        forkingCourt.feeForJuror = 0;
+        forkingCourt.children[0] = GENERAL_COURT;
+
+        forkingCourt.additionalCourtParamsChanges.push(
+            AdditionalCourtParams({hiddenVotes: false, jurorsForCourtJump: 0, timesPerPeriod: _forkingTimesPerPeriod})
+        );
+
         sortitionModule.createTree(FORKING_COURT, _sortitionExtraData);
+
+        uint256[] memory supportedDisputeKits = new uint256[](1);
+        supportedDisputeKits[0] = FORKING_DISPUTE_KIT;
+        emit CourtCreated(
+            FORKING_COURT,
+            FORKING_COURT,
+            false,
+            type(uint256).max,
+            0,
+            0,
+            0,
+            _forkingTimesPerPeriod,
+            supportedDisputeKits,
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+        _enableDisputeKit(FORKING_COURT, FORKING_DISPUTE_KIT, true);
 
         // GENERAL_COURT
         Court storage court = courts.push();
@@ -373,7 +402,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
 
         sortitionModule.createTree(GENERAL_COURT, _sortitionExtraData);
 
-        uint256[] memory supportedDisputeKits = new uint256[](1);
+        supportedDisputeKits = new uint256[](1);
         supportedDisputeKits[0] = DISPUTE_KIT_CLASSIC;
         emit CourtCreated(
             GENERAL_COURT,
@@ -507,16 +536,16 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         uint256[] memory _supportedDisputeKits,
         ICourtEligibility _eligibility
     ) external onlyByOwner {
+        require(_parent != FORKING_COURT, InvalidForkingCourtAsParent());
         require(courts[_parent].minStake <= _minStake, MinStakeLowerThanParentCourt());
         require(_supportedDisputeKits.length > 0, UnsupportedDisputeKit());
-        require(_parent != FORKING_COURT, InvalidForkingCourtAsParent());
 
         uint96 courtID = uint96(courts.length);
         Court storage court = courts.push();
 
         for (uint256 i = 0; i < _supportedDisputeKits.length; i++) {
             require(
-                _supportedDisputeKits[i] != NULL_DISPUTE_KIT && _supportedDisputeKits[i] < disputeKits.length,
+                _supportedDisputeKits[i] != FORKING_DISPUTE_KIT && _supportedDisputeKits[i] < disputeKits.length,
                 WrongDisputeKitIndex()
             );
             _enableDisputeKit(uint96(courtID), _supportedDisputeKits[i], true);
@@ -578,11 +607,17 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     ) external onlyByOwner {
         Court storage court = courts[_courtID];
         require(
-            _courtID == GENERAL_COURT || courts[court.parent].minStake <= _minStake,
+            _courtID == GENERAL_COURT || _courtID == FORKING_COURT || courts[court.parent].minStake <= _minStake,
             MinStakeLowerThanParentCourt()
         );
-        for (uint256 i = 0; i < court.children.length; i++) {
-            require(courts[court.children[i]].minStake >= _minStake, MinStakeHigherThanChildCourt(court.children[i]));
+        if (_courtID != FORKING_COURT) {
+            // Forking court requires max uint minStake so disable this check.
+            for (uint256 i = 0; i < court.children.length; i++) {
+                require(
+                    courts[court.children[i]].minStake >= _minStake,
+                    MinStakeHigherThanChildCourt(court.children[i])
+                );
+            }
         }
         court.minStake = _minStake;
         court.alpha = _alpha;
@@ -616,9 +651,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     function enableDisputeKits(uint96 _courtID, uint256[] memory _disputeKitIDs, bool _enable) external onlyByOwner {
         for (uint256 i = 0; i < _disputeKitIDs.length; i++) {
             require(
-                _disputeKitIDs[i] != NULL_DISPUTE_KIT && _disputeKitIDs[i] < disputeKits.length,
+                (_disputeKitIDs[i] != FORKING_DISPUTE_KIT || _courtID == FORKING_COURT) &&
+                    _disputeKitIDs[i] < disputeKits.length,
                 WrongDisputeKitIndex()
             );
+
             if (_enable) {
                 _enableDisputeKit(_courtID, _disputeKitIDs[i], true);
             } else {
@@ -877,7 +914,6 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         dispute.lastPeriodChange = block.timestamp;
 
         Court storage court = courts[newCourtID];
-        extraRound.nbVotes = msg.value / court.feeForJuror; // As many votes that can be afforded by the provided funds.
         extraRound.pnkAtStakePerJuror = (court.minStake * court.alpha) / ONE_BASIS_POINT;
         extraRound.totalFeesForJurors = msg.value;
         extraRound.disputeKitID = newDisputeKitID;
@@ -887,6 +923,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             // Set nbVotes to 0 since FC has no drawing.
             extraRound.nbVotes = 0;
         } else {
+            extraRound.nbVotes = msg.value / court.feeForJuror; // As many votes that can be afforded by the provided funds.
             // Only increase `disputesWithoutJurors` if nbVotes is non-zero.
             sortitionModule.createDisputeHook(_disputeID, extraRoundID);
         }
@@ -923,7 +960,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
 
         uint256 start = round.repartitions;
         uint256 end = round.repartitions + _iterations;
-
+        // TODO: centralized kit appeal fee distribution.
         uint256 pnkPenaltiesInRound = round.pnkPenalties; // Keep in memory to save gas.
         uint256 numberOfVotesInRound = round.drawnJurors.length;
         uint256 feePerJurorInRound = round.totalFeesForJurors / numberOfVotesInRound;
@@ -1186,10 +1223,13 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _disputeID The ID of the dispute.
     /// @return The appeal cost.
     function appealCost(uint256 _disputeID) public view returns (uint256) {
-        // TODO: make it compatible with Forking Court jump.
         Dispute storage dispute = disputes[_disputeID];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
         Court storage court = courts[dispute.courtID];
+
+        if (dispute.courtID == FORKING_COURT) {
+            return NON_PAYABLE_AMOUNT; // Can't jump from the forking court.
+        }
         (uint96 newCourtID, , uint256 nbVotesAfterAppeal) = _getCompatibleNextRoundSettings(
             dispute,
             round,
@@ -1200,11 +1240,11 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             // No court jump
             return court.feeForJuror * nbVotesAfterAppeal;
         }
-        if (dispute.courtID != GENERAL_COURT && newCourtID != FORKING_COURT) {
-            // Court jump but not to the Forking court
-            return courts[newCourtID].feeForJuror * nbVotesAfterAppeal;
+        if (newCourtID == FORKING_COURT) {
+            // Forking court has 0 feeForJuror and 0 nbVotes so use parameters of the previous court.
+            return court.feeForJuror * ((round.nbVotes * 2) + 1);
         }
-        return NON_PAYABLE_AMOUNT; // Jumping to the Forking Court is not supported yet.
+        return courts[newCourtID].feeForJuror * nbVotesAfterAppeal;
     }
 
     /// @notice Gets the start and the end of a specified dispute's current appeal period.
@@ -1400,16 +1440,15 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             disputeKitID,
             _round.nbVotes
         );
-        if (
-            newCourtID == FORKING_COURT ||
-            newCourtID >= courts.length ||
-            newDisputeKitID == NULL_DISPUTE_KIT ||
-            newDisputeKitID >= disputeKits.length ||
-            newRoundNbVotes == 0
-        ) {
-            // Falling back to the current court and dispute kit with default nbVotes increase.
+        // Falling back to the current court and dispute kit with default nbVotes increase.
+        if (newCourtID >= courts.length) {
             newCourtID = _dispute.courtID;
+        }
+        if (newDisputeKitID >= disputeKits.length) {
             newDisputeKitID = disputeKitID;
+        }
+        // Forking court has 0 votes.
+        if (newRoundNbVotes == 0 && newCourtID != FORKING_COURT) {
             newRoundNbVotes = (_round.nbVotes * 2) + 1;
         }
         // Ensure compatibility between the next round's court and dispute kit.
@@ -1530,7 +1569,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
             if (minJurors == 0) {
                 minJurors = DEFAULT_NB_OF_JURORS;
             }
-            if (disputeKitID == NULL_DISPUTE_KIT || disputeKitID >= disputeKits.length) {
+            if (disputeKitID == FORKING_DISPUTE_KIT || disputeKitID >= disputeKits.length) {
                 disputeKitID = DISPUTE_KIT_CLASSIC;
             }
         } else {

--- a/contracts/src/arbitration/KlerosCore.sol
+++ b/contracts/src/arbitration/KlerosCore.sol
@@ -883,7 +883,13 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         extraRound.disputeKitID = newDisputeKitID;
         extraRound.courtParamsIndex = court.additionalCourtParamsChanges.length - 1;
 
-        sortitionModule.createDisputeHook(_disputeID, extraRoundID);
+        if (newCourtID == FORKING_COURT) {
+            // Set nbVotes to 0 since FC has no drawing.
+            extraRound.nbVotes = 0;
+        } else {
+            // Only increase `disputesWithoutJurors` if nbVotes is non-zero.
+            sortitionModule.createDisputeHook(_disputeID, extraRoundID);
+        }
 
         // Dispute kit was changed, so create a dispute in the new DK contract.
         if (extraRound.disputeKitID != round.disputeKitID) {
@@ -994,6 +1000,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
         }
 
         // Unlock all the PNKs for this draw.
+        // Note: if drawnJurors is 0 it will revert (eg. in centralized kit).
         address account = round.drawnJurors[_params.repartition];
         sortitionModule.unlockStake(account, round.pnkAtStakePerJuror);
 
@@ -1179,6 +1186,7 @@ contract KlerosCore is IArbitratorV2, Initializable, UUPSProxiable {
     /// @param _disputeID The ID of the dispute.
     /// @return The appeal cost.
     function appealCost(uint256 _disputeID) public view returns (uint256) {
+        // TODO: make it compatible with Forking Court jump.
         Dispute storage dispute = disputes[_disputeID];
         Round storage round = dispute.rounds[dispute.rounds.length - 1];
         Court storage court = courts[dispute.courtID];

--- a/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
+++ b/contracts/src/arbitration/devtools/KlerosCoreRuler.sol
@@ -670,7 +670,7 @@ contract KlerosCoreRuler is IArbitratorV2, UUPSProxiable, Initializable {
             if (minJurors == 0) {
                 minJurors = DEFAULT_NB_OF_JURORS;
             }
-            if (disputeKitID == NULL_DISPUTE_KIT) {
+            if (disputeKitID == FORKING_DISPUTE_KIT) {
                 disputeKitID = DISPUTE_KIT_CLASSIC; // 0 index is not used.
             }
         } else {

--- a/contracts/src/arbitration/dispute-kits/CentralizedKit.sol
+++ b/contracts/src/arbitration/dispute-kits/CentralizedKit.sol
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+import {KlerosCore} from "../KlerosCore.sol";
+import {IDisputeKit} from "../interfaces/IDisputeKit.sol";
+import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
+import {Initializable} from "../../proxy/Initializable.sol";
+
+/// @title CentralizedKit
+contract CentralizedKit is IDisputeKit, Initializable {
+    // ************************************* //
+    // *             Structs               * //
+    // ************************************* //
+
+    struct Dispute {
+        uint256 ruling; // The ruling given by the ruler.
+        bool ruled; // Whether the dispute was ruled or not.
+        uint256 coreDisputeID; // Corresponding core dispute ID.
+        uint256 numberOfChoices; // The number of choices jurors have when voting. This does not include choice `0` which is reserved for "refuse to arbitrate".
+        uint256[10] __gap; // Reserved slots for future upgrades.
+    }
+
+    // ************************************* //
+    // *             Storage               * //
+    // ************************************* //
+
+    address public owner; // The owner of the contract.
+    address public ruler; // The address to give a centralized ruling.
+    KlerosCore public core; // The Kleros Core arbitrator.
+    Dispute[] public disputes; // Array of the locally created disputes.
+    mapping(uint256 coreDisputeID => uint256 localDisputeID) public coreDisputeIDToLocal; // Maps the dispute ID in Kleros Core to the local dispute ID.
+
+    uint256[50] private __gap; // Reserved slots for future upgrades.
+
+    // ************************************* //
+    // *              Events               * //
+    // ************************************* //
+
+    /// @notice To be emitted when a dispute is created.
+    /// @param _coreDisputeID The identifier of the dispute in the Arbitrator contract.
+    /// @param _numberOfChoices The number of choices available in the dispute.
+    /// @param _extraData The extra data for the dispute.
+    event DisputeCreation(uint256 indexed _coreDisputeID, uint256 _numberOfChoices, bytes _extraData);
+
+    event RulingGiven(uint256 indexed _coreDisputeID, uint256 _ruling);
+
+    // ************************************* //
+    // *              Modifiers            * //
+    // ************************************* //
+
+    modifier onlyByOwner() {
+        require(owner == msg.sender, OwnerOnly());
+        _;
+    }
+
+    modifier onlyByCore() {
+        require(address(core) == msg.sender, KlerosCoreOnly());
+        _;
+    }
+
+    // ************************************* //
+    // *            Constructor            * //
+    // ************************************* //
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializer.
+    /// @param _owner The owner's address.
+    /// @param _core The KlerosCore arbitrator.
+    /// @param _ruler The ruler.
+    function initialize(address _owner, KlerosCore _core, address _ruler) external initializer {
+        owner = _owner;
+        core = _core;
+        ruler = _ruler;
+    }
+
+    // ************************ //
+    // *      Governance      * //
+    // ************************ //
+
+    /// @notice Changes the `owner` storage variable.
+    /// @param _owner The new value for the `owner` storage variable.
+    function changeOwner(address payable _owner) external onlyByOwner {
+        owner = _owner;
+    }
+
+    /// @notice Changes the `core` storage variable.
+    /// @param _core The new value for the `core` storage variable.
+    function changeCore(address _core) external onlyByOwner {
+        core = KlerosCore(_core);
+    }
+
+    /// @notice Changes the `ruler` storage variable.
+    /// @param _ruler The new value for the `ruler` storage variable.
+    function changeRuler(address _ruler) external onlyByOwner {
+        ruler = _ruler;
+    }
+
+    // ************************************* //
+    // *         State Modifiers           * //
+    // ************************************* //
+
+    /// @notice Creates a local dispute and maps it to the dispute ID in the Core contract.
+    /// @dev Access restricted to Kleros Core only.
+    /// @dev The new `KlerosCore.Round` must be created before calling this function.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _numberOfChoices Number of choices of the dispute
+    /// @param _extraData Additional info about the dispute, for possible use in future dispute kits.
+    /// @param - nbVotes Maximal number of votes this dispute can get. Added for future-proofing.
+    function createDispute(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _numberOfChoices,
+        bytes calldata _extraData,
+        uint256 /*_nbVotes*/
+    ) public override onlyByCore {
+        coreDisputeIDToLocal[_coreDisputeID] = disputes.length;
+
+        Dispute storage dispute = disputes.push();
+        dispute.numberOfChoices = _numberOfChoices;
+        dispute.coreDisputeID = _coreDisputeID;
+
+        emit DisputeCreation(_coreDisputeID, _numberOfChoices, _extraData);
+    }
+
+    /// @notice Gives a ruling to a dispute.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _ruling The given ruling.
+    function giveRuling(uint256 _coreDisputeID, uint256 _ruling) external {
+        require(ruler == msg.sender, RulerOnly());
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        require(dispute.coreDisputeID == _coreDisputeID, DisputeUnknownInThisDisputeKit()); // Extra check for 0 id fallback.
+
+        require(_ruling <= dispute.numberOfChoices, RulingOutOfBounds());
+        require(!dispute.ruled, RulingAlreadyGiven());
+
+        dispute.ruled = true;
+        dispute.ruling = _ruling;
+
+        emit RulingGiven(_coreDisputeID, _ruling);
+    }
+
+    /// @notice Draws the juror from the sortition tree. The drawn address is picked up by Kleros Core. Not used by this contract.
+    /// @dev Access restricted to Kleros Core only.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _nonce Nonce.
+    /// @param - The number of votes in the round (unused, required by interface).
+    /// @return drawnAddress The drawn address.
+    /// @return fromSubcourtID The subcourt ID from which the juror was drawn.
+    function draw(
+        uint256 _coreDisputeID,
+        uint256 _nonce,
+        uint256 /*_roundNbVotes*/
+    ) public override onlyByCore returns (address drawnAddress, uint96 fromSubcourtID) {
+        revert UnsupportedOperation();
+    }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
+
+    /// @notice Gets the current ruling of a specified dispute.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return ruling The current ruling.
+    /// @return tied Whether it's a tie or not.
+    /// @return overridden Whether the ruling was overridden by appeal funding or not.
+    function currentRuling(
+        uint256 _coreDisputeID
+    ) external view override returns (uint256 ruling, bool tied, bool overridden) {
+        Dispute storage dispute = disputes[coreDisputeIDToLocal[_coreDisputeID]];
+        require(dispute.coreDisputeID == _coreDisputeID, DisputeUnknownInThisDisputeKit()); // Extra check for 0 id fallback.
+        require(dispute.ruled, RulingNotGiven());
+        ruling = dispute.ruling;
+    }
+
+    /// @notice Gets the degree of coherence of a particular voter. Not used by this contract.
+    /// @dev This function is called by Kleros Core in order to determine the amount of the reward.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the vote.
+    /// @param - feePerJuror The fee per juror. Unused, required by interface.
+    /// @param - pnkAtStakePerJuror The PNK at stake per juror. Unused, required by interface.
+    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    /// @return feeCoherence The degree of coherence in basis points for the dispute fee reward.
+    function getDegreeOfCoherenceReward(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
+    ) external view override returns (uint256 pnkCoherence, uint256 feeCoherence) {
+        return (0, 0);
+    }
+
+    /// @notice Gets the degree of coherence of a particular voter. Not used by this contract.
+    /// @dev This function is called by Kleros Core in order to determine the amount of the penalty.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the vote.
+    /// @param - feePerJuror The fee per juror. Unused, required by interface.
+    /// @param - pnkAtStakePerJuror The PNK at stake per juror. Unused, required by interface.
+    /// @return pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    function getDegreeOfCoherencePenalty(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID,
+        uint256 /* _feePerJuror */,
+        uint256 /* _pnkAtStakePerJuror */
+    ) external view override returns (uint256 pnkCoherence) {
+        return 0;
+    }
+
+    /// @notice Gets the number of jurors who are eligible to a reward in this round. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @return The number of coherent jurors.
+    function getCoherentCount(uint256 _coreDisputeID, uint256 _coreRoundID) external view override returns (uint256) {
+        return 0;
+    }
+
+    /// @notice Gets the rewards for PNK and fees based on coherence and total reward pool. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param - voteID The ID of the vote. Unused, required by interface.
+    /// @param _coherentCount The number of jurors eligible for reward.
+    /// @param _pnkRewardPool Total amount of PNK available for rewards to all coherent jurors.
+    /// @param _pnkCoherence The degree of coherence in basis points for the dispute PNK reward.
+    /// @param _feeCoherence The degree of coherence in basis points for the dispute fee reward.
+    /// @return pnkReward The pnk reward the juror is eligible to.
+    /// @return feeReward The fee reward the juror is eligible to.
+    function getRewards(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 /*_voteID*/,
+        uint256 _coherentCount,
+        uint256 _pnkRewardPool,
+        uint256 _pnkCoherence,
+        uint256 _feeCoherence
+    ) external view virtual override returns (uint256 pnkReward, uint256 feeReward) {
+        return (0, 0);
+    }
+
+    /// @notice Returns true if all of the jurors have cast their commits for the last round. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether all of the jurors have cast their commits for the last round.
+    function areCommitsAllCast(uint256 _coreDisputeID) external view override returns (bool) {
+        return false;
+    }
+
+    /// @notice Returns true if all of the jurors have cast their votes for the last round. Not used by this contract.
+    /// @dev This function is to be called directly by the core contract and is not for off-chain usage.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether all of the jurors have cast their votes for the last round.
+    function areVotesAllCast(uint256 _coreDisputeID) external view override returns (bool) {
+        return false;
+    }
+
+    /// @notice Returns true if the appeal funding is finished prematurely (e.g. when losing side didn't fund). Not used by this contract.
+    /// @dev This function is to be called directly by the core contract and is not for off-chain usage.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @return Whether the appeal funding is finished.
+    function isAppealFunded(uint256 _coreDisputeID) external view override returns (bool) {
+        return false;
+    }
+
+    /// @notice Returns the next round settings for a given dispute. Not used by this contract.
+    /// @dev This function does not check for compatibility between `newDisputeKitID` and `newCourtID`, this is the Core's responsibility.
+    /// @param - coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit. Unused, required by interface.
+    /// @param _currentCourtID The ID of the current court.
+    /// @param _parentCourtID The ID of the parent court.
+    /// @param _currentCourtJurorsForJump The court jump threshold defined by the current court.
+    /// @param _currentDisputeKitID The ID of the current dispute kit.
+    /// @param _currentRoundNbVotes The number of votes in the current round.
+    /// @return newCourtID Court ID after jump.
+    /// @return newDisputeKitID Dispute kit ID after jump.
+    /// @return newRoundNbVotes The number of votes in the new round.
+    function getNextRoundSettings(
+        uint256 /* _coreDisputeID */,
+        uint96 _currentCourtID,
+        uint96 _parentCourtID,
+        uint256 _currentCourtJurorsForJump,
+        uint256 _currentDisputeKitID,
+        uint256 _currentRoundNbVotes
+    ) public view virtual override returns (uint96 newCourtID, uint256 newDisputeKitID, uint256 newRoundNbVotes) {
+        revert UnsupportedOperation();
+    }
+
+    /// @notice Returns true if the specified voter was active in this round. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _voteID The ID of the voter.
+    /// @return Whether the voter was active or not.
+    function isVoteActive(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID
+    ) external view override returns (bool) {
+        return false;
+    }
+
+    /// @notice Returns the info of the specified round in the core contract. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core, not in the Dispute Kit.
+    /// @param _coreRoundID The ID of the round in Kleros Core, not in the Dispute Kit.
+    /// @param _choice The choice to query.
+    /// @return winningChoice The winning choice of this round.
+    /// @return tied Whether it's a tie or not.
+    /// @return totalVoted Number of jurors who cast the vote already.
+    /// @return totalCommitted Number of jurors who cast the commit already (only relevant for hidden votes).
+    /// @return nbVoters Total number of voters in this round.
+    /// @return choiceCount Number of votes cast for the queried choice.
+    function getRoundInfo(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _choice
+    )
+        external
+        view
+        override
+        returns (
+            uint256 winningChoice,
+            bool tied,
+            uint256 totalVoted,
+            uint256 totalCommitted,
+            uint256 nbVoters,
+            uint256 choiceCount
+        )
+    {
+        revert UnsupportedOperation();
+    }
+
+    /// @notice Returns the vote information for a given vote ID. Not used by this contract.
+    /// @param _coreDisputeID The ID of the dispute in Kleros Core.
+    /// @param _coreRoundID The ID of the round in Kleros Core.
+    /// @param _voteID The ID of the vote.
+    /// @return account The address of the juror who cast the vote.
+    /// @return commit The commit of the vote.
+    /// @return choice The choice that got the vote.
+    /// @return voted Whether the vote was cast or not.
+    function getVoteInfo(
+        uint256 _coreDisputeID,
+        uint256 _coreRoundID,
+        uint256 _voteID
+    ) external view override returns (address account, bytes32 commit, uint256 choice, bool voted) {
+        return (address(0), bytes32(0), 0, false);
+    }
+
+    // ************************************* //
+    // *              Errors               * //
+    // ************************************* //
+
+    error OwnerOnly();
+    error KlerosCoreOnly();
+    error RulerOnly();
+    error UnsupportedOperation();
+    error DisputeUnknownInThisDisputeKit();
+    error RulingOutOfBounds();
+    error RulingAlreadyGiven();
+    error RulingNotGiven();
+}

--- a/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
+++ b/contracts/src/arbitration/dispute-kits/DisputeKitClassic.sol
@@ -8,7 +8,7 @@ import {ISortitionModule} from "../interfaces/ISortitionModule.sol";
 import {Initializable} from "../../proxy/Initializable.sol";
 import {UUPSProxiable} from "../../proxy/UUPSProxiable.sol";
 import {SafeSend} from "../../libraries/SafeSend.sol";
-import {ONE_BASIS_POINT} from "../../libraries/Constants.sol";
+import {ONE_BASIS_POINT, FORKING_COURT, FORKING_DISPUTE_KIT} from "../../libraries/Constants.sol";
 
 /// @title DisputeKitClassic
 /// @notice Dispute kit implementation of the Kleros v1 features including:
@@ -739,6 +739,11 @@ contract DisputeKitClassic is IDisputeKit, Initializable, UUPSProxiable {
         if (newCourtID == 0) {
             // Default court jump logic, unaffected by the newRoundNbVotes override
             newCourtID = _currentRoundNbVotes >= _currentCourtJurorsForJump ? _parentCourtID : _currentCourtID;
+        }
+
+        // Temporary special case for the Forking Court.
+        if (newCourtID == FORKING_COURT) {
+            return (FORKING_COURT, FORKING_DISPUTE_KIT, 0);
         }
         if (newDisputeKitID == 0) {
             // jumpDisputeKitID is undefined for next round

--- a/contracts/src/libraries/Constants.sol
+++ b/contracts/src/libraries/Constants.sol
@@ -10,8 +10,8 @@ uint96 constant FORKING_COURT = 0; // Index of the forking court.
 uint96 constant GENERAL_COURT = 1; // Index of the default (general) court.
 
 // Dispute Kits
-uint256 constant NULL_DISPUTE_KIT = 0; // Null pattern to indicate a top-level DK which has no parent.
-uint256 constant DISPUTE_KIT_CLASSIC = 1; // Index of the default DK. 0 index is skipped.
+uint256 constant FORKING_DISPUTE_KIT = 0; // Index of the forking DK.
+uint256 constant DISPUTE_KIT_CLASSIC = 1; // Index of the default DK.
 
 // Sortition Module
 uint256 constant MAX_STAKE_PATHS = 4; // The maximum number of stake paths a juror can have.

--- a/contracts/test/arbitration/index.ts
+++ b/contracts/test/arbitration/index.ts
@@ -9,6 +9,7 @@ import {
   DisputeKitClassicUniversity,
 } from "../../typechain-types";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { zeroAddress } from "viem";
 
 describe("DisputeKitClassic", async () => {
   let deployer: HardhatEthersSigner;
@@ -27,55 +28,72 @@ describe("DisputeKitClassic", async () => {
 
   it("Kleros Core initialization", async () => {
     const events = await core.queryFilter(core.filters.DisputeKitCreated());
-    expect(events.length).to.equal(5);
-    expect(events[0].args._disputeKitID).to.equal(1);
-    expect(events[0].args._disputeKitAddress).to.equal(disputeKit.target);
-    expect(events[1].args._disputeKitID).to.equal(2);
-    expect(events[1].args._disputeKitAddress).to.equal(disputeKitShutter.target);
-    expect(events[2].args._disputeKitID).to.equal(3);
-    expect(events[2].args._disputeKitAddress).to.equal(disputeKitGated.target);
-    expect(events[3].args._disputeKitID).to.equal(4);
-    expect(events[3].args._disputeKitAddress).to.equal(disputeKitGatedShutter.target);
-    expect(events[4].args._disputeKitID).to.equal(5);
-    expect(events[4].args._disputeKitAddress).to.equal(disputeKitClassicUniversity.target);
+    expect(events.length).to.equal(6);
+    expect(events[0].args._disputeKitID).to.equal(0);
+    expect(events[0].args._disputeKitAddress).to.equal(zeroAddress);
+    expect(events[1].args._disputeKitID).to.equal(1);
+    expect(events[1].args._disputeKitAddress).to.equal(disputeKit.target);
+    expect(events[2].args._disputeKitID).to.equal(2);
+    expect(events[2].args._disputeKitAddress).to.equal(disputeKitShutter.target);
+    expect(events[3].args._disputeKitID).to.equal(3);
+    expect(events[3].args._disputeKitAddress).to.equal(disputeKitGated.target);
+    expect(events[4].args._disputeKitID).to.equal(4);
+    expect(events[4].args._disputeKitAddress).to.equal(disputeKitGatedShutter.target);
+    expect(events[5].args._disputeKitID).to.equal(5);
+    expect(events[5].args._disputeKitAddress).to.equal(disputeKitClassicUniversity.target);
 
     // Reminder: the Forking court will be added which will break these expectations.
     const events2 = await core.queryFilter(core.filters.CourtCreated());
-    expect(events2.length).to.equal(1);
-    expect(events2[0].args._courtID).to.equal(1);
+    expect(events2.length).to.equal(2);
+    expect(events2[0].args._courtID).to.equal(0);
     expect(events2[0].args._parent).to.equal(0);
     expect(events2[0].args._hiddenVotes).to.equal(false);
-    expect(events2[0].args._minStake).to.equal(ethers.parseUnits("200", 18));
-    expect(events2[0].args._alpha).to.equal(10000);
-    expect(events2[0].args._feeForJuror).to.equal(ethers.parseUnits("0.1", 18));
-    expect(events2[0].args._jurorsForCourtJump).to.equal(256);
-    expect(events2[0].args._timesPerPeriod).to.deep.equal([0, 0, 0, 10]);
-    expect(events2[0].args._supportedDisputeKits).to.deep.equal([1]);
+    expect(events2[0].args._minStake).to.equal(ethers.MaxUint256);
+    expect(events2[0].args._alpha).to.equal(0);
+    expect(events2[0].args._feeForJuror).to.equal(0);
+    expect(events2[0].args._jurorsForCourtJump).to.equal(0);
+    expect(events2[0].args._timesPerPeriod).to.deep.equal([0, 0, 0, 0]);
+    expect(events2[0].args._supportedDisputeKits).to.deep.equal([0]);
+
+    expect(events2[1].args._courtID).to.equal(1);
+    expect(events2[1].args._parent).to.equal(0);
+    expect(events2[1].args._hiddenVotes).to.equal(false);
+    expect(events2[1].args._minStake).to.equal(ethers.parseUnits("200", 18));
+    expect(events2[1].args._alpha).to.equal(10000);
+    expect(events2[1].args._feeForJuror).to.equal(ethers.parseUnits("0.1", 18));
+    expect(events2[1].args._jurorsForCourtJump).to.equal(256);
+    expect(events2[1].args._timesPerPeriod).to.deep.equal([0, 0, 0, 10]);
+    expect(events2[1].args._supportedDisputeKits).to.deep.equal([1]);
 
     const events3 = await core.queryFilter(core.filters.DisputeKitEnabled());
-    expect(events3.length).to.equal(5);
+    expect(events3.length).to.equal(6);
 
-    const classicDisputeKit = events3[0].args;
+    const centralizedKit = events3[0].args;
+    expect(centralizedKit._courtID).to.equal(0);
+    expect(centralizedKit._disputeKitID).to.equal(0);
+    expect(centralizedKit._enable).to.equal(true);
+
+    const classicDisputeKit = events3[1].args;
     expect(classicDisputeKit._courtID).to.equal(1);
     expect(classicDisputeKit._disputeKitID).to.equal(1);
     expect(classicDisputeKit._enable).to.equal(true);
 
-    const shutterDisputeKit = events3[1].args;
+    const shutterDisputeKit = events3[2].args;
     expect(shutterDisputeKit._courtID).to.equal(1);
     expect(shutterDisputeKit._disputeKitID).to.equal(2);
     expect(shutterDisputeKit._enable).to.equal(true);
 
-    const gatedDisputeKit = events3[2].args;
+    const gatedDisputeKit = events3[3].args;
     expect(gatedDisputeKit._courtID).to.equal(1);
     expect(gatedDisputeKit._disputeKitID).to.equal(3);
     expect(gatedDisputeKit._enable).to.equal(true);
 
-    const gatedShutterDisputeKit = events3[3].args;
+    const gatedShutterDisputeKit = events3[4].args;
     expect(gatedShutterDisputeKit._courtID).to.equal(1);
     expect(gatedShutterDisputeKit._disputeKitID).to.equal(4);
     expect(gatedShutterDisputeKit._enable).to.equal(true);
 
-    const classicUniversityDisputeKit = events3[4].args;
+    const classicUniversityDisputeKit = events3[5].args;
     expect(classicUniversityDisputeKit._courtID).to.equal(1);
     expect(classicUniversityDisputeKit._disputeKitID).to.equal(5);
     expect(classicUniversityDisputeKit._enable).to.equal(true);

--- a/contracts/test/foundry/KlerosCore_Appeals.t.sol
+++ b/contracts/test/foundry/KlerosCore_Appeals.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore} from "../../src/arbitration/KlerosCore.sol";
 import {DisputeKitClassic} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import {CentralizedKit} from "../../src/arbitration/dispute-kits/CentralizedKit.sol";
 import {DisputeKitClassicMockUncheckedNextRoundSettings} from "../../src/test/DisputeKitClassicMockUncheckedNextRoundSettings.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
 import "../../src/libraries/Constants.sol";
@@ -26,6 +27,7 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
         vm.warp(block.timestamp + minStakingTime);
         sortitionModule.passPhase(); // Generating
         vm.warp(block.timestamp + rngLookahead);
+
         sortitionModule.passPhase(); // Drawing phase
 
         core.draw(disputeID, DEFAULT_NB_OF_JURORS);
@@ -502,6 +504,280 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
 
         (address account, , , ) = disputeKit2.getVoteInfo(disputeID, 1, 0);
         assertEq(account, staker1, "Wrong drawn account in the classic DK");
+    }
+
+    /// @dev Test court jump and dispute kit jump to Forking court.
+    function test_appeal_fullFundingCourtJumpAndDKJumpToForkingCourt() public {
+        // Create a dispute so the index is not 0.
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        assertEq(sortitionModule.disputesWithoutJurors(), 1, "Wrong disputesWithoutJurors count");
+
+        uint256 disputeID = 1;
+
+        vm.prank(owner); // lower jurors for jump so we can jump in the next round. Leave the rest untouched.
+        core.changeCourtParameters(
+            GENERAL_COURT,
+            false, // Hidden votes
+            1000, // min stake
+            10000, // alpha
+            0.03 ether, // fee for juror
+            3, // jurors for jump
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 20000);
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing phase
+
+        core.draw(disputeID, DEFAULT_NB_OF_JURORS);
+        vm.warp(block.timestamp + timesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+
+        uint256[] memory voteIDs = new uint256[](3);
+        voteIDs[0] = 0;
+        voteIDs[1] = 1;
+        voteIDs[2] = 2;
+
+        vm.prank(staker1);
+        disputeKit.castVote(disputeID, voteIDs, 2, 0, "XYZ");
+
+        core.passPeriod(disputeID); // Appeal
+
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(disputeID, 1);
+
+        (, , , , bool isDisputeKitJumping) = core.getCourtAndDisputeKitJumps(disputeID);
+        assertEq(isDisputeKitJumping, true, "Should be jumping");
+
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.CourtJump(disputeID, 1, GENERAL_COURT, FORKING_COURT);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.DisputeKitJump(disputeID, 1, DISPUTE_KIT_CLASSIC, FORKING_DISPUTE_KIT);
+        vm.expectEmit(true, true, true, true);
+        emit CentralizedKit.DisputeCreation(disputeID, 2, arbitratorExtraData);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.AppealDecision(disputeID, arbitrable);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.NewPeriod(disputeID, KlerosCore.Period.evidence);
+        vm.prank(crowdfunder2);
+        disputeKit.fundAppeal{value: 0.42 ether}(disputeID, 2);
+
+        KlerosCore.Round memory round = core.getRoundInfo(disputeID, 1);
+        assertEq(round.disputeKitID, FORKING_DISPUTE_KIT, "Wrong DK ID");
+        assertEq(round.pnkAtStakePerJuror, 0, "Wrong pnkAtStakePerJuror");
+        assertEq(round.totalFeesForJurors, 0.21 ether, "Wrong totalFeesForJurors");
+        assertEq(round.nbVotes, 0, "Wrong nbVotes");
+
+        // We dont increment dispute counter for Forking court.
+        assertEq(sortitionModule.disputesWithoutJurors(), 1, "Wrong disputesWithoutJurors count");
+        (uint96 courtID, , , , ) = core.disputes(disputeID);
+
+        assertEq(courtID, FORKING_COURT, "Wrong court ID");
+
+        (uint256 ruling, bool ruled, uint256 coreDisputeID, uint256 numberOfChoices) = centralizedKit.disputes(0);
+        assertEq(ruling, 0, "Ruling should be empty");
+        assertEq(ruled, false, "Not ruled yet");
+        assertEq(coreDisputeID, 1, "Wrong core dispute ID");
+        assertEq(numberOfChoices, 2, "Wrong numberOfChoices");
+
+        assertEq(centralizedKit.coreDisputeIDToLocal(1), 0, "Wrong local disputeID");
+
+        vm.expectRevert(CentralizedKit.KlerosCoreOnly.selector);
+        vm.prank(disputer);
+        centralizedKit.createDispute(disputeID, 1, 2, arbitratorExtraData, 0);
+    }
+
+    function test_appeal_centralizedKitRuling() public {
+        // Create a dispute so the index is not 0.
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+
+        uint256 disputeID = 1;
+
+        vm.prank(owner); // lower jurors for jump so we can jump in the next round. Leave the rest untouched.
+        core.changeCourtParameters(
+            GENERAL_COURT,
+            false, // Hidden votes
+            1000, // min stake
+            10000, // alpha
+            0.03 ether, // fee for juror
+            3, // jurors for jump
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 20000);
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing phase
+
+        core.draw(disputeID, DEFAULT_NB_OF_JURORS);
+        vm.warp(block.timestamp + timesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+
+        uint256[] memory voteIDs = new uint256[](3);
+        voteIDs[0] = 0;
+        voteIDs[1] = 1;
+        voteIDs[2] = 2;
+
+        vm.prank(staker1);
+        disputeKit.castVote(disputeID, voteIDs, 2, 0, "XYZ");
+
+        core.passPeriod(disputeID); // Appeal
+
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(disputeID, 1);
+
+        (, , , , bool isDisputeKitJumping) = core.getCourtAndDisputeKitJumps(disputeID);
+        assertEq(isDisputeKitJumping, true, "Should be jumping");
+
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.CourtJump(disputeID, 1, GENERAL_COURT, FORKING_COURT);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.DisputeKitJump(disputeID, 1, DISPUTE_KIT_CLASSIC, FORKING_DISPUTE_KIT);
+        vm.expectEmit(true, true, true, true);
+        emit CentralizedKit.DisputeCreation(disputeID, 2, arbitratorExtraData);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.AppealDecision(disputeID, arbitrable);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.NewPeriod(disputeID, KlerosCore.Period.evidence);
+        vm.prank(crowdfunder2);
+        disputeKit.fundAppeal{value: 0.42 ether}(disputeID, 2);
+
+        // Check that no drawing
+        core.draw(disputeID, 10);
+        KlerosCore.Round memory round = core.getRoundInfo(disputeID, 1);
+        assertEq(round.drawnJurors.length, 0, "Should have 0 drawn jurors");
+
+        vm.expectRevert(CentralizedKit.UnsupportedOperation.selector);
+        vm.prank(address(core));
+        centralizedKit.draw(disputeID, 1, 7); // CoreDisputeID, nonce, nbVotes
+
+        vm.expectRevert(CentralizedKit.RulerOnly.selector);
+        vm.prank(other);
+        centralizedKit.giveRuling(disputeID, 1);
+
+        vm.expectRevert(CentralizedKit.DisputeUnknownInThisDisputeKit.selector);
+        vm.prank(ruler);
+        centralizedKit.giveRuling(0, 1);
+
+        vm.expectRevert(CentralizedKit.RulingOutOfBounds.selector);
+        vm.prank(ruler);
+        centralizedKit.giveRuling(disputeID, 3);
+
+        vm.expectRevert(CentralizedKit.DisputeUnknownInThisDisputeKit.selector);
+        centralizedKit.currentRuling(0);
+        vm.expectRevert(CentralizedKit.RulingNotGiven.selector);
+        centralizedKit.currentRuling(disputeID);
+
+        vm.expectEmit(true, true, true, true);
+        emit CentralizedKit.RulingGiven(disputeID, 1);
+        vm.prank(ruler);
+        centralizedKit.giveRuling(disputeID, 1);
+
+        vm.expectRevert(CentralizedKit.RulingAlreadyGiven.selector);
+        vm.prank(ruler);
+        centralizedKit.giveRuling(disputeID, 1);
+
+        (uint256 ruling, bool ruled, , ) = centralizedKit.disputes(0);
+        assertEq(ruling, 1, "Incorrect ruling");
+        assertEq(ruled, true, "Should be ruled");
+
+        (uint256 currentRuling, bool tied, bool overridden) = centralizedKit.currentRuling(disputeID);
+        assertEq(currentRuling, 1, "Incorrect ruling");
+        assertEq(tied, false, "Not tied");
+        assertEq(overridden, false, "Not overridden");
+
+        (currentRuling, , ) = core.currentRuling(disputeID);
+        assertEq(currentRuling, 1, "Incorrect ruling");
+    }
+
+    function test_appeal_centralizedKitRuling_execution() public {
+        uint256 disputeID = 0;
+
+        vm.prank(owner); // lower jurors for jump so we can jump in the next round. Leave the rest untouched.
+        core.changeCourtParameters(
+            GENERAL_COURT,
+            false, // Hidden votes
+            1000, // min stake
+            10000, // alpha
+            0.03 ether, // fee for juror
+            3, // jurors for jump
+            [uint256(60), uint256(120), uint256(180), uint256(240)], // Times per period
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+
+        vm.prank(staker1);
+        core.setStake(GENERAL_COURT, 20000);
+        vm.prank(disputer);
+        arbitrable.createDispute{value: feeForJuror * DEFAULT_NB_OF_JURORS}("Action");
+        vm.warp(block.timestamp + minStakingTime);
+        sortitionModule.passPhase(); // Generating
+        vm.warp(block.timestamp + rngLookahead);
+        sortitionModule.passPhase(); // Drawing phase
+
+        core.draw(disputeID, DEFAULT_NB_OF_JURORS);
+        vm.warp(block.timestamp + timesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+
+        uint256[] memory voteIDs = new uint256[](3);
+        voteIDs[0] = 0;
+        voteIDs[1] = 1;
+        voteIDs[2] = 2;
+
+        vm.prank(staker1);
+        disputeKit.castVote(disputeID, voteIDs, 2, 0, "XYZ");
+
+        core.passPeriod(disputeID); // Appeal
+
+        vm.prank(crowdfunder1);
+        disputeKit.fundAppeal{value: 0.63 ether}(disputeID, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.CourtJump(disputeID, 1, GENERAL_COURT, FORKING_COURT);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.DisputeKitJump(disputeID, 1, DISPUTE_KIT_CLASSIC, FORKING_DISPUTE_KIT);
+        vm.expectEmit(true, true, true, true);
+        emit CentralizedKit.DisputeCreation(disputeID, 2, arbitratorExtraData);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.AppealDecision(disputeID, arbitrable);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.NewPeriod(disputeID, KlerosCore.Period.evidence);
+        vm.prank(crowdfunder2);
+        disputeKit.fundAppeal{value: 0.42 ether}(disputeID, 2);
+
+        vm.warp(block.timestamp + forkingTimesPerPeriod[0]);
+        core.passPeriod(disputeID); // Vote
+        vm.warp(block.timestamp + forkingTimesPerPeriod[2]);
+        core.passPeriod(disputeID); // Appeal
+
+        assertEq(core.appealCost(disputeID), (2 ** 256 - 2) / 2, "Should be non payable amount");
+
+        vm.prank(ruler);
+        centralizedKit.giveRuling(disputeID, 2);
+
+        vm.warp(block.timestamp + forkingTimesPerPeriod[3]);
+        core.passPeriod(disputeID); // Execution
+
+        // Check 0 round
+        core.execute(disputeID, 0, 6);
+        KlerosCore.Round memory round = core.getRoundInfo(disputeID, 0);
+        assertEq(round.sumFeeRewardPaid, 0.09 ether, "Wrong sumFeeRewardPaid");
+
+        // Should panic revert in the forking round.
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x12));
+        core.execute(disputeID, 1, 1);
     }
 
     /// @dev Test dispute jumping between the same dispute kits multiple times across different rounds.
@@ -1880,12 +2156,11 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
         assertEq(account, staker1, "Should have drawn juror in DisputeKit2");
     }
 
-    /// @dev Test that invalid jumpDisputeKitID triggers complete fallback of ALL THREE parameters
+    /// @dev Test that invalid jumpDisputeKitID triggers the fallback
     /// Tests KlerosCore._getCompatibleNextRoundSettings() Scenario 1:
-    /// if jumpDisputeKitID >= disputeKits.length, then ALL parameters (court, DK, nbVotes)
-    /// fallback to current settings, even if other params are valid/custom.
+    /// if jumpDisputeKitID >= disputeKits.length, then DK falls back to current settings.
     /// Verifies safety check: newDisputeKitID >= disputeKits.length
-    function test_appeal_invalidDisputeKitIDCompleteTripleFallback() public {
+    function test_appeal_invalidDisputeKitIDFallback() public {
         uint256 disputeID = 0;
         uint96 court2ID = 2;
         uint96 court3ID = 3;
@@ -1958,6 +2233,9 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
         vm.prank(staker1);
         core.setStake(court2ID, 20000);
 
+        vm.prank(staker1);
+        core.setStake(court3ID, 20000);
+
         // Create dispute in Court2 with DisputeKit2
         bytes memory extraData = abi.encodePacked(uint256(court2ID), DEFAULT_NB_OF_JURORS, dkID2);
         arbitrable.changeArbitratorExtraData(extraData);
@@ -1982,9 +2260,7 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
 
         core.passPeriod(disputeID); // Appeal
 
-        // CRITICAL TEST: Verify COMPLETE TRIPLE FALLBACK
-        // Despite jumpCourtID being valid (Court3) and nbVotes being custom (11),
-        // the invalid jumpDisputeKitID should cause ALL THREE to fallback
+        // CRITICAL TEST: Verify the FALLBACK
         (
             uint96 nextCourtID,
             uint256 nextDisputeKitID,
@@ -1993,19 +2269,19 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             bool isDisputeKitJumping
         ) = core.getCourtAndDisputeKitJumps(disputeID);
 
-        assertEq(nextCourtID, court2ID, "Court should fallback to current (Court2), not jump to Court3");
+        assertEq(nextCourtID, court3ID, "Court should be Court3");
         assertEq(nextDisputeKitID, dkID2, "DK should fallback to current (DK2)");
-        assertEq(nextNbVotes, 7, "nbVotes should fallback to default (7), not custom (11)");
-        assertEq(isCourtJumping, false, "Should NOT be court jumping");
+        assertEq(nextNbVotes, 11, "nbVotes should be custom (11)");
+        assertEq(isCourtJumping, true, "Should be court jumping");
         assertEq(isDisputeKitJumping, false, "Should NOT be DK jumping");
 
-        // Verify appealCost uses Court2's fee (not Court3's), with default nbVotes (not custom)
-        uint256 expectedCost = 0.05 ether * 7; // Court2's fee × 7
-        assertEq(core.appealCost(disputeID), expectedCost, "appealCost should use Court2's fee with default nbVotes");
+        // Verify appealCost uses Court3's fee with custom nbVotes
+        uint256 expectedCost = 0.07 ether * 11; // Court3's fee × 7
+        assertEq(core.appealCost(disputeID), expectedCost, "appealCost should use Court3's fee with custom nbVotes");
 
         // Fund and execute appeal
         vm.prank(crowdfunder1);
-        disputeKit2.fundAppeal{value: 1.05 ether}(disputeID, 1);
+        disputeKit2.fundAppeal{value: 2.31 ether}(disputeID, 1);
 
         // NO CourtJump or DisputeKitJump events should be emitted
         vm.expectEmit(true, true, true, true);
@@ -2013,20 +2289,20 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.NewPeriod(disputeID, KlerosCore.Period.evidence);
         vm.prank(crowdfunder2);
-        disputeKit2.fundAppeal{value: 0.7 ether}(disputeID, 2);
+        disputeKit2.fundAppeal{value: 1.54 ether}(disputeID, 2);
 
         // Verify dispute stayed in Court2 with DK2 and default nbVotes
         (uint96 courtID, , , , ) = core.disputes(disputeID);
-        assertEq(courtID, court2ID, "Dispute should still be in Court2");
+        assertEq(courtID, court3ID, "Dispute should be in Court3");
 
         KlerosCore.Round memory round = core.getRoundInfo(disputeID, 1);
         assertEq(round.disputeKitID, dkID2, "Should still use DK2");
-        assertEq(round.nbVotes, 7, "Should use default nbVotes (7), not custom (11)");
+        assertEq(round.nbVotes, 11, "Should use custom (11)");
 
         // Verify we can draw jurors in the same court and DK
-        core.draw(disputeID, 7);
+        core.draw(disputeID, 15);
         round = core.getRoundInfo(disputeID, 1);
-        assertEq(round.drawnJurors.length, 7, "Should have drawn 7 jurors");
+        assertEq(round.drawnJurors.length, 11, "Should have drawn 11 jurors");
     }
 
     /// @dev Test that incompatible DK with target court falls back to DISPUTE_KIT_CLASSIC
@@ -2210,6 +2486,7 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
     /// sanity check: if newCourtID == FORKING_COURT, trigger complete fallback.
     /// Verifies complete triple fallback of all three parameters (court, DK, nbVotes).
     function test_appeal_forkingCourtTriggersKlerosCoreFallback() public {
+        vm.skip(true); // Forking court can be jumped at.
         uint256 disputeID = 0;
         uint96 court2ID = 2;
         uint256 mockDKID = 2;
@@ -2342,6 +2619,7 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
     /// if newDisputeKitID == NULL_DISPUTE_KIT, trigger complete fallback.
     /// Verifies complete triple fallback of all three parameters.
     function test_appeal_nullDisputeKitTriggersKlerosCoreFallback() public {
+        vm.skip(true); // Forking DK can be jumped at.
         uint256 disputeID = 0;
         uint96 court2ID = 2;
         uint96 court3ID = 3;
@@ -2403,7 +2681,7 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             DisputeKitClassic.NextRoundSettings({
                 enabled: true,
                 jumpCourtID: court3ID, // Valid court (non-zero)
-                jumpDisputeKitID: NULL_DISPUTE_KIT, // 0 - will be passed raw to KlerosCore
+                jumpDisputeKitID: FORKING_DISPUTE_KIT, // 0 - will be passed raw to KlerosCore
                 jumpDisputeKitIDOnCourtJump: 0,
                 nbVotes: customNbVotes // Custom nbVotes (non-zero)
             })
@@ -2583,30 +2861,30 @@ contract KlerosCore_AppealsTest is KlerosCore_TestBase {
             bool isDisputeKitJumping
         ) = core.getCourtAndDisputeKitJumps(disputeID);
 
-        assertEq(nextCourtID, court2ID, "Court should fallback to current (Court2), not Court3");
+        assertEq(nextCourtID, court3ID, "Court should jump to Court3");
         assertEq(nextDisputeKitID, mockDKID, "DK should fallback to current (mockDK)");
         assertEq(nextNbVotes, 7, "nbVotes should fallback to default (7)");
-        assertEq(isCourtJumping, false, "Should NOT be court jumping");
+        assertEq(isCourtJumping, true, "Should be court jumping");
         assertEq(isDisputeKitJumping, false, "Should NOT be DK jumping");
 
-        // Verify appealCost uses Court2's fee
-        uint256 expectedCost = 0.05 ether * 7;
+        // Verify appealCost uses Court3's fee
+        uint256 expectedCost = 0.08 ether * 7;
         assertEq(core.appealCost(disputeID), expectedCost, "appealCost should use Court2 fee");
 
         // Fund and execute appeal
         vm.prank(crowdfunder1);
-        mockDK.fundAppeal{value: 1.05 ether}(disputeID, 1);
+        mockDK.fundAppeal{value: 1.68 ether}(disputeID, 1);
 
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.AppealDecision(disputeID, arbitrable);
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.NewPeriod(disputeID, KlerosCore.Period.evidence);
         vm.prank(crowdfunder2);
-        mockDK.fundAppeal{value: 0.7 ether}(disputeID, 2);
+        mockDK.fundAppeal{value: 1.12 ether}(disputeID, 2);
 
         // Verify complete fallback
         (uint96 courtID, , , , ) = core.disputes(disputeID);
-        assertEq(courtID, court2ID, "Should still be in Court2");
+        assertEq(courtID, court3ID, "Should be in Court3");
 
         KlerosCore.Round memory round = core.getRoundInfo(disputeID, 1);
         assertEq(round.disputeKitID, mockDKID, "Should still use mockDK");

--- a/contracts/test/foundry/KlerosCore_Governance.t.sol
+++ b/contracts/test/foundry/KlerosCore_Governance.t.sol
@@ -441,7 +441,7 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
         );
 
         uint256[] memory badSupportedDK = new uint256[](2);
-        badSupportedDK[0] = NULL_DISPUTE_KIT; // Include NULL_DK to check that it reverts
+        badSupportedDK[0] = FORKING_DISPUTE_KIT; // Include FORKING_DISPUTE_KIT to check that it reverts
         badSupportedDK[1] = DISPUTE_KIT_CLASSIC;
         vm.expectRevert(KlerosCore.WrongDisputeKitIndex.selector);
         vm.prank(owner);
@@ -627,6 +627,34 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
         _assertTimesPerPeriod(GENERAL_COURT, [uint256(10), uint256(20), uint256(30), uint256(40)]);
     }
 
+    function test_changeCourtParameters_ForkingCourt() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.CourtModified(
+            FORKING_COURT,
+            true,
+            2000,
+            20000,
+            0.04 ether,
+            50,
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Explicitly convert otherwise it throws
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+        core.changeCourtParameters(
+            FORKING_COURT,
+            true, // Hidden votes
+            2000, // min stake
+            20000, // alpha
+            0.04 ether, // fee for juror
+            50, // jurors for jump
+            [uint256(10), uint256(20), uint256(30), uint256(40)], // Times per period
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+
+        _assertCourtParameters(FORKING_COURT, FORKING_COURT, true, 2000, 20000, 0.04 ether, 50, 2);
+        _assertTimesPerPeriod(FORKING_COURT, [uint256(10), uint256(20), uint256(30), uint256(40)]);
+    }
+
     function test_enableDisputeKits() public {
         DisputeKitSybilResistant newDK = new DisputeKitSybilResistant();
         uint256 newDkID = 2;
@@ -641,7 +669,7 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
 
         vm.expectRevert(KlerosCore.WrongDisputeKitIndex.selector);
         vm.prank(owner);
-        supportedDK[0] = NULL_DISPUTE_KIT;
+        supportedDK[0] = FORKING_DISPUTE_KIT;
         core.enableDisputeKits(GENERAL_COURT, supportedDK, true);
 
         vm.expectRevert(KlerosCore.WrongDisputeKitIndex.selector);
@@ -733,5 +761,12 @@ contract KlerosCore_GovernanceTest is KlerosCore_TestBase {
         assertEq(courtID, GENERAL_COURT, "Wrong courtID"); // Value in extra data is out of scope so fall back
         assertEq(minJurors, 41, "Wrong minJurors");
         assertEq(disputeKitID, 6, "Wrong disputeKitID");
+
+        // Forking court, forking DK.
+        extraData = abi.encodePacked(uint256(FORKING_COURT), DEFAULT_NB_OF_JURORS, FORKING_DISPUTE_KIT);
+        (courtID, minJurors, disputeKitID) = core.extraDataToCourtIDMinJurorsDisputeKit(extraData);
+        assertEq(courtID, GENERAL_COURT, "Wrong courtID"); // fallback
+        assertEq(minJurors, DEFAULT_NB_OF_JURORS, "Wrong minJurors");
+        assertEq(disputeKitID, DISPUTE_KIT_CLASSIC, "Wrong disputeKitID"); // fallback
     }
 }

--- a/contracts/test/foundry/KlerosCore_Initialization.t.sol
+++ b/contracts/test/foundry/KlerosCore_Initialization.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {KlerosCore_TestBase} from "./KlerosCore_TestBase.sol";
 import {KlerosCore, IERC721} from "../../src/arbitration/KlerosCore.sol";
 import {KlerosCoreMock} from "../../src/test/KlerosCoreMock.sol";
-import {DisputeKitClassic} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import {DisputeKitClassic, IDisputeKit} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
 import {SortitionModuleMock} from "../../src/test/SortitionModuleMock.sol";
 import {UUPSProxy} from "../../src/proxy/UUPSProxy.sol";
 import {BlockHashRNG} from "../../src/rng/BlockHashRNG.sol";
@@ -21,30 +21,44 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
         assertEq(core.owner(), msg.sender, "Wrong owner");
         assertEq(core.guardian(), guardian, "Wrong guardian");
         assertEq(address(core.pinakion()), address(pinakion), "Wrong pinakion address");
-        assertEq(core.jurorProsecutionModule(), jurorProsecutionModule, "Wrong jurorProsecutionModule address");
         assertEq(address(core.sortitionModule()), address(sortitionModule), "Wrong sortitionModule address");
         assertEq(core.getDisputeKitsLength(), 2, "Wrong DK array length");
 
-        _assertCourtParameters(FORKING_COURT, FORKING_COURT, false, 0, 0, 0, 0, 0);
+        _assertCourtParameters(FORKING_COURT, FORKING_COURT, false, type(uint256).max, 0, 0, 0, 0);
         _assertCourtParameters(GENERAL_COURT, FORKING_COURT, false, 1000, 10000, 0.03 ether, 511, 1);
 
         uint256[] memory children = core.getCourtChildren(GENERAL_COURT);
         assertEq(children.length, 0, "No children");
+        children = core.getCourtChildren(FORKING_COURT);
+        assertEq(children.length, 1, "Wrong number of children");
         _assertTimesPerPeriod(GENERAL_COURT, timesPerPeriod);
+        _assertTimesPerPeriod(FORKING_COURT, forkingTimesPerPeriod);
 
-        assertEq(address(core.disputeKits(NULL_DISPUTE_KIT)), address(0), "Wrong address NULL_DISPUTE_KIT");
+        assertEq(
+            address(core.disputeKits(FORKING_DISPUTE_KIT)),
+            address(centralizedKit),
+            "Wrong address FORKING_DISPUTE_KIT"
+        );
         assertEq(
             address(core.disputeKits(DISPUTE_KIT_CLASSIC)),
             address(disputeKit),
             "Wrong address DISPUTE_KIT_CLASSIC"
         );
-        assertEq(core.isSupported(FORKING_COURT, NULL_DISPUTE_KIT), false, "Forking court null dk should be false");
+        assertEq(
+            core.isSupported(FORKING_COURT, FORKING_DISPUTE_KIT),
+            true,
+            "Forking court FORKING_DISPUTE_KIT should be true"
+        );
         assertEq(
             core.isSupported(FORKING_COURT, DISPUTE_KIT_CLASSIC),
             false,
             "Forking court classic dk should be false"
         );
-        assertEq(core.isSupported(GENERAL_COURT, NULL_DISPUTE_KIT), false, "General court null dk should be false");
+        assertEq(
+            core.isSupported(GENERAL_COURT, FORKING_DISPUTE_KIT),
+            false,
+            "General court FORKING_DISPUTE_KIT should be false"
+        );
         assertEq(core.isSupported(GENERAL_COURT, DISPUTE_KIT_CLASSIC), true, "General court classic dk should be true");
         assertEq(core.paused(), false, "Wrong paused value");
         assertEq(core.wNative(), address(wNative), "Wrong wNative");
@@ -60,6 +74,10 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
         assertEq(pinakion.allowance(staker1, address(core)), 1 ether, "Wrong allowance for staker1");
         assertEq(pinakion.balanceOf(staker2), 1 ether, "Wrong token balance of staker2");
         assertEq(pinakion.allowance(staker2, address(core)), 1 ether, "Wrong allowance for staker2");
+
+        assertEq(centralizedKit.owner(), msg.sender, "Wrong CentralDK owner");
+        assertEq(address(centralizedKit.core()), address(core), "Wrong core in centralDK");
+        assertEq(centralizedKit.ruler(), ruler, "Wrong ruler in centralDK");
 
         assertEq(disputeKit.owner(), msg.sender, "Wrong DK owner");
         assertEq(address(disputeKit.core()), address(core), "Wrong core in DK");
@@ -97,7 +115,6 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
         address newOwner = msg.sender;
         address newGuardian = vm.addr(1);
         address newStaker1 = vm.addr(2);
-        address newJurorProsecutionModule = vm.addr(8);
         uint256 newMinStake = 1000;
         uint256 newAlpha = 10000;
         uint256 newFeeForJuror = 0.03 ether;
@@ -147,10 +164,30 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
 
         KlerosCoreMock newCore = KlerosCoreMock(address(proxyCore));
         vm.expectEmit(true, true, true, true);
+        emit KlerosCore.DisputeKitCreated(FORKING_DISPUTE_KIT, centralizedKit);
+        vm.expectEmit(true, true, true, true);
         emit KlerosCore.DisputeKitCreated(DISPUTE_KIT_CLASSIC, newDisputeKit);
         vm.expectEmit(true, true, true, true);
 
         uint256[] memory supportedDK = new uint256[](1);
+        supportedDK[0] = FORKING_DISPUTE_KIT;
+        emit KlerosCore.CourtCreated(
+            FORKING_COURT,
+            FORKING_COURT,
+            false,
+            type(uint256).max,
+            0,
+            0,
+            0,
+            [uint256(0), uint256(0), uint256(0), uint256(0)], // Explicitly convert otherwise it throws
+            supportedDK,
+            NULL_ELIGIBILITY_REQUIREMENT
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit KlerosCore.DisputeKitEnabled(FORKING_COURT, FORKING_DISPUTE_KIT, true);
+
+        vm.expectEmit(true, true, true, true);
         supportedDK[0] = DISPUTE_KIT_CLASSIC;
         emit KlerosCore.CourtCreated(
             GENERAL_COURT,
@@ -164,17 +201,19 @@ contract KlerosCore_InitializationTest is KlerosCore_TestBase {
             supportedDK,
             NULL_ELIGIBILITY_REQUIREMENT
         );
+
         vm.expectEmit(true, true, true, true);
         emit KlerosCore.DisputeKitEnabled(GENERAL_COURT, DISPUTE_KIT_CLASSIC, true);
         newCore.initialize(
             payable(newOwner),
             newGuardian,
             newPinakion,
-            newJurorProsecutionModule,
             newDisputeKit,
+            centralizedKit,
             newHiddenVotes,
             [newMinStake, newAlpha, newFeeForJuror, newJurorsForCourtJump],
             newTimesPerPeriod,
+            forkingTimesPerPeriod,
             newSortitionExtraData,
             newSortitionModule,
             address(wNative),

--- a/contracts/test/foundry/KlerosCore_TestBase.sol
+++ b/contracts/test/foundry/KlerosCore_TestBase.sol
@@ -8,6 +8,7 @@ import {KlerosCore, IERC721} from "../../src/arbitration/KlerosCore.sol";
 import {IArbitratorV2} from "../../src/arbitration/interfaces/IArbitratorV2.sol";
 import {IDisputeKit} from "../../src/arbitration/interfaces/IDisputeKit.sol";
 import {DisputeKitClassic} from "../../src/arbitration/dispute-kits/DisputeKitClassic.sol";
+import {CentralizedKit} from "../../src/arbitration/dispute-kits/CentralizedKit.sol";
 import {DisputeKitSybilResistant} from "../../src/arbitration/dispute-kits/DisputeKitSybilResistant.sol";
 import {ISortitionModule} from "../../src/arbitration/interfaces/ISortitionModule.sol";
 import {SortitionModuleMock, SortitionModule} from "../../src/test/SortitionModuleMock.sol";
@@ -35,6 +36,7 @@ abstract contract KlerosCore_TestBase is Test {
 
     KlerosCoreMock core;
     DisputeKitClassic disputeKit;
+    CentralizedKit centralizedKit;
     SortitionModuleMock sortitionModule;
     BlockHashRNG rng;
     PNK pinakion;
@@ -55,8 +57,8 @@ abstract contract KlerosCore_TestBase is Test {
     address disputer;
     address crowdfunder1;
     address crowdfunder2;
+    address ruler;
     address other;
-    address jurorProsecutionModule;
 
     // ************************************* //
     // *         Test Parameters           * //
@@ -69,6 +71,7 @@ abstract contract KlerosCore_TestBase is Test {
     bytes sortitionExtraData;
     bytes arbitratorExtraData;
     uint256[4] timesPerPeriod;
+    uint256[4] forkingTimesPerPeriod;
     bool hiddenVotes;
     uint256 totalSupply = 1000000 ether;
     uint256 minStakingTime;
@@ -81,6 +84,7 @@ abstract contract KlerosCore_TestBase is Test {
         KlerosCoreMock coreLogic = new KlerosCoreMock();
         SortitionModuleMock smLogic = new SortitionModuleMock();
         DisputeKitClassic dkLogic = new DisputeKitClassic();
+        CentralizedKit centralDkLogic = new CentralizedKit();
         DisputeTemplateRegistry registryLogic = new DisputeTemplateRegistry();
         pinakion = new PNK();
         feeToken = new TestERC20("Test", "TST");
@@ -93,16 +97,17 @@ abstract contract KlerosCore_TestBase is Test {
         disputer = vm.addr(4);
         crowdfunder1 = vm.addr(5);
         crowdfunder2 = vm.addr(6);
+        ruler = vm.addr(7);
         vm.deal(disputer, 10 ether);
         vm.deal(crowdfunder1, 10 ether);
         vm.deal(crowdfunder2, 10 ether);
-        jurorProsecutionModule = vm.addr(8);
         other = vm.addr(9);
         minStake = 1000;
         alpha = 10000;
         feeForJuror = 0.03 ether;
         jurorsForCourtJump = 511;
         timesPerPeriod = [60, 120, 180, 240];
+        forkingTimesPerPeriod = [0, 0, 0, 0];
 
         pinakion.transfer(msg.sender, totalSupply - 2 ether);
         pinakion.transfer(staker1, 1 ether);
@@ -117,6 +122,16 @@ abstract contract KlerosCore_TestBase is Test {
         rng = new BlockHashRNG(msg.sender, address(sortitionModule), rngLookahead);
 
         UUPSProxy proxyCore = new UUPSProxy(address(coreLogic), "");
+
+        bytes memory initDataCentralDk = abi.encodeWithSignature(
+            "initialize(address,address,address)",
+            owner,
+            address(proxyCore),
+            ruler
+        );
+
+        UUPSProxy proxyCentralDk = new UUPSProxy(address(centralDkLogic), initDataCentralDk);
+        centralizedKit = CentralizedKit(address(proxyCentralDk));
 
         bytes memory initDataDk = abi.encodeWithSignature(
             "initialize(address,address,address)",
@@ -151,11 +166,12 @@ abstract contract KlerosCore_TestBase is Test {
             payable(owner),
             guardian,
             pinakion,
-            jurorProsecutionModule,
             disputeKit,
+            centralizedKit,
             hiddenVotes,
             [minStake, alpha, feeForJuror, jurorsForCourtJump],
             timesPerPeriod,
+            forkingTimesPerPeriod,
             sortitionExtraData,
             sortitionModule,
             address(wNative),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a `FORKING_DISPUTE_KIT` to the Kleros arbitration system, replacing the previous `NULL_DISPUTE_KIT` and modifying related logic to accommodate the new dispute kit and its interactions with the forking court.

### Detailed summary
- Introduced `FORKING_DISPUTE_KIT` constant and replaced `NULL_DISPUTE_KIT` references.
- Updated logic in `KlerosCoreRuler.sol` and `KlerosCore.sol` to handle forking disputes.
- Modified dispute kit handling in various deployment and test files.
- Enhanced tests to cover forking court and dispute kit scenarios.
- Adjusted parameters for court and dispute kit creation and management.

> The following files were skipped due to too many changes: `contracts/test/foundry/KlerosCore_Appeals.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized dispute kit where disputes are created by core and rulings are issued by a designated ruler, with new on-chain events for dispute creation and rulings.
  * Added support for a forking court with configurable timing parameters and dedicated dispute-kit behavior.
* **Bug Fixes**
  * Appeals involving the forking court now follow updated round creation rules, including correct dispute-hook handling.
  * Adjusted appeal costs and compatibility/fallback dispute-kit selection so forking-court transitions behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->