### PR TITLE
fix(bots): use estimateGas and cap real-send gas in keeper bot draw/execute

### DIFF
--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -352,7 +352,8 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
     return success;
   }
   try {
-    const tx = await (await core.draw(dispute.id, iterations, HIGH_GAS_LIMIT)).wait();
+    const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
   } catch (e) {
@@ -374,7 +375,8 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     return success;
   }
   try {
-    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, HIGH_GAS_LIMIT)).wait();
+    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;
   } catch (e) {

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -353,13 +353,26 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
     logger.error(`Draw: will fail for ${dispute.id}, skipping`);
     return success;
   }
+  let batchIterations = iterations;
   try {
-    const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    // If the estimate exceeds MAX_TX_GAS_LIMIT, halve the batch and retry so a single
+    // dispute never gets stuck skipping forever on the same over-cap iteration count.
+    let drawGas = ((await core.draw.estimateGas(dispute.id, batchIterations)) * 150n) / 100n; // 50% extra gas
+    while (drawGas > MAX_TX_GAS_LIMIT && batchIterations > 1) {
+      batchIterations = Math.ceil(batchIterations / 2);
+      logger.warn(
+        `Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, ` +
+          `retrying with ${batchIterations} iterations`
+      );
+      drawGas = ((await core.draw.estimateGas(dispute.id, batchIterations)) * 150n) / 100n;
+    }
     if (drawGas > MAX_TX_GAS_LIMIT) {
-      logger.error(`Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      logger.error(
+        `Draw: gas ${drawGas} still exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id} at 1 iteration, skipping`
+      );
       return success;
     }
-    const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
+    const tx = await (await core.draw(dispute.id, batchIterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
   } catch (e) {
@@ -380,15 +393,32 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     logger.error(`Execute: will fail for ${dispute.id}, skipping`);
     return success;
   }
+  let batchIterations = iterations;
   try {
+    // If the estimate exceeds MAX_TX_GAS_LIMIT, halve the batch and retry so a single
+    // dispute never gets stuck skipping forever on the same over-cap iteration count.
     // 50% extra gas
-    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n;
+    const estimateExecGas = async () => {
+      const gas = await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, batchIterations);
+      return (gas * 150n) / 100n;
+    };
+    let execGas = await estimateExecGas();
+    while (execGas > MAX_TX_GAS_LIMIT && batchIterations > 1) {
+      batchIterations = Math.ceil(batchIterations / 2);
+      logger.warn(
+        `Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, ` +
+          `retrying with ${batchIterations} iterations`
+      );
+      execGas = await estimateExecGas();
+    }
     if (execGas > MAX_TX_GAS_LIMIT) {
-      logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      logger.error(
+        `Execute: gas ${execGas} still exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id} at 1 iteration, skipping`
+      );
       return success;
     }
     const tx = await (
-      await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })
+      await core.execute(dispute.id, dispute.currentRoundIndex, batchIterations, { gasLimit: execGas })
     ).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -21,6 +21,7 @@ const MAX_DELAYED_STAKES_ITERATIONS = 50;
 const WAIT_FOR_RNG_DURATION = 5 * 1000; // 5 seconds
 const ITERATIONS_COOLDOWN_PERIOD = 10 * 1000; // 10 seconds
 const HIGH_GAS_LIMIT = { gasLimit: 50_000_000 }; // 50M gas
+const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider (#2501, #2569)
 const HEARTBEAT_URL = env.optionalNoDefault("HEARTBEAT_URL_KEEPER_BOT");
 const SUBGRAPH_URL = env.require("SUBGRAPH_URL");
 const MAX_JURORS_PER_DISPUTE = 1000; // Skip disputes with more than this number of jurors
@@ -353,6 +354,10 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
   }
   try {
     const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    if (drawGas > MAX_TX_GAS_LIMIT) {
+      logger.error(`Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      return success;
+    }
     const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
@@ -369,13 +374,17 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
   const { core } = await getContracts();
   let success = false;
   try {
-    await core.execute.staticCall(dispute.id, dispute.currentRoundIndex, iterations, HIGH_GAS_LIMIT);
+    await core.execute.staticCall(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: MAX_TX_GAS_LIMIT });
   } catch {
     logger.error(`Execute: will fail for ${dispute.id}, skipping`);
     return success;
   }
   try {
     const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    if (execGas > MAX_TX_GAS_LIMIT) {
+      logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      return success;
+    }
     const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -20,8 +20,9 @@ const MAX_EXECUTE_ITERATIONS = 20;
 const MAX_DELAYED_STAKES_ITERATIONS = 50;
 const WAIT_FOR_RNG_DURATION = 5 * 1000; // 5 seconds
 const ITERATIONS_COOLDOWN_PERIOD = 10 * 1000; // 10 seconds
-const HIGH_GAS_LIMIT = { gasLimit: 50_000_000 }; // 50M gas
-const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider (#2501, #2569)
+// Local eth_call budget for the 300-iteration juror-availability probe
+const DRAW_PROBE_GAS_LIMIT = { gasLimit: 50_000_000 };
+const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider
 const HEARTBEAT_URL = env.optionalNoDefault("HEARTBEAT_URL_KEEPER_BOT");
 const SUBGRAPH_URL = env.require("SUBGRAPH_URL");
 const MAX_JURORS_PER_DISPUTE = 1000; // Skip disputes with more than this number of jurors
@@ -337,7 +338,7 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
     // MAX_DRAW_CALLS_WITHOUT_JURORS calls to draw() given this nb of iterations.
     const simulatedIterations = iterations * MAX_DRAW_CALLS_WITHOUT_JURORS;
     const { drawnJurors: drawnJurorsBefore } = await core.getRoundInfo(dispute.id, dispute.currentRoundIndex);
-    const nbDrawnJurors = (await core.draw.staticCall(dispute.id, simulatedIterations, HIGH_GAS_LIMIT)) as bigint;
+    const nbDrawnJurors = (await core.draw.staticCall(dispute.id, simulatedIterations, DRAW_PROBE_GAS_LIMIT)) as bigint;
     const extraJurors = nbDrawnJurors - BigInt(drawnJurorsBefore.length);
     logger.debug(
       `Draw: ${extraJurors} jurors available in the next ${simulatedIterations} iterations for dispute ${dispute.id}`
@@ -380,12 +381,15 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     return success;
   }
   try {
-    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    // 50% extra gas
+    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n;
     if (execGas > MAX_TX_GAS_LIMIT) {
       logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
       return success;
     }
-    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
+    const tx = await (
+      await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })
+    ).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;
   } catch (e) {


### PR DESCRIPTION
## Summary

The keeper bot's `drawJurors()` and `executeRepartitions()` used a hardcoded `gasLimit: 50_000_000` on their real transaction-send paths. On networks/providers that enforce a lower max-per-tx gas cap (observed: 25M), the RPC silently rejects these sends with `ProviderError: exceeds maximum per-tx gas limit`, causing juror rewards to go undistributed with only a generic "Failed to execute repartitions for dispute #X, skipping it" log — no clear signal of the actual cause.

Root cause confirmed against production logs (BetterStack): the preceding `staticCall` simulation with the same 50M override succeeded, while the real send with the identical override failed — because `eth_call` isn't subject to the provider's per-tx submission cap, only `eth_sendRawTransaction` is.

Closes #2569
Fixes #2501

## Changes

| File | Change |
|------|--------|
| `contracts/scripts/keeperBot.ts` | `draw()`/`execute()` real-send paths now use `estimateGas() * 150n / 100n` (matching the pattern already used by `passPhase`, `passPeriod`, `executeRuling`, `withdrawLeftoverPNK`, `withdrawFeesAndRewards`) instead of a blind hardcoded gas limit |
| `contracts/scripts/keeperBot.ts` | Added `MAX_TX_GAS_LIMIT = 25_000_000n` (documented, references #2501/#2569). If the buffered estimate exceeds it, the send is skipped cleanly (logged, `success = false`) instead of being submitted and risking an on-chain revert that burns real gas |
| `contracts/scripts/keeperBot.ts` | `execute.staticCall`'s gas budget aligned to `MAX_TX_GAS_LIMIT` (it mirrors the real send's exact args, so a successful pre-flight now proves the real send fits within the same cap) |
| `contracts/scripts/keeperBot.ts` | `draw.staticCall` intentionally left unchanged at its own gas budget (renamed `HIGH_GAS_LIMIT` → `DRAW_PROBE_GAS_LIMIT` for clarity) — it explores an inflated iteration count (`iterations * MAX_DRAW_CALLS_WITHOUT_JURORS`, up to 300) to probe juror availability ahead, not a 1:1 pre-flight for the real send, so it must not share the real-send cap |

## Test Plan

- [x] `yarn check-types` — 0 errors (contracts/)
- [x] `yarn check-style` — 0 errors, 0 warnings (contracts/)
- [x] Manual source-level verification against the file's established `estimateGas()` conventions (5+ other functions in the same file)
- [ ] Staging: deploy to a keeper bot instance against a provider with a gas cap below 50M, trigger a `drawJurors()` and `executeRepartitions()` cycle, confirm no `ProviderError` and correct skip-logging on any over-cap edge case — **pending, will confirm before merge**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving gas management for the `draw` and `execute` functions in the `keeperBot` script. It introduces limits to prevent excessive gas usage during transactions, ensuring smoother execution and reducing the risk of failures.

### Detailed summary
- Replaced `HIGH_GAS_LIMIT` with `DRAW_PROBE_GAS_LIMIT` for drawing jurors.
- Introduced `MAX_TX_GAS_LIMIT` for limiting gas per transaction.
- Implemented logic to halve batch iterations if gas estimates exceed `MAX_TX_GAS_LIMIT`.
- Updated `draw` and `execute` functions to utilize dynamic gas limits based on estimates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated drawing and repartition transactions with more accurate gas estimates.
  * Added safeguards to keep transactions within maximum gas limits, including adaptive batch sizing.
  * Refined juror-availability checks during transaction simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->