### PR TITLE
fix(bots): use estimateGas and cap real-send gas in keeper bot draw/execute (master)

### DIFF
--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -22,6 +22,7 @@ const MAX_DELAYED_STAKES_ITERATIONS = 50;
 const WAIT_FOR_RNG_DURATION = 5 * 1000; // 5 seconds
 const ITERATIONS_COOLDOWN_PERIOD = 10 * 1000; // 10 seconds
 const HIGH_GAS_LIMIT = { gasLimit: 50_000_000 }; // 50M gas
+const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider (#2501, #2569)
 const HEARTBEAT_URL = env.optionalNoDefault("HEARTBEAT_URL_KEEPER_BOT");
 const SUBGRAPH_URL = env.require("SUBGRAPH_URL");
 const MAX_JURORS_PER_DISPUTE = 1000; // Skip disputes with more than this number of jurors
@@ -368,6 +369,10 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
   }
   try {
     const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    if (drawGas > MAX_TX_GAS_LIMIT) {
+      logger.error(`Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      return success;
+    }
     const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
@@ -384,13 +389,17 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
   const { core } = await getContracts();
   let success = false;
   try {
-    await core.execute.staticCall(dispute.id, dispute.currentRoundIndex, iterations, HIGH_GAS_LIMIT);
-  } catch (e) {
+    await core.execute.staticCall(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: MAX_TX_GAS_LIMIT });
+  } catch {
     logger.error(`Execute: will fail for ${dispute.id}, skipping`);
     return success;
   }
   try {
     const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    if (execGas > MAX_TX_GAS_LIMIT) {
+      logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      return success;
+    }
     const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -368,13 +368,26 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
     logger.error(`Draw: will fail for ${dispute.id}, skipping`);
     return success;
   }
+  let batchIterations = iterations;
   try {
-    const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    // If the estimate exceeds MAX_TX_GAS_LIMIT, halve the batch and retry so a single
+    // dispute never gets stuck skipping forever on the same over-cap iteration count.
+    let drawGas = ((await core.draw.estimateGas(dispute.id, batchIterations)) * 150n) / 100n; // 50% extra gas
+    while (drawGas > MAX_TX_GAS_LIMIT && batchIterations > 1) {
+      batchIterations = Math.ceil(batchIterations / 2);
+      logger.warn(
+        `Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, ` +
+          `retrying with ${batchIterations} iterations`
+      );
+      drawGas = ((await core.draw.estimateGas(dispute.id, batchIterations)) * 150n) / 100n;
+    }
     if (drawGas > MAX_TX_GAS_LIMIT) {
-      logger.error(`Draw: estimated gas ${drawGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      logger.error(
+        `Draw: gas ${drawGas} still exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id} at 1 iteration, skipping`
+      );
       return success;
     }
-    const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
+    const tx = await (await core.draw(dispute.id, batchIterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
   } catch (e) {
@@ -395,15 +408,32 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     logger.error(`Execute: will fail for ${dispute.id}, skipping`);
     return success;
   }
+  let batchIterations = iterations;
   try {
+    // If the estimate exceeds MAX_TX_GAS_LIMIT, halve the batch and retry so a single
+    // dispute never gets stuck skipping forever on the same over-cap iteration count.
     // 50% extra gas
-    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n;
+    const estimateExecGas = async () => {
+      const gas = await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, batchIterations);
+      return (gas * 150n) / 100n;
+    };
+    let execGas = await estimateExecGas();
+    while (execGas > MAX_TX_GAS_LIMIT && batchIterations > 1) {
+      batchIterations = Math.ceil(batchIterations / 2);
+      logger.warn(
+        `Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, ` +
+          `retrying with ${batchIterations} iterations`
+      );
+      execGas = await estimateExecGas();
+    }
     if (execGas > MAX_TX_GAS_LIMIT) {
-      logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
+      logger.error(
+        `Execute: gas ${execGas} still exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id} at 1 iteration, skipping`
+      );
       return success;
     }
     const tx = await (
-      await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })
+      await core.execute(dispute.id, dispute.currentRoundIndex, batchIterations, { gasLimit: execGas })
     ).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -367,7 +367,8 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
     return success;
   }
   try {
-    const tx = await (await core.draw(dispute.id, iterations, HIGH_GAS_LIMIT)).wait();
+    const drawGas = ((await core.draw.estimateGas(dispute.id, iterations)) * 150n) / 100n; // 50% extra gas
+    const tx = await (await core.draw(dispute.id, iterations, { gasLimit: drawGas })).wait();
     logger.info(`Draw txID: ${tx?.hash}`);
     success = true;
   } catch (e) {
@@ -389,7 +390,8 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     return success;
   }
   try {
-    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, HIGH_GAS_LIMIT)).wait();
+    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;
   } catch (e) {

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -21,8 +21,9 @@ const MAX_EXECUTE_ITERATIONS = 20;
 const MAX_DELAYED_STAKES_ITERATIONS = 50;
 const WAIT_FOR_RNG_DURATION = 5 * 1000; // 5 seconds
 const ITERATIONS_COOLDOWN_PERIOD = 10 * 1000; // 10 seconds
-const HIGH_GAS_LIMIT = { gasLimit: 50_000_000 }; // 50M gas
-const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider (#2501, #2569)
+// Local eth_call budget for the 300-iteration juror-availability probe
+const DRAW_PROBE_GAS_LIMIT = { gasLimit: 50_000_000 };
+const MAX_TX_GAS_LIMIT = 25_000_000n; // Max gas per tx enforced by the provider
 const HEARTBEAT_URL = env.optionalNoDefault("HEARTBEAT_URL_KEEPER_BOT");
 const SUBGRAPH_URL = env.require("SUBGRAPH_URL");
 const MAX_JURORS_PER_DISPUTE = 1000; // Skip disputes with more than this number of jurors
@@ -352,7 +353,7 @@ const drawJurors = async (dispute: { id: string; currentRoundIndex: string }, it
   try {
     const simulatedIterations = iterations * MAX_DRAW_CALLS_WITHOUT_JURORS; // Drawing will be skipped as long as no juror is available in the next MAX_DRAW_CALLS_WITHOUT_JURORS calls to draw() given this nb of iterations.
     const { drawnJurors: drawnJurorsBefore } = await core.getRoundInfo(dispute.id, dispute.currentRoundIndex);
-    const nbDrawnJurors = (await core.draw.staticCall(dispute.id, simulatedIterations, HIGH_GAS_LIMIT)) as bigint;
+    const nbDrawnJurors = (await core.draw.staticCall(dispute.id, simulatedIterations, DRAW_PROBE_GAS_LIMIT)) as bigint;
     const extraJurors = nbDrawnJurors - BigInt(drawnJurorsBefore.length);
     logger.debug(
       `Draw: ${extraJurors} jurors available in the next ${simulatedIterations} iterations for dispute ${dispute.id}`
@@ -395,12 +396,15 @@ const executeRepartitions = async (dispute: { id: string; currentRoundIndex: str
     return success;
   }
   try {
-    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n; // 50% extra gas
+    // 50% extra gas
+    const execGas = ((await core.execute.estimateGas(dispute.id, dispute.currentRoundIndex, iterations)) * 150n) / 100n;
     if (execGas > MAX_TX_GAS_LIMIT) {
       logger.error(`Execute: estimated gas ${execGas} exceeds MAX_TX_GAS_LIMIT for dispute ${dispute.id}, skipping`);
       return success;
     }
-    const tx = await (await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })).wait();
+    const tx = await (
+      await core.execute(dispute.id, dispute.currentRoundIndex, iterations, { gasLimit: execGas })
+    ).wait();
     logger.info(`Execute txID: ${tx?.hash}`);
     success = true;
   } catch (e) {


### PR DESCRIPTION
Backport of #2570 to `master`.

`master` and `dev` have diverged too far to merge (35 commits on `master` not in `dev`, 714 the other way), so this cherry-picks the four commits from `fix/keeper-bot-gas-estimation` instead. Authorship is preserved.

## Conflict resolution

Three commits applied cleanly. `bb9a5b01f` conflicted on a single line in `execute`: `master` still used `} catch (e) {` where `dev` has `} catch {`, on top of the `staticCall` gas-argument change. Resolved in favour of the `dev` version, so this PR also drops one unused `e` binding.

## Result

Net change is +51/-6 in `contracts/scripts/keeperBot.ts`, semantically identical to #2570 (+50/-5 there). The gas logic lands self-consistent: `DRAW_PROBE_GAS_LIMIT` and `MAX_TX_GAS_LIMIT` are both defined and no `HIGH_GAS_LIMIT` reference survives.

The remaining `master`/`dev` drift in this file is untouched and unrelated to gas handling: `SortitionModuleNeo` / `CORE_TYPE` support, the `BlockHashRNG` branch in `isRngReady`, `any` vs `unknown` typings, and formatting.

## Notes

- Not typechecked locally (no typechain artifacts on this branch) - relying on CI.
- Should land after or alongside #2570 so `master` never carries a fix that `dev` lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving gas management in the `keeperBot` script by introducing a new gas limit for drawing jurors and executing transactions, ensuring that gas estimates do not exceed predefined limits.

### Detailed summary
- Replaced `HIGH_GAS_LIMIT` with `DRAW_PROBE_GAS_LIMIT` for drawing jurors.
- Introduced `MAX_TX_GAS_LIMIT` to limit gas per transaction.
- Added logic to halve batch iterations if gas estimates exceed `MAX_TX_GAS_LIMIT` for both drawing jurors and executing transactions.
- Updated static calls to use `MAX_TX_GAS_LIMIT`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability by dynamically estimating gas and adjusting batch sizes when limits are approached.
  * Prevented transactions from being attempted when even a single iteration exceeds the configured gas limit.
  * Added a dedicated gas limit for checking draw availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->