### PR TITLE
fix: alignment cases list view

### DIFF
--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
@@ -20,7 +20,7 @@ const Container = styled.div<{ isLabel?: boolean }>`
   flex: 0 1 ${responsiveSize(400, 450, 900)};
   align-items: center;
   padding-right: ${responsiveSize(12, 24, 900)};
-  gap: 8px;
+  gap: ${responsiveSize(16, 24, 900)};
 `;
 
 const RestOfFieldsContainer = styled.div`
@@ -34,6 +34,20 @@ const RestOfFieldsContainer = styled.div`
 `;
 
 const StyledField = styled(Field)<{ style?: string }>`
+  .value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  a {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+  }
+
   ${({ style }) => style ?? ""}
 `;
 
@@ -50,7 +64,12 @@ const DisputeInfoList: React.FC<IDisputeInfoList> = ({ fieldItems, showLabels, d
     () =>
       fieldItems.map((item) =>
         item.display ? (
-          <StyledField key={item.name} {...(item as IField)} value={truncateText(item.value ?? "", 20)} displayAsList />
+          <StyledField
+            key={item.name}
+            {...(item as IField)}
+            value={item.link ? (item.value ?? "") : truncateText(item.value ?? "", 20)}
+            displayAsList
+          />
         ) : null
       ),
     [fieldItems]

--- a/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/DisputeInfoList.tsx
@@ -35,7 +35,6 @@ const RestOfFieldsContainer = styled.div`
 
 const StyledField = styled(Field)<{ style?: string }>`
   .value {
-    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -45,7 +44,6 @@ const StyledField = styled(Field)<{ style?: string }>`
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    overflow-wrap: anywhere;
   }
 
   ${({ style }) => style ?? ""}
@@ -64,12 +62,7 @@ const DisputeInfoList: React.FC<IDisputeInfoList> = ({ fieldItems, showLabels, d
     () =>
       fieldItems.map((item) =>
         item.display ? (
-          <StyledField
-            key={item.name}
-            {...(item as IField)}
-            value={item.link ? (item.value ?? "") : truncateText(item.value ?? "", 20)}
-            displayAsList
-          />
+          <StyledField key={item.name} {...(item as IField)} value={truncateText(item.value ?? "", 20)} displayAsList />
         ) : null
       ),
     [fieldItems]

--- a/web/src/components/DisputeView/DisputeInfo/index.tsx
+++ b/web/src/components/DisputeView/DisputeInfo/index.tsx
@@ -14,6 +14,8 @@ import { useIsList } from "context/IsListProvider";
 import { formatDate } from "utils/date";
 import { isUndefined } from "utils/index";
 
+import { responsiveSize } from "styles/responsiveSize";
+
 import DisputeInfoCard from "./DisputeInfoCard";
 import DisputeInfoList from "./DisputeInfoList";
 
@@ -91,7 +93,7 @@ const DisputeInfo: React.FC<IDisputeInfo> = ({
         name: t("dispute_info.category"),
         value: category ?? t("dispute_info.general"),
         display: true,
-        style: "justify-self: end;",
+        style: `justify-self: end; max-width: ${responsiveSize(110, 160, 900)};`,
       },
       { icon: PileCoinsIcon, name: t("dispute_info.juror_rewards"), value: rewards, display: !isUndefined(rewards) },
       {

--- a/web/src/components/DisputeView/DisputeListView.tsx
+++ b/web/src/components/DisputeView/DisputeListView.tsx
@@ -28,6 +28,8 @@ const ListContainer = styled.div`
   justify-content: space-between;
   align-items: flex-start;
   flex-grow: 1;
+  min-width: 0;
+  gap: ${responsiveSize(16, 24, 900)};
 `;
 
 const TitleContainer = styled.div<{ isLabel?: boolean }>`
@@ -39,6 +41,10 @@ const TitleContainer = styled.div<{ isLabel?: boolean }>`
   h3 {
     margin: 0;
     flex: 1;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 `;
 

--- a/web/src/components/DisputeView/PeriodBanner.tsx
+++ b/web/src/components/DisputeView/PeriodBanner.tsx
@@ -16,7 +16,8 @@ interface IContainer {
 
 const Container = styled.div<IContainer>`
   height: ${({ isCard }) => (isCard ? "45px" : "100%")};
-  width: ${({ isCard }) => (isCard ? "auto" : responsiveSize(140, 200, 900))};
+  width: ${({ isCard }) => (isCard ? "auto" : responsiveSize(180, 200, 900))};
+  min-width: ${({ isCard }) => (isCard ? "auto" : "min-content")};
   border-top-right-radius: 3px;
   border-top-left-radius: 3px;
   display: flex;
@@ -34,7 +35,7 @@ const Container = styled.div<IContainer>`
 
   ${landscapeStyle(
     () => css`
-      padding: 0 24px;
+      padding: 0 ${responsiveSize(16, 24)};
     `
   )}
 `;

--- a/web/src/components/DisputeView/PeriodBanner.tsx
+++ b/web/src/components/DisputeView/PeriodBanner.tsx
@@ -35,7 +35,7 @@ const Container = styled.div<IContainer>`
 
   ${landscapeStyle(
     () => css`
-      padding: 0 ${responsiveSize(16, 24)};
+      padding: 0 ${responsiveSize(16, 24, 900)};
     `
   )}
 `;


### PR DESCRIPTION
closes #2284 

looking much better at 901px
<img width="896" height="756" alt="image" src="https://github.com/user-attachments/assets/412d7e77-1477-4d33-9ed8-59ba5dc35bbb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing and sizing across dispute views.
  * Prevented long field values and dispute titles from disrupting layouts.
  * Added clearer truncation for non-linked values and improved wrapping for links.
  * Enhanced landscape-mode padding and minimum-width behavior for period banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the styling and layout of various components in the `DisputeView` section, improving responsiveness and visual presentation.

### Detailed summary
- Added `min-width: 0` and `gap` to `DisputeListView`.
- Updated `h3` in `TitleContainer` to use `-webkit-box` for text clamping.
- Adjusted `gap` in `DisputeInfoList`.
- Added styles for `.value` and `a` in `StyledField` for text overflow handling.
- Increased `width` and added `min-width` to `Container` in `PeriodBanner`.
- Modified padding in `Container` using `responsiveSize`.
- Updated `style` in `DisputeInfo` to include `max-width` for better layout control.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->