### PR TITLE
fix(bots): restructure keeper drawing phase gate to allow mid-phase entry

### DIFF
--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -758,6 +758,13 @@ async function main() {
         }
         do {
           const drawIterations = Math.min(MAX_DRAW_ITERATIONS, getNumber(numberOfMissingJurors));
+          if (drawIterations === 0) {
+            // Dispute was fully drawn externally (e.g. another keeper instance) between the
+            // pre-loop snapshot and this iteration. Nothing left to draw; avoid a wasted
+            // drawJurors(dispute, 0) call and the misleading "Failed to draw jurors" log it
+            // would otherwise produce.
+            break;
+          }
           logger.info(
             `Drawing ${drawIterations} out of ${numberOfMissingJurors} jurors needed for dispute #${dispute.id}`
           );

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -738,7 +738,13 @@ async function main() {
       await passPhase();
     }
     if (await isPhaseDrawing()) {
-      let drawIterationsTotal = 0;
+      // Actual jurors newly drawn across the run, measured via getMissingJurors() deltas —
+      // NOT the requested `drawIterations` count. drawJurors() returns true once its transaction
+      // confirms, regardless of how many jurors it actually drew (its pre-flight probe checks a
+      // much larger simulated horizon than the real batch it submits), so counting requested
+      // iterations would let a fully-stalled run (transactions confirm, nobody gets drawn)
+      // silently suppress the stall warning below.
+      let actualJurorsDrawn = 0;
       let maxDrawingTimePassed = await hasMaxDrawingTimePassed();
       for (const dispute of disputesWithoutJurors) {
         if (maxDrawingTimePassed) {
@@ -759,20 +765,27 @@ async function main() {
             logger.error(`Failed to draw jurors for dispute #${dispute.id}, skipping it`);
             break;
           }
-          drawIterationsTotal += drawIterations;
           await delay(ITERATIONS_COOLDOWN_PERIOD); // To avoid spiking the gas price
           maxDrawingTimePassed = await hasMaxDrawingTimePassed();
+          const missingBefore = numberOfMissingJurors;
           numberOfMissingJurors = await getMissingJurors(dispute);
+          actualJurorsDrawn += getNumber(missingBefore) - getNumber(numberOfMissingJurors);
         } while (!(numberOfMissingJurors === 0n) && !maxDrawingTimePassed);
       }
-      // Warn if the drawing run completed with zero draws but disputes still need jurors.
+      // Warn if the drawing run completed with zero actual draws but disputes still need jurors.
       // This indicates a stall (no eligible jurors staked, RNG issue, or all draws failing).
-      if (drawIterationsTotal === 0 && disputesWithoutJurors.length > 0) {
-        const pendingIds = disputesWithoutJurors.map((d) => d.id).join(", ");
-        logger.warn(
-          `Drawing phase run completed with zero draws for ${disputesWithoutJurors.length} ` +
-            `dispute(s) still needing jurors: [${pendingIds}]`
-        );
+      // Re-query which disputes are still unresolved rather than trusting the pre-loop snapshot.
+      if (actualJurorsDrawn === 0 && disputesWithoutJurors.length > 0) {
+        const stillPending = await filterAsync(disputesWithoutJurors, async (dispute) => {
+          return !(await isDisputeFullyDrawn(dispute));
+        });
+        if (stillPending.length > 0) {
+          const pendingIds = stillPending.map((d) => d.id).join(", ");
+          logger.warn(
+            `Drawing phase run completed with zero draws for ${stillPending.length} ` +
+              `dispute(s) still needing jurors: [${pendingIds}]`
+          );
+        }
       }
       // At this point, either all disputes are fully drawn or max drawing time has passed
     }

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -635,7 +635,7 @@ async function main() {
     const minStakingTime = await sortition.minStakingTime();
     const blockTime = await getBlockTime();
     return await sortition.lastPhaseChange().then((lastPhaseChange) => {
-      return toBigInt(blockTime) - lastPhaseChange > minStakingTime;
+      return toBigInt(blockTime) - lastPhaseChange >= minStakingTime;
     });
   };
 
@@ -643,7 +643,7 @@ async function main() {
     const maxDrawingTime = await sortition.maxDrawingTime();
     const blockTime = await getBlockTime();
     return await sortition.lastPhaseChange().then((lastPhaseChange) => {
-      return toBigInt(blockTime) - lastPhaseChange > maxDrawingTime;
+      return toBigInt(blockTime) - lastPhaseChange >= maxDrawingTime;
     });
   };
 
@@ -708,7 +708,17 @@ async function main() {
   }
 
   logger.info(`Disputes needing more jurors: ${disputesWithoutJurors.map((dispute) => dispute.id)}`);
-  if ((await hasMinStakingTimePassed()) && disputesWithoutJurors.length > 0) {
+
+  // Phase-aware dispatch:
+  //  - If already in drawing phase (e.g. advanced by an external actor or resumed after a keeper
+  //    restart mid-draw), enter the drawing loop directly — no minStakingTime gate required.
+  //  - Otherwise, require minStakingTime to have elapsed (>= to match contract semantics) before
+  //    advancing from staking through generating into drawing.
+  const enterDrawingBlock =
+    (disputesWithoutJurors.length > 0 && (await isPhaseDrawing())) ||
+    ((await hasMinStakingTimePassed()) && disputesWithoutJurors.length > 0);
+
+  if (enterDrawingBlock) {
     // ----------------------------------------------- //
     //                DRAWING ATTEMPT                  //
     // ----------------------------------------------- //
@@ -726,6 +736,7 @@ async function main() {
       await passPhase();
     }
     if (await isPhaseDrawing()) {
+      let drawIterationsTotal = 0;
       let maxDrawingTimePassed = await hasMaxDrawingTimePassed();
       for (const dispute of disputesWithoutJurors) {
         if (maxDrawingTimePassed) {
@@ -746,10 +757,20 @@ async function main() {
             logger.error(`Failed to draw jurors for dispute #${dispute.id}, skipping it`);
             break;
           }
+          drawIterationsTotal += drawIterations;
           await delay(ITERATIONS_COOLDOWN_PERIOD); // To avoid spiking the gas price
           maxDrawingTimePassed = await hasMaxDrawingTimePassed();
           numberOfMissingJurors = await getMissingJurors(dispute);
         } while (!(numberOfMissingJurors === 0n) && !maxDrawingTimePassed);
+      }
+      // Warn if the drawing run completed with zero draws but disputes still need jurors.
+      // This indicates a stall (no eligible jurors staked, RNG issue, or all draws failing).
+      if (drawIterationsTotal === 0 && disputesWithoutJurors.length > 0) {
+        const pendingIds = disputesWithoutJurors.map((d) => d.id).join(", ");
+        logger.warn(
+          `Drawing phase run completed with zero draws for ${disputesWithoutJurors.length} ` +
+            `dispute(s) still needing jurors: [${pendingIds}]`
+        );
       }
       // At this point, either all disputes are fully drawn or max drawing time has passed
     }

--- a/contracts/scripts/keeperBot.ts
+++ b/contracts/scripts/keeperBot.ts
@@ -710,12 +710,14 @@ async function main() {
   logger.info(`Disputes needing more jurors: ${disputesWithoutJurors.map((dispute) => dispute.id)}`);
 
   // Phase-aware dispatch:
-  //  - If already in drawing phase (e.g. advanced by an external actor or resumed after a keeper
-  //    restart mid-draw), enter the drawing loop directly — no minStakingTime gate required.
-  //  - Otherwise, require minStakingTime to have elapsed (>= to match contract semantics) before
-  //    advancing from staking through generating into drawing.
+  //  - If already in generating or drawing phase (e.g. advanced by an external actor or resumed
+  //    after a keeper restart mid-cycle), enter the block directly — no minStakingTime gate
+  //    required. minStakingTime only governs the staking -> generating transition
+  //    (SortitionModule.sol); generating -> drawing only requires RNG readiness.
+  //  - Otherwise (phase is staking), require minStakingTime to have elapsed (>= to match contract
+  //    semantics) before advancing from staking through generating into drawing.
   const enterDrawingBlock =
-    (disputesWithoutJurors.length > 0 && (await isPhaseDrawing())) ||
+    (disputesWithoutJurors.length > 0 && ((await isPhaseGenerating()) || (await isPhaseDrawing()))) ||
     ((await hasMinStakingTimePassed()) && disputesWithoutJurors.length > 0);
 
   if (enterDrawingBlock) {


### PR DESCRIPTION
## Summary

The keeper bot's drawing-phase entry gate was phase-agnostic: `hasMinStakingTimePassed()` and `hasMaxDrawingTimePassed()` both read `sortition.lastPhaseChange()` regardless of the court's current phase, and the outer gate applied the `minStakingTime` predicate to the entire drawing workflow instead of only the `staking -> generating` transition. If the court was already in `generating` or `drawing` (advanced externally, or after a keeper crash mid-cycle) when a fresh keeper run started, the run could skip the entire drawing/RNG-wait block — and with `minStakingTime == maxDrawingTime` on non-devnet deployments, the unconditional back-to-staking cleanup could even push the phase back to `staking` with zero `draw()` calls, because the keeper's own predicates used strict `>` while `SortitionModule.sol` uses `>=`.

Closes #2574

## Changes

`contracts/scripts/keeperBot.ts` only — this PR is scoped to the production fix. Three rounds, incorporating code review feedback:

| Change | Why |
|--------|-----|
| `hasMinStakingTimePassed()` / `hasMaxDrawingTimePassed()`: `>` → `>=` | Matches `SortitionModule.sol`'s own boundary semantics |
| Drawing-entry gate restructured to be phase-aware: enters the block directly when the court is already `generating` or `drawing` and disputes still need jurors, without waiting on `minStakingTime` | `minStakingTime` only gates the `staking -> generating` transition per the contract; `generating -> drawing` only requires RNG readiness |
| Zero-draw observability warning now counts actual jurors drawn (via `getMissingJurors()` deltas) instead of requested iterations | `drawJurors()` returns `true` once its transaction confirms, not based on how many jurors it actually drew, so the warning could be silently suppressed by a fully-stalled run |

## Test Plan

- [x] `yarn check-types` — clean
- [x] `yarn check-style` — clean

## Note on scope

This PR previously included a new regression test file (`contracts/test/arbitration/keeperBot-phase-gate.ts`). Per review feedback, those tests reimplemented local copies of the keeper's phase predicates rather than exercising `keeperBot.ts` itself (it has no exports and self-executes `main()` on import), so they could pass even if the production fix regressed. Rather than ship tests that don't actually protect this code, the tests move to a follow-up PR that first makes the keeper's phase-entry logic importable/testable, then wires proper regression coverage against the real implementation. That follow-up targets this PR's branch as its base.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `keeperBot.ts` functionality by refining phase transitions for juror drawing and improving logging for disputes. It adjusts conditions for entering drawing phases and adds checks for actual jurors drawn, aiming to prevent stalls and improve clarity in dispute processing.

### Detailed summary
- Changed comparison from `>` to `>=` for `minStakingTime` and `maxDrawingTime`.
- Introduced `enterDrawingBlock` logic to handle phase transitions more effectively.
- Added checks for actual jurors drawn to prevent misleading logs.
- Implemented warnings for stalls when no jurors are drawn.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated drawing-time checks to include the exact cutoff time.
  * Allowed drawing to begin during active generating or drawing phases.
  * Preserved the minimum staking-time requirement for staking operations.
  * Improved juror-count tracking and prevented unnecessary empty draw attempts.
  * Added warnings when unresolved disputes remain without newly drawn jurors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->